### PR TITLE
Own niche markdown extensions via private UTIs

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,6 +17,12 @@
 				<string>public.markdown</string>
 				<string>net.ia.markdown</string>
 				<string>com.unknown.md</string>
+				<string>doc.md-preview.mdown</string>
+				<string>doc.md-preview.mkd</string>
+				<string>doc.md-preview.mkdn</string>
+				<string>doc.md-preview.mdwn</string>
+				<string>doc.md-preview.mdtxt</string>
+				<string>doc.md-preview.mdtext</string>
 			</array>
 		</dict>
 	</array>
@@ -43,12 +49,6 @@
 				<array>
 					<string>md</string>
 					<string>markdown</string>
-					<string>mdown</string>
-					<string>mkd</string>
-					<string>mkdn</string>
-					<string>mdwn</string>
-					<string>mdtxt</string>
-					<string>mdtext</string>
 				</array>
 				<key>public.mime-type</key>
 				<array>
@@ -111,6 +111,111 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>md</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mdown)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mdown</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdown</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mkd)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mkd</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mkd</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mkdn)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mkdn</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mkdn</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mdwn)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mdwn</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdwn</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mdtxt)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mdtxt</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdtxt</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mdtext)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mdtext</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdtext</string>
 				</array>
 			</dict>
 		</dict>

--- a/quick-look/Info.plist
+++ b/quick-look/Info.plist
@@ -14,6 +14,12 @@
 				<string>net.daringfireball.markdown</string>
 				<string>net.ia.markdown</string>
 				<string>com.unknown.md</string>
+				<string>doc.md-preview.mdown</string>
+				<string>doc.md-preview.mkd</string>
+				<string>doc.md-preview.mkdn</string>
+				<string>doc.md-preview.mdwn</string>
+				<string>doc.md-preview.mdtxt</string>
+				<string>doc.md-preview.mdtext</string>
 			</array>
 			<key>QLSupportsSearchableItems</key>
 			<false/>


### PR DESCRIPTION
## Summary

- Declare exported, app-private UTIs under `doc.md-preview.*` for the less common markdown extensions: `mdown`, `mkd`, `mkdn`, `mdwn`, `mdtxt`, `mdtext`.
- Remove those extensions from `net.daringfireball.markdown`'s tag specification so each one resolves to its dedicated private UTI rather than the contested public one.
- Each private UTI conforms to `net.daringfireball.markdown`, so anything that handles standard markdown still treats these files identically.
- Add the new UTIs to the Quick Look extension's `QLSupportedContentTypes` for explicitness (conformance should propagate, but listing them is unambiguous).

## Why

Building on #39 — which made our `LSHandlerRank` claim `Owner` — this further strengthens default-handler behavior for the long tail of markdown extensions. Because no other app declares UTIs in our `doc.md-preview.*` namespace, LaunchServices has no competing candidate when resolving these file types and Markdown Preview wins uncontested. \`.md\` and \`.markdown\` continue to use the standard \`net.daringfireball.markdown\` UTI, where the \`Owner\` rank is what carries the claim.

This is plist-only — no code changes.

## Test plan

- [ ] Fresh install on a machine that has another markdown app set as default; double-click each of `foo.mdown`, `foo.mkd`, `foo.mkdn`, `foo.mdwn`, `foo.mdtxt`, `foo.mdtext` and confirm Markdown Preview opens them without needing "Open With → Always Open With".
- [ ] Confirm `.md` and `.markdown` still open in Markdown Preview (their behavior is unchanged by this PR).
- [ ] Confirm Quick Look (spacebar in Finder) renders previews for all the niche extensions above.
- [ ] After install, run `lsregister -dump | grep -i md-preview` and verify the new `doc.md-preview.*` UTIs appear.
- [ ] Confirm Finder's Get Info → "Open with" lists Markdown Preview for the niche extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)