### PR TITLE
fix: HTML-escape text and code in rendered output (#33)

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		9A0209432FA10E6600092060 /* Exceptions for "md-preview" folder in "quick-look" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				EscapingHTMLFormatter.swift,
 				MarkdownAssetSchemeHandler.swift,
 				MarkdownFrontmatter.swift,
 				MarkdownHTML.swift,

--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -1,0 +1,284 @@
+//
+//  EscapingHTMLFormatter.swift
+//  md-preview
+//
+
+import Foundation
+import Markdown
+
+// Mirrors swift-markdown's HTMLFormatter but HTML-escapes text, code, and
+// attribute values. Upstream HTMLFormatter emits unescaped content
+// (swift-markdown 0.7.x), so characters like `<`, `>`, and `&` either render
+// invisibly or get reinterpreted as HTML — see issue #33.
+struct EscapingHTMLFormatter: MarkupWalker {
+    private(set) var result = ""
+
+    let options: HTMLFormatterOptions
+
+    private var inTableHead = false
+    private var tableColumnAlignments: [Table.ColumnAlignment?]?
+    private var currentTableColumn = 0
+
+    init(options: HTMLFormatterOptions = []) {
+        self.options = options
+    }
+
+    static func format(_ markdown: String, options: HTMLFormatterOptions = []) -> String {
+        let document = Document(parsing: markdown)
+        var walker = EscapingHTMLFormatter(options: options)
+        walker.visit(document)
+        return walker.result
+    }
+
+    // MARK: Block elements
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
+        if options.contains(.parseAsides),
+           let aside = Aside(blockQuote, tagRequirement: .requireSingleWordTag) {
+            result += "<aside data-kind=\"\(escapeAttribute(aside.kind.rawValue))\">\n"
+            for child in aside.content {
+                visit(child)
+            }
+            result += "</aside>\n"
+        } else {
+            result += "<blockquote>\n"
+            descendInto(blockQuote)
+            result += "</blockquote>\n"
+        }
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
+        let languageAttr: String
+        if let language = codeBlock.language {
+            languageAttr = " class=\"language-\(escapeAttribute(language))\""
+        } else {
+            languageAttr = ""
+        }
+        result += "<pre><code\(languageAttr)>\(escapeText(codeBlock.code))</code></pre>\n"
+    }
+
+    mutating func visitHeading(_ heading: Heading) {
+        result += "<h\(heading.level)>\(escapeText(heading.plainText))</h\(heading.level)>\n"
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+        result += "<hr />\n"
+    }
+
+    mutating func visitHTMLBlock(_ html: HTMLBlock) {
+        // Raw HTML blocks are passed through per CommonMark.
+        result += html.rawHTML
+    }
+
+    mutating func visitListItem(_ listItem: ListItem) {
+        result += "<li>"
+        if let checkbox = listItem.checkbox {
+            result += "<input type=\"checkbox\" disabled=\"\""
+            if checkbox == .checked {
+                result += " checked=\"\""
+            }
+            result += " /> "
+        }
+        descendInto(listItem)
+        result += "</li>\n"
+    }
+
+    mutating func visitOrderedList(_ orderedList: OrderedList) {
+        let start: String
+        if orderedList.startIndex != 1 {
+            start = " start=\"\(orderedList.startIndex)\""
+        } else {
+            start = ""
+        }
+        result += "<ol\(start)>\n"
+        descendInto(orderedList)
+        result += "</ol>\n"
+    }
+
+    mutating func visitUnorderedList(_ unorderedList: UnorderedList) {
+        result += "<ul>\n"
+        descendInto(unorderedList)
+        result += "</ul>\n"
+    }
+
+    mutating func visitParagraph(_ paragraph: Paragraph) {
+        result += "<p>"
+        descendInto(paragraph)
+        result += "</p>\n"
+    }
+
+    mutating func visitTable(_ table: Table) {
+        result += "<table>\n"
+        tableColumnAlignments = table.columnAlignments
+        descendInto(table)
+        tableColumnAlignments = nil
+        result += "</table>\n"
+    }
+
+    mutating func visitTableHead(_ tableHead: Table.Head) {
+        result += "<thead>\n<tr>\n"
+        inTableHead = true
+        currentTableColumn = 0
+        descendInto(tableHead)
+        inTableHead = false
+        result += "</tr>\n</thead>\n"
+    }
+
+    mutating func visitTableBody(_ tableBody: Table.Body) {
+        if !tableBody.isEmpty {
+            result += "<tbody>\n"
+            descendInto(tableBody)
+            result += "</tbody>\n"
+        }
+    }
+
+    mutating func visitTableRow(_ tableRow: Table.Row) {
+        result += "<tr>\n"
+        currentTableColumn = 0
+        descendInto(tableRow)
+        result += "</tr>\n"
+    }
+
+    mutating func visitTableCell(_ tableCell: Table.Cell) {
+        guard let alignments = tableColumnAlignments,
+              currentTableColumn < alignments.count else { return }
+        guard tableCell.colspan > 0, tableCell.rowspan > 0 else { return }
+
+        let element = inTableHead ? "th" : "td"
+        result += "<\(element)"
+
+        if let alignment = alignments[currentTableColumn] {
+            result += " align=\"\(alignment)\""
+        }
+        currentTableColumn += 1
+
+        if tableCell.rowspan > 1 {
+            result += " rowspan=\"\(tableCell.rowspan)\""
+        }
+        if tableCell.colspan > 1 {
+            result += " colspan=\"\(tableCell.colspan)\""
+        }
+
+        result += ">"
+        descendInto(tableCell)
+        result += "</\(element)>\n"
+    }
+
+    // MARK: Inline elements
+
+    mutating func visitInlineCode(_ inlineCode: InlineCode) {
+        result += "<code>\(escapeText(inlineCode.code))</code>"
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) {
+        result += "<em>"
+        descendInto(emphasis)
+        result += "</em>"
+    }
+
+    mutating func visitStrong(_ strong: Strong) {
+        result += "<strong>"
+        descendInto(strong)
+        result += "</strong>"
+    }
+
+    mutating func visitImage(_ image: Image) {
+        result += "<img"
+        if let source = image.source, !source.isEmpty {
+            result += " src=\"\(escapeAttribute(source))\""
+        }
+        if let title = image.title, !title.isEmpty {
+            result += " title=\"\(escapeAttribute(title))\""
+        }
+        result += " />"
+    }
+
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) {
+        result += inlineHTML.rawHTML
+    }
+
+    mutating func visitLineBreak(_ lineBreak: LineBreak) {
+        result += "<br />\n"
+    }
+
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) {
+        result += "\n"
+    }
+
+    mutating func visitLink(_ link: Link) {
+        result += "<a"
+        if let destination = link.destination {
+            result += " href=\"\(escapeAttribute(destination))\""
+        }
+        result += ">"
+        descendInto(link)
+        result += "</a>"
+    }
+
+    mutating func visitText(_ text: Text) {
+        result += escapeText(text.string)
+    }
+
+    mutating func visitStrikethrough(_ strikethrough: Strikethrough) {
+        result += "<del>"
+        descendInto(strikethrough)
+        result += "</del>"
+    }
+
+    mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
+        if let destination = symbolLink.destination {
+            result += "<code>\(escapeText(destination))</code>"
+        }
+    }
+
+    mutating func visitInlineAttributes(_ attributes: InlineAttributes) {
+        result += "<span data-attributes=\"\(escapeAttribute(attributes.attributes))\""
+
+        if options.contains(.parseInlineAttributeClass) {
+            let wrappedAttributes = "{\(attributes.attributes)}"
+            if let attributesData = wrappedAttributes.data(using: .utf8) {
+                struct ParsedAttributes: Decodable {
+                    var `class`: String
+                }
+                let decoder = JSONDecoder()
+                decoder.allowsJSON5 = true
+                if let parsed = try? decoder.decode(ParsedAttributes.self, from: attributesData) {
+                    result += " class=\"\(escapeAttribute(parsed.class))\""
+                }
+            }
+        }
+
+        result += ">"
+        descendInto(attributes)
+        result += "</span>"
+    }
+}
+
+private func escapeText(_ string: String) -> String {
+    var out = ""
+    out.reserveCapacity(string.count)
+    for ch in string {
+        switch ch {
+        case "&": out += "&amp;"
+        case "<": out += "&lt;"
+        case ">": out += "&gt;"
+        default: out.append(ch)
+        }
+    }
+    return out
+}
+
+private func escapeAttribute(_ string: String) -> String {
+    var out = ""
+    out.reserveCapacity(string.count)
+    for ch in string {
+        switch ch {
+        case "&": out += "&amp;"
+        case "<": out += "&lt;"
+        case ">": out += "&gt;"
+        case "\"": out += "&quot;"
+        default: out.append(ch)
+        }
+    }
+    return out
+}

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -10,7 +10,7 @@ enum MarkdownHTML {
     static func makeHTML(from markdown: String,
                          allowsScroll: Bool = false,
                          assetBaseHref: String? = nil) -> String {
-        let renderedBody = renderMermaidBlocks(in: HTMLFormatter.format(MarkdownFrontmatter.split(markdown).body))
+        let renderedBody = renderMermaidBlocks(in: EscapingHTMLFormatter.format(MarkdownFrontmatter.split(markdown).body))
         let body = injectHeadingIDs(in: renderedBody.html)
         let scrollOverride = allowsScroll ? """
         <style>


### PR DESCRIPTION
## Summary

Closes #33.

swift-markdown's `HTMLFormatter` doesn't escape `<`, `>`, or `&` in text,
inline code, or code blocks (see upstream `Sources/Markdown/Walker/Walkers/HTMLFormatter.swift`
lines 89/225/275). As a result:

- `a < b` in body text loses everything from `<` onward (the browser treats it as a malformed tag).
- `<div>` inside a code span disappears.
- Code blocks containing `<`, `>`, or `&` render mangled or partially.
- URLs/titles with `&` or `<` could break attribute parsing.

Replace the call with a new `EscapingHTMLFormatter` — a `MarkupWalker` that mirrors
upstream behavior but HTML-escapes text content and attribute values:

- Text, inline code, code blocks, headings, symbol links: escape `&`/`<`/`>`.
- Link `href`, image `src`/`title`, language class, etc.: escape `&`/`<`/`>`/`"`.
- Raw HTML blocks (`HTMLBlock`) and inline HTML (`InlineHTML`) still pass through verbatim, per CommonMark.

## Files

- `md-preview/EscapingHTMLFormatter.swift` — new walker.
- `md-preview/MarkdownHTML.swift` — call `EscapingHTMLFormatter.format` instead of `HTMLFormatter.format` (one-line change).
- `md-preview.xcodeproj/project.pbxproj` — add the new file to the `quick-look` extension target's membership exceptions so both targets compile it.

## Test plan

- [x] `xcodebuild -scheme md-preview -configuration Debug -destination 'platform=macOS,arch=arm64' build` → BUILD SUCCEEDED
- [ ] Open a markdown file containing `a < b`, `Tom & Jerry`, ``` `<div class="foo">` ```, and a fenced code block with `<`, `>`, `&` — all symbols render verbatim.
- [ ] Raw HTML blocks (e.g. `<kbd>` or a styled `<div>` block) still render as real HTML, not as escaped text.
- [ ] Headings, lists (incl. task lists), tables, blockquotes, links, images, mermaid, KaTeX, frontmatter — all render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)