### PR TITLE
Claim Owner rank for markdown UTIs in LaunchServices

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -10,7 +10,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>LSHandlerRank</key>
-			<string>Default</string>
+			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>net.daringfireball.markdown</string>


### PR DESCRIPTION
## Summary

- Promote `LSHandlerRank` for the Markdown document type from `Default` to `Owner` in `Info.plist`.
- This makes Markdown Preview's claim on `net.daringfireball.markdown` (and the other registered markdown UTIs) the strongest tier in LaunchServices, so the OS prefers it as the default handler over apps that only assert `Default` or no rank at all.

## Why

Some users have reported that Markdown Preview does not become the default app for \`.md\` files after installation. \`Default\` is a weak claim — any competing markdown app that registers as \`Owner\` outranks it, and LaunchServices may also fall back to whichever app was installed most recently. \`Owner\` is the conventional rank for an app that intends to be the primary handler for a document type.

This is a one-line plist change; no code changes, no behavior changes inside the app. Existing per-file overrides set by the user via Finder → "Open With → Always Open With" continue to take precedence.

## Test plan

- [ ] Install a fresh build on a machine that already has another markdown app set as default.
- [ ] Confirm that double-clicking a \`.md\` file opens it in Markdown Preview after one launch (or after running \`lsregister -kill -r -domain local -domain system -domain user\` if the LaunchServices cache is sticky).
- [ ] Confirm \`.markdown\`, \`.mdown\`, \`.mkd\`, \`.mkdn\`, \`.mdwn\`, \`.mdtxt\`, \`.mdtext\` still resolve to the correct UTI and open in the app.
- [ ] Verify Quick Look previews still render (the QL extension's plist is unaffected).
- [ ] Sanity-check Finder's Get Info → "Open with" lists Markdown Preview for these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)