### PR TITLE
Bump to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.4] – 2026-05-02
+
+Relative images and links in Markdown files now render in the sandboxed app.
+
+- **Render relative local assets via a folder-access banner.** When a document references images or files alongside it, Markdown Preview now shows an in-window banner offering to grant read access to the parent folder. Once granted, the access is remembered across launches and assets load through a dedicated `md-asset://` scheme so they appear inline in the preview.
+- **Stable DMG filename for GitHub releases.** The DMG attached to each GitHub release is now `Markdown-Preview.dmg` without a version suffix, so download links stay valid across versions.
+
 ## [0.0.3] – 2026-05-02
 
 Better Markdown rendering and a tidier **Open With** menu.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.3
-CURRENT_PROJECT_VERSION = 7
+MARKETING_VERSION = 0.0.4
+CURRENT_PROJECT_VERSION = 8


### PR DESCRIPTION
## Summary
- Bumps `MARKETING_VERSION` to `0.0.4` and `CURRENT_PROJECT_VERSION` to `8` in `Version.xcconfig`.
- Adds a `CHANGELOG.md` entry covering the relative-asset folder-access banner (#17) and the stable `Markdown-Preview.dmg` filename used for GitHub release assets.

## Test plan
- [ ] `./scripts/release.sh` (or `--draft`) picks up the new version and changelog notes
- [ ] App build still succeeds at the new marketing/build numbers