### PR TITLE
Hide YAML frontmatter from preview, show it in Inspector

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				MarkdownAssetSchemeHandler.swift,
+				MarkdownFrontmatter.swift,
 				MarkdownHTML.swift,
 				MarkdownWebView.swift,
 			);

--- a/md-preview/InspectorView.swift
+++ b/md-preview/InspectorView.swift
@@ -15,19 +15,28 @@ struct DocumentMetadata: Equatable {
     var imageCount: Int = 0
     var modifiedDate: Date?
     var fileSize: Int64?
+    var frontmatter: [FrontmatterEntry] = []
 }
 
 extension DocumentMetadata {
     static func make(url: URL?, markdown: String) -> DocumentMetadata {
         var meta = DocumentMetadata()
         meta.fileName = url?.lastPathComponent ?? "Untitled"
-        meta.characterCount = markdown.count
-        meta.wordCount = markdown.split { $0.isWhitespace }.count
-        meta.lineCount = markdown.isEmpty ? 0 : markdown.components(separatedBy: .newlines).count
-        meta.headingCount = markdown.components(separatedBy: .newlines)
+
+        let split = MarkdownFrontmatter.split(markdown)
+        if let raw = split.raw {
+            meta.frontmatter = MarkdownFrontmatter.parse(raw)
+        }
+        let body = split.body
+        let bodyLines = body.components(separatedBy: .newlines)
+
+        meta.characterCount = body.count
+        meta.wordCount = body.split { $0.isWhitespace }.count
+        meta.lineCount = body.isEmpty ? 0 : bodyLines.count
+        meta.headingCount = bodyLines
             .filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }.count
-        let totalRefs = max(0, markdown.components(separatedBy: "](").count - 1)
-        meta.imageCount = max(0, markdown.components(separatedBy: "![").count - 1)
+        let totalRefs = max(0, body.components(separatedBy: "](").count - 1)
+        meta.imageCount = max(0, body.components(separatedBy: "![").count - 1)
         meta.linkCount = max(0, totalRefs - meta.imageCount)
 
         if let url,
@@ -44,6 +53,14 @@ struct InspectorView: View {
 
     var body: some View {
         Form {
+            if !metadata.frontmatter.isEmpty {
+                Section("Properties") {
+                    ForEach(metadata.frontmatter) { entry in
+                        LabeledContent(entry.key, value: entry.value)
+                    }
+                }
+            }
+
             Section {
                 LabeledContent("File Name", value: metadata.fileName)
                 LabeledContent("Document Type", value: "Markdown Document")

--- a/md-preview/MarkdownFrontmatter.swift
+++ b/md-preview/MarkdownFrontmatter.swift
@@ -1,0 +1,64 @@
+//
+//  MarkdownFrontmatter.swift
+//  md-preview
+//
+
+import Foundation
+
+struct FrontmatterEntry: Equatable, Identifiable {
+    let id: Int
+    let key: String
+    let value: String
+}
+
+// Swift-markdown is CommonMark: it has no YAML frontmatter notion, so a closing
+// `---` would otherwise turn the preceding lines into a setext H2 in the
+// rendered output. We strip the block before parsing and surface the parsed
+// entries in the Inspector instead.
+enum MarkdownFrontmatter {
+
+    static func split(_ markdown: String) -> (raw: String?, body: String) {
+        let stripped = markdown.first == "\u{FEFF}" ? String(markdown.dropFirst()) : markdown
+        var lines: [String] = []
+        stripped.enumerateLines { line, _ in lines.append(line) }
+
+        guard let first = lines.first,
+              first.trimmingCharacters(in: .whitespaces) == "---"
+        else { return (nil, markdown) }
+
+        guard let close = lines.dropFirst().firstIndex(where: {
+            let trimmed = $0.trimmingCharacters(in: .whitespaces)
+            return trimmed == "---" || trimmed == "..."
+        }) else { return (nil, markdown) }
+
+        let raw = lines[1..<close].joined(separator: "\n")
+        let body = lines[(close + 1)...].joined(separator: "\n")
+        return (raw, body)
+    }
+
+    // Best-effort parse: each top-level `key: value` line becomes an entry;
+    // indented continuation lines append to the previous value. We don't
+    // interpret YAML types — values are shown verbatim in the Inspector.
+    static func parse(_ raw: String) -> [FrontmatterEntry] {
+        var entries: [FrontmatterEntry] = []
+        for rawLine in raw.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            if line.trimmingCharacters(in: .whitespaces).isEmpty { continue }
+
+            if line.first == " " || line.first == "\t", !entries.isEmpty {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                let prev = entries[entries.count - 1]
+                let combined = prev.value.isEmpty ? trimmed : "\(prev.value) \(trimmed)"
+                entries[entries.count - 1] = FrontmatterEntry(id: prev.id, key: prev.key, value: combined)
+                continue
+            }
+
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let key = line[..<colon].trimmingCharacters(in: .whitespaces)
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+            entries.append(FrontmatterEntry(id: entries.count, key: key, value: value))
+        }
+        return entries
+    }
+}

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -10,7 +10,7 @@ enum MarkdownHTML {
     static func makeHTML(from markdown: String,
                          allowsScroll: Bool = false,
                          assetBaseHref: String? = nil) -> String {
-        let body = injectHeadingIDs(in: HTMLFormatter.format(markdown))
+        let body = injectHeadingIDs(in: HTMLFormatter.format(MarkdownFrontmatter.split(markdown).body))
         let scrollOverride = allowsScroll ? """
         <style>
         html, body { overflow: auto !important; }


### PR DESCRIPTION
## Summary

- swift-markdown is plain CommonMark and has no YAML frontmatter notion, so a closing \`---\` was being interpreted as a setext heading underline — collapsing the metadata block into one giant H2 in the rendered preview.
- New \`MarkdownFrontmatter\` helper splits a leading \`---\` … (\`---\`|\`...\`) block off before \`HTMLFormatter.format\`, so the rendered preview is clean (matches GitHub / Obsidian / VS Code behavior).
- Parsed entries are surfaced in a new **Properties** section at the top of the Inspector, so the metadata is still one click away.
- Word/line/heading counts now operate on the body (frontmatter excluded) and the body is split into lines once instead of three times.

## Test plan

- [ ] Open a markdown file with YAML frontmatter — preview no longer shows the giant H2 collapsing of \`title: ...\` / \`date: ...\` / \`tags: ...\`.
- [ ] Inspector shows a **Properties** section listing each key/value pair from the frontmatter.
- [ ] Open a markdown file with no frontmatter — Inspector has no Properties section, preview unchanged.
- [ ] Quick Look extension also hides the frontmatter (shares \`MarkdownHTML.makeHTML\`).
- [ ] Counts in Inspector (Words / Lines / Headings) reflect body content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)