### PR TITLE
Replace Ink with swift-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Pull requests are welcome. For larger changes, please open an issue first to dis
 
 - [swift-markdown](https://github.com/swiftlang/swift-markdown) — Markdown parser (Apple, cmark-gfm-backed)
 - [Sparkle](https://sparkle-project.org) — Auto-update framework
-- [Amore](http://amore.computer/) — macOS release automation (signing, notarization, DMG, S3 hosting, appcast)
+- [Amore](http://amore.computer/) — macOS release automation (signing, notarization, DMG, hosting, appcast)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## Features
 
-- **Native rendering** — `WKWebView` pipeline backed by [Ink](https://github.com/JohnSundell/Ink), with heading anchors and link handling.
+- **Native rendering** — `WKWebView` pipeline backed by [swift-markdown](https://github.com/swiftlang/swift-markdown), with heading anchors and link handling.
 - **Document outline** — sidebar TOC that mirrors your headings; click to jump.
 - **Inspector panel** — toggleable side panel with file metadata.
 - **In-document search** — toolbar search field plus standard <kbd>⌘F</kbd> / <kbd>⌘G</kbd> / <kbd>⌘⇧G</kbd> for next/previous match.
@@ -61,7 +61,7 @@ cd md-preview.app
 open md-preview.xcodeproj
 ```
 
-Build and run the `md-preview` scheme. Swift Package Manager will resolve [Sparkle](https://github.com/sparkle-project/Sparkle) and [Ink](https://github.com/JohnSundell/Ink) on first build.
+Build and run the `md-preview` scheme. Swift Package Manager will resolve [Sparkle](https://github.com/sparkle-project/Sparkle) and [swift-markdown](https://github.com/swiftlang/swift-markdown) on first build.
 
 ## Project layout
 
@@ -96,7 +96,7 @@ Pull requests are welcome. For larger changes, please open an issue first to dis
 
 ## Acknowledgments
 
-- [Ink](https://github.com/JohnSundell/Ink) — Markdown parser
+- [swift-markdown](https://github.com/swiftlang/swift-markdown) — Markdown parser (Apple, cmark-gfm-backed)
 - [Sparkle](https://sparkle-project.org) — Auto-update framework
 - [Amore](http://amore.computer/) — macOS release automation (signing, notarization, DMG, S3 hosting, appcast)
 

--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		9A0207D32FA0ED7D00092060 /* Ink in Frameworks */ = {isa = PBXBuildFile; productRef = 9A0207D42FA0ED7D00092060 /* Ink */; };
 		9A0209302FA10D4C00092060 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A02092F2FA10D4C00092060 /* Quartz.framework */; };
 		9A02093C2FA10D4C00092060 /* quick-look.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9A02092D2FA10D4C00092060 /* quick-look.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		9A02095A2FA1100000092060 /* Ink in Frameworks */ = {isa = PBXBuildFile; productRef = 9A02095B2FA1100000092060 /* Ink */; };
 		9A0209C12FA1100200092060 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9A0209C22FA1100200092060 /* Sparkle */; };
+		9A33940A2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3394092FA5AF500015D9A4 /* Markdown */; };
+		9A33940C2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A33940B2FA5AF500015D9A4 /* Markdown */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,8 +87,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9A0207D32FA0ED7D00092060 /* Ink in Frameworks */,
 				9A0209C12FA1100200092060 /* Sparkle in Frameworks */,
+				9A33940A2FA5AF500015D9A4 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,7 +97,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A0209302FA10D4C00092060 /* Quartz.framework in Frameworks */,
-				9A02095A2FA1100000092060 /* Ink in Frameworks */,
+				9A33940C2FA5AF500015D9A4 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,8 +154,8 @@
 			);
 			name = "md-preview";
 			packageProductDependencies = (
-				9A0207D42FA0ED7D00092060 /* Ink */,
 				9A0209C22FA1100200092060 /* Sparkle */,
+				9A3394092FA5AF500015D9A4 /* Markdown */,
 			);
 			productName = "md-preview";
 			productReference = 9A0207C12FA0ED7C00092060 /* Markdown Preview.app */;
@@ -178,7 +178,7 @@
 			);
 			name = "quick-look";
 			packageProductDependencies = (
-				9A02095B2FA1100000092060 /* Ink */,
+				9A33940B2FA5AF500015D9A4 /* Markdown */,
 			);
 			productName = "quick-look";
 			productReference = 9A02092D2FA10D4C00092060 /* quick-look.appex */;
@@ -212,8 +212,8 @@
 			mainGroup = 9A0207B82FA0ED7C00092060;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				9A0207D52FA0ED7D00092060 /* XCRemoteSwiftPackageReference "Ink" */,
 				9A0209C32FA1100200092060 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				9A3394082FA5AF500015D9A4 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9A0207C22FA0ED7C00092060 /* Products */;
@@ -552,14 +552,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		9A0207D52FA0ED7D00092060 /* XCRemoteSwiftPackageReference "Ink" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/JohnSundell/Ink";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.0;
-			};
-		};
 		9A0209C32FA1100200092060 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -568,23 +560,31 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		9A3394082FA5AF500015D9A4 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/swiftlang/swift-markdown.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.3;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		9A0207D42FA0ED7D00092060 /* Ink */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9A0207D52FA0ED7D00092060 /* XCRemoteSwiftPackageReference "Ink" */;
-			productName = Ink;
-		};
-		9A02095B2FA1100000092060 /* Ink */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9A0207D52FA0ED7D00092060 /* XCRemoteSwiftPackageReference "Ink" */;
-			productName = Ink;
-		};
 		9A0209C22FA1100200092060 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9A0209C32FA1100200092060 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		9A3394092FA5AF500015D9A4 /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9A3394082FA5AF500015D9A4 /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
+		};
+		9A33940B2FA5AF500015D9A4 /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9A3394082FA5AF500015D9A4 /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -4,12 +4,11 @@
 //
 
 import Foundation
-import Ink
+import Markdown
 
 enum MarkdownHTML {
     static func makeHTML(from markdown: String, allowsScroll: Bool = false) -> String {
-        let parser = MarkdownParser()
-        let body = injectHeadingIDs(in: parser.html(from: markdown))
+        let body = injectHeadingIDs(in: HTMLFormatter.format(markdown))
         let scrollOverride = allowsScroll ? """
         <style>
         html, body { overflow: auto !important; }


### PR DESCRIPTION
## Summary

- Swap the Markdown engine from [Ink](https://github.com/JohnSundell/Ink) to Apple's [swift-markdown](https://github.com/swiftlang/swift-markdown) 0.7.3 (cmark-gfm-backed). Same one-call API: `HTMLFormatter.format(_:)`.
- The existing heading-ID regex post-processor and the entire CSS stylesheet are unchanged — only the parser/HTML emitter swapped.
- Package wired into both `md-preview` and `quick-look` (Quick Look extension) targets.
- README updated (Features, Building from source, Acknowledgments).

## Why

- swift-markdown is officially maintained by Apple/swiftlang and tracks the [GFM spec](https://github.github.com/gfm/) via `cmark-gfm`.
- Ink hasn't seen a release since 2020 and has weak GFM table / task-list / strikethrough support — all of which now work out of the box.
- Future capability: `HTMLFormatterOptions.parseAsides` can turn `> Note: …` blockquotes into semantic `<aside data-kind="note">` tags whenever we want to lean into it (not enabled in this PR to keep the diff minimal).

## Test plan

- [x] `xcodebuild -resolvePackageDependencies` resolves cleanly (swift-markdown 0.7.3 + transitive cmark-gfm 0.7.1).
- [x] `xcodebuild -scheme md-preview -configuration Debug build` → `BUILD SUCCEEDED` (both app target and embedded `quick-look.appex`).
- [ ] Manual smoke: open a representative `.md` in the app and via Finder spacebar (Quick Look). Eyeball:
  - [ ] Headings still get anchor IDs (sidebar TOC clicks should jump correctly).
  - [ ] GFM tables render (this is now supported where it wasn't before).
  - [ ] Task lists render (`- [ ]` / `- [x]`).
  - [ ] Inline code, fenced code blocks with language hints, blockquotes, images, links.

## Notes

- Direct Distribution pipeline (`scripts/release.sh` → Amore + Sparkle) is unaffected.
- App Store build (`scripts/archive-appstore.sh`) is unaffected — `Markdown` is a pure-Swift package, sandbox-clean, and has no XPC requirements.
- CHANGELOG entry intentionally not added — that's tied to the next version bump per the release workflow in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)