### PR TITLE
Anchor sidebar title to safe area for fullscreen

### DIFF
--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -54,7 +54,7 @@ final class SidebarViewController: NSViewController {
         scrollView.documentView = outlineView
 
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 44),
+            titleLabel.topAnchor.constraint(equalTo: container.safeAreaLayoutGuide.topAnchor, constant: 8),
             titleLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
             titleLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -14),
 


### PR DESCRIPTION
## Summary
- The sidebar's TOC title (filename) was pinned with a hardcoded `container.topAnchor + 44`, a magic number meant to clear the toolbar.
- With `.fullSizeContentView` enabled on the window, the actual top inset differs between windowed and fullscreen modes, so in fullscreen the title slid up behind the toolbar (see report).
- Anchored the title to `container.safeAreaLayoutGuide.topAnchor + 8` so AppKit positions it correctly in either mode. The outline rows still scroll under the toolbar (standard sidebar behavior).

## Test plan
- [ ] Open a markdown file, toggle fullscreen — the filename label sits below the toolbar with no overlap.
- [ ] Exit fullscreen — title still has comfortable spacing below the unified title-bar/toolbar.
- [ ] Resize the sidebar; title truncates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)