### PR TITLE
Bump to 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.9] – 2026-05-03
+
+Mermaid diagram rendering in the app and Quick Look.
+
+- **Fenced `mermaid` code blocks now render as diagrams.** The Markdown pipeline detects `mermaid` fences, swaps them for diagram containers, and runs the Mermaid renderer on load — flowcharts, sequence diagrams, class diagrams, and the rest show up inline instead of as raw code.
+- **Renderer is bundled, so previews work offline.** The Mermaid script ships inside the app bundle and is shared with the Quick Look extension; no CDN request is made when opening a document.
+- **Diagrams follow the system appearance.** Mermaid initializes with the dark theme when the system is in dark mode and the default theme otherwise, and uses the SF system font so labels match the surrounding text.
+
 ## [0.0.8] – 2026-05-03
 
 Tabbed Inspector with native segmented picker.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.8
-CURRENT_PROJECT_VERSION = 12
+MARKETING_VERSION = 0.0.9
+CURRENT_PROJECT_VERSION = 13


### PR DESCRIPTION
## Summary
- Bumps `MARKETING_VERSION` to `0.0.9` and `CURRENT_PROJECT_VERSION` to `13` in `Version.xcconfig`.
- Adds a `[0.0.9] – 2026-05-03` entry to `CHANGELOG.md` covering the Mermaid diagram rendering shipped in #27.

## Test plan
- [ ] `./scripts/release.sh` validates the changelog entry and produces a signed/notarized DMG.
- [ ] Quick Look and the app both render a `mermaid` fenced code block as a diagram offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)