### PR TITLE
feat: add Homebrew install via pluk-inc/tap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,11 +83,6 @@ Default is **unpublish** (reversible — flips `published=false` on Amore so it 
 
 To inspect or change: `amore config show --bundle-id doc.md-preview` / `amore config set ...`. CLI lives at `/usr/local/bin/amore`.
 
-## Known issues
-
-- **`SUFeedURL` mismatch**. Info.plist points to `https://storage.md-preview.app/appcast.xml` but Amore actually publishes to `https://storage.md-preview.app/v1/apps/doc.md-preview/appcast.xml`. Fix Info.plist before any non-test release ships to real users — already-installed copies will check the wrong URL forever. Either change `SUFeedURL` to the `/v1/apps/...` path, or configure a CDN rewrite at `storage.md-preview.app` to map `/appcast.xml` → the real path.
-- **No git remote yet**. `git remote -v` is empty. Run `gh repo create` before relying on the GitHub release portion of `scripts/release.sh` (it auto-skips when no remote exists).
-
 ## Common Xcode tasks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@
 
 > Drop a `.md` on the icon (or set Markdown Preview as your default handler) and get a clean, scrollable preview with a real document outline — no Electron, no browser tab.
 
+## Installation
+
+```sh
+brew install --cask pluk-inc/tap/markdown-preview
+```
+
+Or grab the latest signed and notarized DMG from the [Releases](https://github.com/pluk-inc/md-preview.app/releases) page.
+
 ## Screenshots
 
 <p align="center">
@@ -59,10 +67,6 @@ flowchart TD
 
 `.md`, `.markdown`, `.mdown`, `.txt`
 UTI: `net.daringfireball.markdown`
-
-## Installation
-
-Grab the latest signed and notarized DMG from the [Releases](https://github.com/pluk-inc/md-preview.app/releases) page.
 
 ## Requirements
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,6 +13,10 @@
 # Source of truth:
 #   - Version.xcconfig  → MARKETING_VERSION, CURRENT_PROJECT_VERSION
 #   - CHANGELOG.md      → release notes (## [X.Y.Z] – YYYY-MM-DD)
+#
+# After amore publishes, this also bumps the Homebrew tap at
+# pluk-inc/homebrew-tap (Casks/markdown-preview.rb) so `brew upgrade
+# --cask` users converge on the new version. Skipped on --beta / --draft.
 
 set -euo pipefail
 
@@ -166,6 +170,46 @@ if [[ -z "$DMG_URL" ]]; then
 fi
 echo "▸ DMG: $DMG_URL"
 
+# ── Download DMG (used by cask bump + GH release) ──────────────────────────
+SHOULD_BUMP_CASK=true
+[[ -n "$BETA_FLAG$DRAFT_FLAG" ]] && SHOULD_BUMP_CASK=false
+
+DMG_PATH=""
+if $SHOULD_BUMP_CASK || ! $SKIP_GH; then
+    DMG_PATH="$(mktemp -d)/Markdown-Preview.dmg"
+    echo "▸ Downloading DMG"
+    curl -fsSL -o "$DMG_PATH" "$DMG_URL"
+fi
+
+# ── Bump pluk-inc/homebrew-tap ─────────────────────────────────────────────
+if $SHOULD_BUMP_CASK; then
+    echo "▸ Bumping pluk-inc/homebrew-tap"
+    DMG_SHA="$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
+    TAP_DIR="$(mktemp -d)/homebrew-tap"
+    if git clone --depth=1 --quiet git@github.com:pluk-inc/homebrew-tap.git "$TAP_DIR"; then
+        CASK_FILE="$TAP_DIR/Casks/markdown-preview.rb"
+        /usr/bin/sed -i '' -E "s|^  version \".*\"|  version \"$VERSION,$BUILD\"|" "$CASK_FILE"
+        /usr/bin/sed -i '' -E "s|^  sha256 \".*\"|  sha256 \"$DMG_SHA\"|"          "$CASK_FILE"
+        if ! grep -q "version \"$VERSION,$BUILD\"" "$CASK_FILE" || \
+           ! grep -q "sha256 \"$DMG_SHA\""        "$CASK_FILE"; then
+            echo "  ✗ cask sed didn't take — fix Casks/markdown-preview.rb manually"
+        elif (cd "$TAP_DIR" && git diff --quiet); then
+            echo "  ⚠ cask already at $VERSION,$BUILD — nothing to push"
+        else
+            (cd "$TAP_DIR" && \
+                git -c user.name="$(git config user.name)" \
+                    -c user.email="$(git config user.email)" \
+                    commit -am "markdown-preview $VERSION,$BUILD" >/dev/null && \
+                git push --quiet origin HEAD) \
+                && echo "  ✓ pushed cask bump" \
+                || echo "  ✗ push failed — fix manually in pluk-inc/homebrew-tap"
+        fi
+    else
+        echo "  ⚠ failed to clone homebrew-tap — skipping cask bump"
+    fi
+    rm -rf "$(dirname "$TAP_DIR")"
+fi
+
 if $SKIP_GH; then
     echo "✓ Released $VERSION ($BUILD). GitHub step skipped."
     exit 0
@@ -180,10 +224,6 @@ else
     git tag -a "$TAG" -m "Release $VERSION ($BUILD)"
 fi
 git push origin "$TAG" 2>/dev/null || git push origin "$TAG"
-
-DMG_PATH="$(mktemp -d)/Markdown-Preview.dmg"
-echo "▸ Downloading DMG to attach"
-curl -fsSL -o "$DMG_PATH" "$DMG_URL"
 
 PRERELEASE_FLAG=""
 [[ -n "$BETA_FLAG" ]] && PRERELEASE_FLAG="--prerelease"


### PR DESCRIPTION
## Summary

- Promote `brew install --cask pluk-inc/tap/markdown-preview` as the primary install method in the README; keep the DMG link as a fallback.
- Wire `scripts/release.sh` to auto-bump [pluk-inc/homebrew-tap](https://github.com/pluk-inc/homebrew-tap) after `amore release` succeeds — shallow-clones the tap, rewrites `version` + `sha256` in `Casks/markdown-preview.rb`, commits, pushes. Skipped on `--beta` / `--draft`; non-fatal on failure.
- Drop the stale "Known issues" section in `CLAUDE.md` (SUFeedURL is handled via the Cloudflare 301; git remote now exists).

## Why a personal tap and not homebrew-cask?

Submitted upstream first ([Homebrew/homebrew-cask#262530](https://github.com/Homebrew/homebrew-cask/pull/262530)) and was passed on for now: their repo-audit policy requires the upstream repo + domain to be 30 days old. Both were registered 2026-04-28, so the earliest re-submission window is ~2026-05-28. Running our own tap unblocks brew users in the meantime; once we re-land in homebrew-cask, this tap can be deprecated.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax clean
- [x] sed patterns verified against the live cask file (rewrite both lines exactly once)
- [x] Tap currently audits clean: `brew audit --cask pluk-inc/tap/markdown-preview` exits 0
- [x] Livecheck resolves: `brew livecheck --cask pluk-inc/tap/markdown-preview` → `0.0.10,14 ==> 0.0.10,14`
- [ ] Next release (0.0.11) exercises the auto-bump path end-to-end