### PR TITLE
Bump to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.2] – 2026-05-01
+
+Compatibility release: Markdown Preview now runs on macOS 15 Sequoia in addition to macOS 26 Tahoe.
+
+- **Lowered the minimum macOS version to 15.0 (Sequoia).** Previously required macOS 26 Tahoe.
+- **Replaced the app icon with an Icon Composer `.icon` bundle.** Fixes the icon appearing oversized on Sequoia — the system now applies its own mask and the standard safe-area inset.
+
 ## [0.0.1] – 2026-04-30
 
 First public build of Markdown Preview — a fast, native macOS reader for `.md` files.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.1
-CURRENT_PROJECT_VERSION = 5
+MARKETING_VERSION = 0.0.2
+CURRENT_PROJECT_VERSION = 6


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` to 0.0.2 and `CURRENT_PROJECT_VERSION` to 6
- Add `CHANGELOG.md` entry covering the macOS 15 support shipped in #8 (lowered deployment target + Icon Composer `.icon` swap that fixes the oversized icon on Sequoia)

Once this lands on `main`, run `./scripts/release.sh` to ship the build (no `--version` flag needed — `Version.xcconfig` already matches).

## Test plan

- [ ] CI green
- [ ] `./scripts/release.sh` validates the changelog entry and skips the version-bump commit (since `Version.xcconfig` already matches)
- [ ] `amore release` archives, signs, notarizes, and publishes 0.0.2
- [ ] Installed 0.0.2 on macOS 15 Sequoia: app launches, icon renders at correct size in Dock/Finder/Launchpad
- [ ] Installed 0.0.2 on macOS 26 Tahoe: no regression in icon or core functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)