### PR TITLE
Bump to 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.7] – 2026-05-03
+
+YAML frontmatter rendering fix and Inspector metadata.
+
+- **YAML frontmatter no longer collapses into a giant heading.** The CommonMark renderer was treating the closing `---` of a frontmatter block as a setext heading underline, turning `title:` / `date:` / `tags:` into one oversized H2 at the top of the document. The block is now stripped before parsing and the preview matches what GitHub, Obsidian, and VS Code show.
+- **Frontmatter shows up in the Inspector.** A new **Properties** section at the top of the Inspector lists each key/value pair from the document's frontmatter, so the metadata is one click away even though it's hidden from the rendered preview. The Quick Look extension hides it too.
+- **Word, line, and heading counts now reflect body content.** The Inspector's stats no longer include the frontmatter block in their totals.
+
 ## [0.0.6] – 2026-05-02
 
 Toolbar, banner, and table-of-contents polish.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.6
-CURRENT_PROJECT_VERSION = 10
+MARKETING_VERSION = 0.0.7
+CURRENT_PROJECT_VERSION = 11


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` to `0.0.7` and `CURRENT_PROJECT_VERSION` to `11` in `Version.xcconfig`.
- Adds the `0.0.7` entry to `CHANGELOG.md` covering the frontmatter rendering fix and Inspector "Properties" section from #23.

Depends on #23 — merge that first so the changelog entry matches the shipped behavior.

## Test plan

- [ ] After both PRs land, run `./scripts/release.sh` and confirm the changelog entry is picked up automatically (the script validates the entry exists for the resolved version).
- [ ] Confirm the About panel and `defaults read .../Markdown\ Preview Info CFBundleShortVersionString` show `0.0.7` in the resulting build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)