### PR TITLE
Release 0.0.10 (14)

### DIFF
--- a/.agents/skills/changelog-maintenance/SKILL.md
+++ b/.agents/skills/changelog-maintenance/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: changelog-maintenance
-description: Maintain a clear and informative changelog for software releases. Use when documenting version changes, tracking features, or communicating updates to users. Handles semantic versioning, changelog formats, and release notes.
+description: Maintain a clear and informative changelog for software releases. Use when documenting version changes, tracking features, or communicating updates to users. Always identifies external contributors from git/GitHub and credits them with @username tags. Handles semantic versioning, changelog formats, and release notes.
 metadata:
-  tags: changelog, release-notes, versioning, semantic-versioning, documentation
+  tags: changelog, release-notes, versioning, semantic-versioning, documentation, contributors
   platforms: Claude, ChatGPT, Gemini
 ---
 
@@ -15,6 +15,29 @@ metadata:
 - **Migration guide**: document breaking changes
 
 ## Instructions
+
+### Step 0: Identify contributors (REQUIRED — do this first)
+
+**Always** check who contributed before drafting an entry. Skipping this step is a defect.
+
+1. Determine the previous-release tag/commit. Either parse it from `CHANGELOG.md` (the heading just below the new version) or ask the user.
+2. List commit authors and merged PR authors in the range:
+
+   ```bash
+   # Authors of all commits in the release range
+   git log --format='%h %an <%ae> %s' <prev>..HEAD
+
+   # Merged PRs in the range (if a GitHub remote is configured)
+   gh pr list --state merged --limit 50 \
+     --json number,title,author,mergedAt \
+     --search "merged:>=<prev-merge-date>"
+   ```
+
+3. Identify the maintainer(s) — usually the current `git config user.email` / repo owner — and treat everyone else as an **external contributor** that MUST be credited by GitHub `@username`.
+4. For PRs that close an issue authored by someone other than the PR author (e.g. `Closes #33`), inspect the issue with `gh issue view <n> --json author` and credit the **reporter** as well.
+5. Resolve every contributor's GitHub `login` (the `@handle`). If a commit author's email doesn't map to a GitHub login, look up the merged PR via `gh pr list --search "<commit-sha>"` and use `author.login` from there. Never invent a handle.
+
+If the result is "maintainer-only", omit the Contributors block. If there is at least one external contributor or external bug reporter, you MUST include the Contributors block from Step 1.
 
 ### Step 1: Keep a Changelog format
 
@@ -77,6 +100,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated dependencies (fixes CVE-2024-12345)
 - Implemented CSRF protection
 - Added helmet.js security headers
+
+### Contributors
+
+Thanks to the external contributors who shipped in this release:
+
+- [@octocat](https://github.com/octocat) — webhook support for order events ([#142](https://github.com/username/repo/pull/142))
+- [@hubot](https://github.com/hubot) — reported the password-reset email bug ([#138](https://github.com/username/repo/issues/138))
 
 ## [1.1.2] - 2025-01-08
 
@@ -290,11 +320,13 @@ docs/migration/
 1. **Reverse chronological**: latest version at the top
 2. **Include dates**: ISO 8601 format (YYYY-MM-DD)
 3. **Categorize entries**: Added, Changed, Fixed, etc.
+4. **Identify and credit external contributors**: every release entry MUST be preceded by the Step 0 contributor check (`git log` + `gh pr list` + issue-reporter lookup for closed issues). When any non-maintainer contributed code or reported a fixed bug, a `### Contributors` block with `[@handle](https://github.com/handle)` GitHub-tag links and the relevant PR/issue numbers MUST be added. Resolve handles from real GitHub data — never invent them.
 
 ### Prohibited items (MUST NOT)
 
 1. **No copying Git logs**: write from the user's perspective
 2. **Vague wording**: "Bug fixes", "Performance improvements" (be specific)
+3. **No silent contributor omission**: do not ship a release entry without running the Step 0 check, even if the user didn't ask for credits explicitly. If the check returns maintainer-only, that is fine — but it must have been run.
 
 ## Best practices
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.0.10] – 2026-05-04
+
+LaTeX math, broader file-format support, and a rendering fix for inline HTML.
+
+- **LaTeX math equations now render via KaTeX.** Inline math (`$…$`, `\(…\)`) and display math (`$$…$$`, `\[…\]`) are detected in the Markdown pipeline and typeset on load, in both the app and the Quick Look extension. KaTeX ships inside the bundle, so previews work offline.
+- **Math extraction skips code spans and code fences.** Dollar signs and `\(…\)` sequences inside backticks or fenced code blocks are no longer mistaken for math, so shell snippets like `` `$PATH` `` and code samples render verbatim instead of being swallowed by the math pass.
+- **More Markdown file types open natively.** Added support for `.mkd`, `.mkdn`, `.mdwn`, `.mdtxt`, `.mdtext`, and `.rmd`, alongside the existing `.md` / `.markdown` / `.mdown` / `.txt`. Quick Look and the Open With list pick the app up for these extensions too. Thanks to [@dppeak](https://github.com/dppeak) for the contribution.
+- **HTML in body text and code is now properly escaped.** `a < b`, `Tom & Jerry`, `` `<div>` ``, and fenced code containing `<`, `>`, or `&` previously rendered mangled or vanished entirely because swift-markdown's default `HTMLFormatter` doesn't escape those characters in text or code. A new `EscapingHTMLFormatter` walker handles escaping while still passing raw HTML blocks through verbatim per CommonMark. Thanks to [@yaksher](https://github.com/yaksher) for the bug report.
+
 ## [0.0.9] – 2026-05-03
 
 Mermaid diagram rendering in the app and Quick Look.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,24 @@
 
 ## [0.0.10] – 2026-05-04
 
-LaTeX math, broader file-format support, and a rendering fix for inline HTML.
+LaTeX math rendering, broader Markdown file-format support, and a rendering fix for inline HTML in body text and code.
 
-- **LaTeX math equations now render via KaTeX.** Inline math (`$…$`, `\(…\)`) and display math (`$$…$$`, `\[…\]`) are detected in the Markdown pipeline and typeset on load, in both the app and the Quick Look extension. KaTeX ships inside the bundle, so previews work offline.
-- **Math extraction skips code spans and code fences.** Dollar signs and `\(…\)` sequences inside backticks or fenced code blocks are no longer mistaken for math, so shell snippets like `` `$PATH` `` and code samples render verbatim instead of being swallowed by the math pass.
-- **More Markdown file types open natively.** Added support for `.mkd`, `.mkdn`, `.mdwn`, `.mdtxt`, `.mdtext`, and `.rmd`, alongside the existing `.md` / `.markdown` / `.mdown` / `.txt`. Quick Look and the Open With list pick the app up for these extensions too. Thanks to [@dppeak](https://github.com/dppeak) for the contribution.
-- **HTML in body text and code is now properly escaped.** `a < b`, `Tom & Jerry`, `` `<div>` ``, and fenced code containing `<`, `>`, or `&` previously rendered mangled or vanished entirely because swift-markdown's default `HTMLFormatter` doesn't escape those characters in text or code. A new `EscapingHTMLFormatter` walker handles escaping while still passing raw HTML blocks through verbatim per CommonMark. Thanks to [@yaksher](https://github.com/yaksher) for the bug report.
+### Added
+
+- **LaTeX math now renders via KaTeX.** Inline math (`$…$`, `\(…\)`) and display math (`$$…$$`, `\[…\]`) are typeset on load in both the app and the Quick Look extension. KaTeX ships inside the bundle, so previews work offline.
+- **More Markdown file types open natively.** Added `.mkd`, `.mkdn`, `.mdwn`, `.mdtxt`, `.mdtext`, and `.rmd` alongside the existing `.md` / `.markdown` / `.mdown` / `.txt`. Quick Look and the Open With list pick the app up for these extensions too.
+
+### Fixed
+
+- **Math extraction skips code spans and fences.** Dollar signs and `\(…\)` sequences inside backticks or fenced code blocks are no longer mistaken for math, so snippets like `` `$PATH` `` and code samples render verbatim instead of being eaten by the math pass.
+- **HTML in body text and code is now properly escaped.** `a < b`, `Tom & Jerry`, `` `<div>` ``, and fenced code containing `<`, `>`, or `&` previously rendered mangled or vanished entirely because swift-markdown's default `HTMLFormatter` doesn't escape those characters in text or code. A new `EscapingHTMLFormatter` walker handles escaping while still passing raw HTML blocks through verbatim per CommonMark.
+
+### Contributors
+
+Thanks to the external contributors who shipped in this release:
+
+- [@dppeak](https://github.com/dppeak) — broader Markdown file-format support ([#31](https://github.com/pluk-inc/md-preview.app/pull/31))
+- [@yaksher](https://github.com/yaksher) — reported the HTML-escape bug fixed in [#35](https://github.com/pluk-inc/md-preview.app/pull/35) ([#33](https://github.com/pluk-inc/md-preview.app/issues/33))
 
 ## [0.0.9] – 2026-05-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,17 @@ Version is managed centrally in `Version.xcconfig` (`MARKETING_VERSION`, `CURREN
 
 ## Release pipeline
 
+### Branch and PR naming
+
+Every release goes through a dedicated branch and PR — never push the version bump or changelog directly to `main`.
+
+- **Branch name**: `release/X.Y.Z` — exactly the marketing version, no `v` prefix, no build number, no suffix. Examples: `release/0.0.10`, `release/1.2.0`. Beta cuts use `release/X.Y.Z-betaN` (e.g. `release/0.1.0-beta1`).
+- **PR title**: `Release X.Y.Z (N)` where `N` is `CURRENT_PROJECT_VERSION`. Example: `Release 0.0.10 (14)`. This matches the commit message the release script writes, so the PR, the bump commit, and the eventual git tag all line up. For betas: `Release X.Y.Z-betaN (build)`.
+- **PR body**: short Summary (version bump + changelog added), a "What's in X.Y.Z" section that mirrors the changelog bullets, and a Test plan.
+- **One PR per release**. The branch contains only the bump (`Version.xcconfig`) and the new `CHANGELOG.md` entry — keep unrelated changes out so the release diff stays auditable.
+
+### Commands
+
 One command:
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ One command:
 ./scripts/release.sh --skip-github       # local amore release only
 ```
 
-Before running, **add a `CHANGELOG.md` entry** for the version being shipped:
+Before running, **add a `CHANGELOG.md` entry** for the version being shipped. **Always invoke the `changelog-maintenance` skill** (`.claude/skills/changelog-maintenance`) via the Skill tool whenever the user asks you to write, generate, or update a changelog entry — do not draft freeform. The skill enforces the project's house format, the Keep-a-Changelog category split (Added / Changed / Fixed / Security), and contributor crediting (it always inspects `git log` and `gh pr list` for non-maintainer authors and adds a `### Contributors` block with `@username` GitHub tags when any are found).
+
+Entry shape:
 
 ```md
 ## [0.0.2] – 2026-05-01

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.9
-CURRENT_PROJECT_VERSION = 13
+MARKETING_VERSION = 0.0.10
+CURRENT_PROJECT_VERSION = 14


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` to `0.0.10` and `CURRENT_PROJECT_VERSION` to `14`.
- Add `CHANGELOG.md` entry covering everything merged since 0.0.9.

## What's in 0.0.10

- **LaTeX math via KaTeX** — inline (`$…$`, `\(…\)`) and display (`$$…$$`, `\[…\]`) typeset on load in app + Quick Look, bundled offline (#36).
- **Math extraction respects code** — dollar signs / `\(…\)` inside backticks or fenced blocks no longer get swallowed by the math pass (#37).
- **Broader Markdown file support** — `.mkd`, `.mkdn`, `.mdwn`, `.mdtxt`, `.mdtext`, `.rmd` alongside the existing extensions (#31, thanks [@dppeak](https://github.com/dppeak)).
- **HTML-escape fix in body and code** — replaces swift-markdown's default `HTMLFormatter` with an `EscapingHTMLFormatter` walker so `<`, `>`, `&` in text and code spans/blocks render correctly while raw HTML blocks still pass through (#35, thanks [@yaksher](https://github.com/yaksher) for the report in #33).

## Test plan

- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` succeeds
- [ ] App launches and reports `0.0.10 (14)` in About window
- [ ] Open a doc with inline + display math → renders via KaTeX
- [ ] Open a doc with `\$PATH` and `\(x\)` inside a code fence → renders verbatim
- [ ] Open `.mkd` / `.rmd` from Finder → opens in Markdown Preview
- [ ] Doc containing `a < b`, `Tom & Jerry`, and `<div>` inside backticks → renders verbatim, raw HTML blocks still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)