### PR TITLE
Bump to 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.5] – 2026-05-02
+
+Small fullscreen polish for the sidebar.
+
+- **Sidebar title sits correctly in fullscreen.** The document title at the top of the table-of-contents pane no longer slides under the toolbar when the window enters fullscreen — it now anchors to the safe-area inset and stays put in both windowed and fullscreen modes.
+
 ## [0.0.4] – 2026-05-02
 
 Relative images and links in Markdown files now render in the sandboxed app.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.4
-CURRENT_PROJECT_VERSION = 8
+MARKETING_VERSION = 0.0.5
+CURRENT_PROJECT_VERSION = 9


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` to `0.0.5` and `CURRENT_PROJECT_VERSION` to `9` in `Version.xcconfig`.
- Adds a `CHANGELOG.md` entry for `0.0.5` covering the sole change since `0.0.4`: the sidebar document title now anchors to the safe-area inset so it stays visible in fullscreen instead of sliding under the toolbar (#19).

## Test plan

- [ ] Build the `md-preview` scheme and confirm both the app and Quick Look extension report version `0.0.5 (9)`.
- [ ] Open a Markdown document, enter fullscreen, and verify the sidebar title sits below the toolbar in both windowed and fullscreen modes.
- [ ] After merge, run `./scripts/release.sh` from `main` to ship `0.0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)