### PR TITLE
Bump to 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.0.6] – 2026-05-02
+
+Toolbar, banner, and table-of-contents polish.
+
+- **Search field collapses to a magnifying-glass button in narrow windows.** When the toolbar is too tight to fit the expanded search field, it now folds into an icon-only button matching the rest of the toolbar instead of being clipped.
+- **Open With toolbar item shows the resolved editor.** When a default Markdown editor is set, the toolbar item now reads "Open in <Editor>" as both label and tooltip, and the menu lists apps by their Finder display name without the `.app` suffix. The chosen editor's location is also remembered alongside its bundle ID, so launches still resolve when the bundle ID is unavailable.
+- **Folder-access banner no longer clips text on macOS 15.** The banner now advertises a fixed height to the titlebar accessory so descenders in the message label aren't cut off, and the redundant top/bottom separators are hidden on macOS 15 (where AppKit already draws system ones).
+- **Folder-access banner stays until access is granted.** Removed the dismiss button so the prompt no longer disappears when accidentally clicked — it now goes away only after you grant read access to the folder.
+- **TOC clicks scroll headings below the toolbar.** Jumping to a heading from the sidebar now accounts for the toolbar height plus a small breathing margin, so the target heading lands in view instead of behind the toolbar.
+- **Share toolbar button is the right size.** The share item no longer renders an oversized icon next to the other toolbar buttons.
+
 ## [0.0.5] – 2026-05-02
 
 Small fullscreen polish for the sidebar.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.5
-CURRENT_PROJECT_VERSION = 9
+MARKETING_VERSION = 0.0.6
+CURRENT_PROJECT_VERSION = 10


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` to 0.0.6 and `CURRENT_PROJECT_VERSION` to 10 in `Version.xcconfig`.
- Adds a `[0.0.6] – 2026-05-02` entry to `CHANGELOG.md` covering the toolbar/banner/TOC polish from #21 (collapsing search field, Open With label and persistence, banner sizing on macOS 15, banner dismiss removal, TOC scroll inset, and share-button sizing).

## Test plan

- [ ] `./scripts/release.sh` after merge cuts the 0.0.6 DMG, GitHub release, and appcast entry without errors.
- [ ] Installed 0.0.6 build shows the new version in About and updates cleanly from 0.0.5 via Sparkle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)