### PR TITLE
Gate Sparkle for Mac App Store builds

### DIFF
--- a/AppStore.xcconfig
+++ b/AppStore.xcconfig
@@ -1,0 +1,21 @@
+// Overlay xcconfig for Mac App Store builds.
+// Pass via:  xcodebuild -xcconfig AppStore.xcconfig ...
+// or via the helper:  ./scripts/archive-appstore.sh
+
+#include "Version.xcconfig"
+
+// Compile out Sparkle and its menu item.
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) APPSTORE
+
+// Sparkle-free entitlements (no XPC mach-lookup temp exceptions).
+CODE_SIGN_ENTITLEMENTS = md-preview/md-preview-appstore.entitlements
+
+// Info.plist without SUFeedURL / SUPublicEDKey / SUEnableInstallerLauncherService.
+INFOPLIST_FILE = Info-AppStore.plist
+
+// Mac App Store distribution requires Apple Distribution + a MAS provisioning profile.
+// Keep automatic signing on, but switch the cert to the distribution one.
+CODE_SIGN_STYLE = Manual
+CODE_SIGN_IDENTITY = Apple Distribution
+// Set this to the name of your Mac App Store provisioning profile in App Store Connect:
+// PROVISIONING_PROFILE_SPECIFIER = Markdown Preview MAS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,22 @@ Default is **unpublish** (reversible — flips `published=false` on Amore so it 
 
 To inspect or change: `amore config show --bundle-id doc.md-preview` / `amore config set ...`. CLI lives at `/usr/local/bin/amore`.
 
+## Mac App Store builds
+
+The app supports a parallel App Store build that compiles Sparkle out and ships sandbox-clean entitlements:
+
+```bash
+./scripts/archive-appstore.sh                       # → build/AppStore.xcarchive
+./scripts/archive-appstore.sh path/out.xcarchive    # custom archive path
+```
+
+How the gate works:
+- `AppStore.xcconfig` overlays `Version.xcconfig` and sets `SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) APPSTORE`, swaps `CODE_SIGN_ENTITLEMENTS` to `md-preview/md-preview-appstore.entitlements` (no Sparkle XPC mach-lookup), and swaps `INFOPLIST_FILE` to `Info-AppStore.plist` (no `SU*` keys).
+- `AppDelegate.swift` wraps `import Sparkle`, the `SPUStandardUpdaterController` property, and `checkForUpdates(_:)` in `#if !APPSTORE`. The "Check for Updates…" menu item is removed at launch when `APPSTORE` is defined.
+- The script strips the embedded `Sparkle.framework` from the archive after `xcodebuild archive` and re-signs the app — SwiftPM embeds the framework even when no code references it. Override the resign identity with `APPSTORE_SIGN_IDENTITY=...` if "Apple Distribution" is ambiguous.
+
+Before first submission: set `PROVISIONING_PROFILE_SPECIFIER` in `AppStore.xcconfig` to your MAS provisioning profile name. The Direct Distribution pipeline (`scripts/release.sh` → Amore + Sparkle) is unaffected.
+
 ## Known issues
 
 - **`SUFeedURL` mismatch**. Info.plist points to `https://storage.md-preview.app/appcast.xml` but Amore actually publishes to `https://storage.md-preview.app/v1/apps/doc.md-preview/appcast.xml`. Fix Info.plist before any non-test release ships to real users — already-installed copies will check the wrong URL forever. Either change `SUFeedURL` to the `/v1/apps/...` path, or configure a CDN rewrite at `storage.md-preview.app` to map `/appcast.xml` → the real path.

--- a/Info-AppStore.plist
+++ b/Info-AppStore.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Markdown Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document</string>
+			<key>UTTypeIdentifier</key>
+			<string>net.daringfireball.markdown</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>md</string>
+					<string>markdown</string>
+					<string>mdown</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>text/markdown</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -6,8 +6,10 @@
 //
 
 import Cocoa
-import Sparkle
 import UniformTypeIdentifiers
+#if !APPSTORE
+import Sparkle
+#endif
 
 extension NSToolbarItem.Identifier {
     static let openWith = NSToolbarItem.Identifier("OpenWith")
@@ -21,11 +23,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
 
     @IBOutlet var window: NSWindow!
 
+    #if !APPSTORE
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: nil,
         userDriverDelegate: nil
     )
+    #endif
 
     private var pendingLaunchURL: URL?
     private var hasLaunched = false
@@ -59,6 +63,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         toolbar.displayMode = .iconOnly
         window.toolbar = toolbar
         window.toolbarStyle = .unified
+
+        #if APPSTORE
+        removeUpdaterMenuItem()
+        #endif
 
         hasLaunched = true
 
@@ -523,9 +531,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         ) { _, _ in }
     }
 
+    #if !APPSTORE
     @IBAction func checkForUpdates(_ sender: Any?) {
         updaterController.updater.checkForUpdates()
     }
+    #else
+    private func removeUpdaterMenuItem() {
+        guard let appMenu = NSApp.mainMenu?.item(at: 0)?.submenu else { return }
+        guard let idx = appMenu.items.firstIndex(where: {
+            $0.title.range(of: "Check for Updates", options: .caseInsensitive) != nil
+        }) else { return }
+        appMenu.removeItem(at: idx)
+        if idx > 0, appMenu.items[idx - 1].isSeparatorItem {
+            appMenu.removeItem(at: idx - 1)
+        }
+    }
+    #endif
 
     @IBAction func openDocument(_ sender: Any?) {
         guard window.isVisible else {

--- a/md-preview/md-preview-appstore.entitlements
+++ b/md-preview/md-preview-appstore.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/archive-appstore.sh
+++ b/scripts/archive-appstore.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Archive Markdown Preview for Mac App Store submission.
+#
+# Compiles with -DAPPSTORE so all Sparkle code is excluded, swaps in the
+# Sparkle-free entitlements + Info.plist, and produces an .xcarchive ready
+# to upload via Xcode Organizer or `xcrun altool` / `xcrun notarytool`.
+#
+# Prereqs:
+#   - "Apple Distribution" cert installed in your login keychain.
+#   - A Mac App Store provisioning profile downloaded for doc.md-preview.
+#     Set its name in AppStore.xcconfig (PROVISIONING_PROFILE_SPECIFIER).
+#
+# Usage:
+#   scripts/archive-appstore.sh                # archives to build/AppStore.xcarchive
+#   scripts/archive-appstore.sh path/out.xcarchive
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEME="md-preview"
+ARCHIVE_PATH="${1:-$PROJECT_ROOT/build/AppStore.xcarchive}"
+
+mkdir -p "$(dirname "$ARCHIVE_PATH")"
+
+xcodebuild \
+    -project "$PROJECT_ROOT/md-preview.xcodeproj" \
+    -scheme "$SCHEME" \
+    -configuration Release \
+    -xcconfig "$PROJECT_ROOT/AppStore.xcconfig" \
+    -archivePath "$ARCHIVE_PATH" \
+    archive
+
+# Sparkle is gated out at the source level (#if !APPSTORE), but Swift Package
+# Manager still embeds Sparkle.framework into the bundle. Strip it and
+# re-sign so the archive ships nothing Sparkle-related.
+APP="$ARCHIVE_PATH/Products/Applications/Markdown Preview.app"
+SPARKLE_FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework"
+if [[ -d "$SPARKLE_FRAMEWORK" ]]; then
+    echo "Stripping embedded Sparkle.framework from archive…"
+    rm -rf "$SPARKLE_FRAMEWORK"
+    SIGN_IDENTITY="${APPSTORE_SIGN_IDENTITY:-Apple Distribution}"
+    codesign --force --sign "$SIGN_IDENTITY" \
+        --entitlements "$PROJECT_ROOT/md-preview/md-preview-appstore.entitlements" \
+        --options runtime \
+        "$APP"
+fi
+
+echo
+echo "Archive ready: $ARCHIVE_PATH"
+echo "Next: open it in Xcode Organizer and Distribute App → App Store Connect."


### PR DESCRIPTION
## Summary

- Wraps `import Sparkle`, `SPUStandardUpdaterController`, and `checkForUpdates(_:)` in `#if !APPSTORE` and removes the "Check for Updates…" menu item at launch when the flag is set.
- Adds Sparkle-free `md-preview-appstore.entitlements` (no XPC mach-lookup temp exceptions) and `Info-AppStore.plist` (no `SU*` keys) for MAS submissions.
- Adds `AppStore.xcconfig` overlay that swaps entitlements + Info.plist, sets the `APPSTORE` swift flag, and switches to manual `Apple Distribution` signing.
- Adds `scripts/archive-appstore.sh` which runs `xcodebuild archive -xcconfig AppStore.xcconfig`, then strips the SwiftPM-embedded `Sparkle.framework` and re-signs (SwiftPM bundles it even when no source references it).
- The Direct Distribution path (`scripts/release.sh` → Amore + Sparkle) is unchanged.

## Test plan

- [x] Verified Debug build still compiles with Sparkle imported (`xcodebuild build`)
- [x] Verified `SWIFT_ACTIVE_COMPILATION_CONDITIONS=APPSTORE` build succeeds with Sparkle gated out
- [ ] Set `PROVISIONING_PROFILE_SPECIFIER` in `AppStore.xcconfig` to the MAS provisioning profile, run `./scripts/archive-appstore.sh`, and validate the archive in Xcode Organizer
- [ ] Confirm the produced .app contains no `Frameworks/Sparkle.framework` and no Sparkle-related entitlements (`codesign -d --entitlements -`)
- [ ] Upload to App Store Connect and verify submission is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)