### PR TITLE
Flesh out 0.0.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## [0.0.1] – 2026-04-30
 
-Initial release.
+First public build of Markdown Preview — a fast, native macOS reader for `.md` files.
 
-- First public build of Markdown Preview.
-- Sparkle auto-updates wired up.
+### Highlights
+
+- Native WKWebView rendering with heading anchors and external link handling
+- Sidebar table of contents that mirrors document headings (click to jump)
+- Toggleable inspector panel with file metadata
+- In-document search via the toolbar field plus standard `⌘F` / `⌘G` / `⌘⇧G`
+- Open With menu that filters to apps declaring an editor role for Markdown and remembers your pick
+- Share menu that copies the Markdown source itself, so Copy / Mail / Notes / Messages get the content instead of a file URL
+- Quick Look extension for system-wide `.md` previews from Finder, Spotlight, and Mail
+- Offer to register as the default `.md` handler on first launch
+- Supports `.md`, `.markdown`, `.mdown`, and `.txt`


### PR DESCRIPTION
## Summary
- Replace the placeholder `## [0.0.1]` entry in `CHANGELOG.md` with the user-facing highlights for the first public build.
- `scripts/release.sh` extracts the section between `## [0.0.1]` and the next heading via awk and feeds it to both `amore release --release-notes` and `gh release create --notes`. Landing this on `main` is the only change needed before running the release script (Version.xcconfig is already at 0.0.1 / build 5).

## Test plan
- [ ] Verify the diff matches expectations.
- [ ] After merge, run `scripts/release.sh` from `main` — confirm the release notes show on the resulting GitHub release and the Amore appcast entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)