### PR TITLE
Bump to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.8] – 2026-05-03
+
+Tabbed Inspector with native segmented picker.
+
+- **Inspector now has Document and Properties tabs.** A native segmented picker with SF Symbol icons (doc / info) splits the panel into a Document tab for file and content stats and a Properties tab for YAML frontmatter, instead of stacking everything in one scrolling list.
+- **Empty Properties tab shows a placeholder.** Documents without frontmatter now display "No YAML frontmatter" filling the available space, so the tab doesn't collapse to nothing.
+- **Picker matches Apple's pill-style segmented look on macOS 26 Tahoe.** Uses `.controlSize(.large)` plus `.buttonSizing(.flexible)` on Tahoe and falls back to `.fixedSize()` on macOS 15 Sequoia.
+
 ## [0.0.7] – 2026-05-03
 
 YAML frontmatter rendering fix and Inspector metadata.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.7
-CURRENT_PROJECT_VERSION = 11
+MARKETING_VERSION = 0.0.8
+CURRENT_PROJECT_VERSION = 12


### PR DESCRIPTION
## Summary

- Adds `## [0.0.8] – 2026-05-03` entry to `CHANGELOG.md` covering the Tabbed Inspector change merged in #25
- Bumps `Version.xcconfig`: `MARKETING_VERSION 0.0.7 → 0.0.8`, `CURRENT_PROJECT_VERSION 11 → 12`

## Test plan

- [ ] `./scripts/release.sh` validates the changelog entry exists for 0.0.8
- [ ] Inspector renders Document / Properties tabs with the segmented picker on macOS 26
- [ ] Properties tab shows "No YAML frontmatter" placeholder for documents without frontmatter
- [ ] Properties tab lists key/value pairs for documents with frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)