### PR TITLE
Use amore --format json for DMG URL lookup

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -149,13 +149,19 @@ fi
 
 # ── amore release ──────────────────────────────────────────────────────────
 echo "▸ amore release"
+if ! command -v jq >/dev/null; then
+    echo "  ✗ jq not installed — brew install jq" >&2
+    exit 1
+fi
 LOG="$(mktemp)"
 "$AMORE" release --scheme "$SCHEME" --release-notes "$NOTES" $BETA_FLAG $DRAFT_FLAG \
+    --format json \
     | tee "$LOG"
 
-DMG_URL="$(grep -oE 'https://[^[:space:]]+\.dmg' "$LOG" | tail -1 || true)"
+# amore --format json prints text progress, then a single JSON object at the end
+DMG_URL="$(sed -n '/^{/,$p' "$LOG" | jq -er '.release.downloadURL' 2>/dev/null || true)"
 if [[ -z "$DMG_URL" ]]; then
-    echo "✗ couldn't parse DMG URL from amore output (see $LOG)" >&2
+    echo "✗ no .release.downloadURL in amore JSON output (see $LOG)" >&2
     exit 1
 fi
 echo "▸ DMG: $DMG_URL"


### PR DESCRIPTION
## Summary
- amore CLI now supports `--format json` on `amore release`, emitting a structured object with `.release.downloadURL` after the progress output
- Replaced the brittle `grep -oE 'https://[^[:space:]]+\.dmg'` scan over the full log with a `jq` lookup on the trailing JSON document
- Added a `jq` preflight so the script fails fast with a clear message if it's missing

`amore releases list/update/delete` don't yet support `--format json`, so the table parsing in `scripts/rollback-release.sh` is unchanged.

## Test plan
- [ ] `./scripts/release.sh --draft` — DMG URL is parsed and printed, GitHub release skipped
- [ ] Run with `jq` uninstalled — script exits with the preflight error before invoking amore