### PR TITLE
Fix Open With list: drop self-bundle copies and non-editors

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -378,10 +378,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
 
     private func editorCandidates(for fileURL: URL) -> [EditorCandidate] {
         let myBundleID = Bundle.main.bundleIdentifier
-        let myBundleURL = Bundle.main.bundleURL.resolvingSymlinksInPath().standardizedFileURL
+        // Every URL Launch Services has registered for our bundle id — covers stale DerivedData /
+        // archive copies the sandbox can't introspect by reading their Info.plist.
+        var selfURLs: Set<URL> = [Bundle.main.bundleURL.resolvingSymlinksInPath().standardizedFileURL]
+        if let myBundleID {
+            for url in NSWorkspace.shared.urlsForApplications(withBundleIdentifier: myBundleID) {
+                selfURLs.insert(url.resolvingSymlinksInPath().standardizedFileURL)
+            }
+        }
 
         return NSWorkspace.shared.urlsForApplications(toOpen: fileURL).compactMap { appURL in
-            if appURL.resolvingSymlinksInPath().standardizedFileURL == myBundleURL { return nil }
+            if selfURLs.contains(appURL.resolvingSymlinksInPath().standardizedFileURL) { return nil }
             let plist = infoPlist(at: appURL)
             let bundleID = (plist?["CFBundleIdentifier"] as? String)
                 ?? Bundle(url: appURL)?.bundleIdentifier
@@ -463,29 +470,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
             return true
         }
 
-        let markdownUTIs: Set<String> = [
-            "net.daringfireball.markdown",
-            "public.plain-text",
-            "public.text",
-            "public.source-code",
-            "public.data",
-            "public.item",
-            "public.content"
-        ]
-        // "*" matches apps that declare a wildcard CFBundleTypeExtensions (generic editors).
-        let markdownExtensions = Set(Self.markdownFileExtensions + ["*"])
+        let strongMarkdownUTIs: Set<String> = ["net.daringfireball.markdown"]
+        let plainTextUTIs: Set<String> = ["public.plain-text", "public.text",
+                                          "public.utf8-plain-text", "public.utf16-plain-text"]
+        let markdownExtensions: Set<String> = ["md", "markdown", "mdown"]
 
         var matchedAsEditor = false
         var matchedAsViewer = false
 
         for docType in docTypes {
-            let utis = (docType["LSItemContentTypes"] as? [String]) ?? []
-            let extensions = (docType["CFBundleTypeExtensions"] as? [String])?
-                .map { $0.lowercased() } ?? []
+            let utis = Set((docType["LSItemContentTypes"] as? [String]) ?? [])
+            let extensions = Set(((docType["CFBundleTypeExtensions"] as? [String]) ?? [])
+                .map { $0.lowercased() })
+            let rank = (docType["LSHandlerRank"] as? String) ?? "Default"
 
-            let handlesMarkdown = !markdownUTIs.isDisjoint(with: utis) ||
-                                  !markdownExtensions.isDisjoint(with: extensions)
-            guard handlesMarkdown else { continue }
+            let hasMarkdownUTI = !strongMarkdownUTIs.isDisjoint(with: utis)
+            let hasMarkdownExtension = !markdownExtensions.isDisjoint(with: extensions)
+            // A generic plain-text claim only counts as "real text editor" when the entry's UTI
+            // list is purely text-flavored and isn't ranked Alternate. That filters Postico
+            // (Alternate) and Numbers (bundles public.plain-text with CSV/TSV import UTIs).
+            let isPureTextEntry = !utis.isEmpty && utis.isSubset(of: plainTextUTIs.union(strongMarkdownUTIs))
+            let isPlainTextEditor = !plainTextUTIs.isDisjoint(with: utis)
+                && rank != "Alternate"
+                && isPureTextEntry
+
+            guard hasMarkdownUTI || hasMarkdownExtension || isPlainTextEditor else { continue }
 
             let role = (docType["CFBundleTypeRole"] as? String) ?? "Editor"
             switch role {
@@ -496,7 +505,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
 
         if matchedAsEditor { return true }
         if matchedAsViewer { return false }
-        return true
+        return false
     }
 
     private func disabledItem(_ title: String) -> NSMenuItem {

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -316,6 +316,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
     // MARK: - Open With
 
     private static let markdownFileExtensions = ["md", "markdown", "mdown", "txt"]
+    private static let markdownDocTypeExtensions: Set<String> = ["md", "markdown", "mdown"]
+    private static let strongMarkdownUTIs: Set<String> = ["net.daringfireball.markdown"]
+    private static let plainTextUTIs: Set<String> = [
+        "public.plain-text", "public.text",
+        "public.utf8-plain-text", "public.utf16-plain-text"
+    ]
+    private static let textyUTIs: Set<String> = plainTextUTIs.union(strongMarkdownUTIs)
     private static let defaultEditorBundleIDKey = "MarkdownPreview.defaultEditorBundleID"
     private static let editorBundleIDPriority = [
         "com.microsoft.VSCode",
@@ -392,7 +399,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
             let plist = infoPlist(at: appURL)
             let bundleID = (plist?["CFBundleIdentifier"] as? String)
                 ?? Bundle(url: appURL)?.bundleIdentifier
-            if let bundleID, bundleID == myBundleID { return nil }
             guard canEditMarkdown(plist: plist) else { return nil }
             return EditorCandidate(url: appURL, bundleID: bundleID)
         }
@@ -470,11 +476,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
             return true
         }
 
-        let strongMarkdownUTIs: Set<String> = ["net.daringfireball.markdown"]
-        let plainTextUTIs: Set<String> = ["public.plain-text", "public.text",
-                                          "public.utf8-plain-text", "public.utf16-plain-text"]
-        let markdownExtensions: Set<String> = ["md", "markdown", "mdown"]
-
         var matchedAsEditor = false
         var matchedAsViewer = false
 
@@ -484,15 +485,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
                 .map { $0.lowercased() })
             let rank = (docType["LSHandlerRank"] as? String) ?? "Default"
 
-            let hasMarkdownUTI = !strongMarkdownUTIs.isDisjoint(with: utis)
-            let hasMarkdownExtension = !markdownExtensions.isDisjoint(with: extensions)
+            let hasMarkdownUTI = !Self.strongMarkdownUTIs.isDisjoint(with: utis)
+            let hasMarkdownExtension = !Self.markdownDocTypeExtensions.isDisjoint(with: extensions)
             // A generic plain-text claim only counts as "real text editor" when the entry's UTI
             // list is purely text-flavored and isn't ranked Alternate. That filters Postico
             // (Alternate) and Numbers (bundles public.plain-text with CSV/TSV import UTIs).
-            let isPureTextEntry = !utis.isEmpty && utis.isSubset(of: plainTextUTIs.union(strongMarkdownUTIs))
-            let isPlainTextEditor = !plainTextUTIs.isDisjoint(with: utis)
-                && rank != "Alternate"
-                && isPureTextEntry
+            let isPureTextEntry = !utis.isEmpty && utis.isSubset(of: Self.textyUTIs)
+            let isPlainTextEditor = isPureTextEntry && rank != "Alternate"
 
             guard hasMarkdownUTI || hasMarkdownExtension || isPlainTextEditor else { continue }
 


### PR DESCRIPTION
## Summary

The "Open with…" popup was showing two classes of garbage:

- **Duplicate Markdown Preview entries** — Launch Services has 21 stale paths registered for `doc.md-preview` (old archives, ejected DMGs, Trash copies). Three are still on disk (`/Applications`, the DerivedData Debug build, and a `/private/tmp` archive build), so all three slipped through the existing self-filter. The sandbox can't read those bundles' `Info.plist` files, so `bundleID == myBundleID` silently skipped them.
- **Non-editor apps** like Postico, Numbers, Hex Fiend — Launch Services returns them because they declare generic `public.plain-text` (or wildcard `*`) claims. The old filter accepted those plus root UTIs (`public.data` / `public.item` / `public.content`) that almost everything conforms to.

## Changes

`md-preview/AppDelegate.swift`:

- `editorCandidates(for:)` now asks `NSWorkspace.urlsForApplications(withBundleIdentifier:)` for every URL Launch Services has registered under our bundle id, and rejects candidates by URL set. No longer relies on being able to read each candidate's `Info.plist`.
- `canEditMarkdown(plist:)` dropped the over-broad UTIs (`public.data`, `public.item`, `public.content`, `public.source-code`) and the `"*"` extension wildcard. A `public.plain-text` claim now counts as "real text editor" only when:
  - the doc-type entry's UTI list is a subset of the text/markdown UTIs (filters Numbers, which bundles `public.plain-text` with `public.comma-separated-values-text`), and
  - `LSHandlerRank` ≠ `Alternate` (filters Postico, which self-declares as a fallback handler).
- Fall-through return for "no doc-type matched" flipped from permissive to strict; only an entirely missing `CFBundleDocumentTypes` retains the legacy permissive pass.

Real text editors that declare via UTI only (TextEdit, BBEdit, …) still pass because their plain-text entry is purely text-flavored.

## Test plan

- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` succeeds
- [ ] Open a `.md` file and click the "Open with…" toolbar item — list contains Typora / Cursor / Zed / VS Code / TextEdit / Xcode (whichever are installed), no duplicate Markdown Preview entries
- [ ] Postico, Numbers, Hex Fiend no longer appear
- [ ] Selecting an entry still launches that editor and persists the choice across relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)