### PR TITLE
Release 0.0.11 (15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.0.11] – 2026-05-04
+
+Homebrew install path and stronger default-handler claims for Markdown files.
+
+### Added
+
+- **Install via Homebrew.** `brew install --cask pluk-inc/tap/markdown-preview` is now the primary install method; the DMG remains as a fallback. The release script auto-bumps the [pluk-inc/homebrew-tap](https://github.com/pluk-inc/homebrew-tap) cask (version + sha256) after each successful `amore release`, so brew users pick up new versions on the same cadence as direct downloads.
+
+### Fixed
+
+- **Markdown Preview now wins as the default `.md` handler on more setups.** `LSHandlerRank` for the standard markdown UTI was promoted from `Default` to `Owner`, so LaunchServices prefers Markdown Preview over apps that only assert a weaker claim. Users who previously had to set "Always Open With" by hand should pick the app up automatically after a fresh install.
+- **Long-tail markdown extensions are now claimed uncontested.** `.mdown`, `.mkd`, `.mkdn`, `.mdwn`, `.mdtxt`, and `.mdtext` are exported under app-private UTIs (`doc.md-preview.*`) that conform to `net.daringfireball.markdown`. Because no other app declares UTIs in that namespace, LaunchServices has no competing candidate for these files and Markdown Preview opens them without requiring user intervention.
+
 ## [0.0.10] – 2026-05-04
 
 LaTeX math rendering, broader Markdown file-format support, and a rendering fix for inline HTML in body text and code.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.10
-CURRENT_PROJECT_VERSION = 14
+MARKETING_VERSION = 0.0.11
+CURRENT_PROJECT_VERSION = 15


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` to 0.0.11 and `CURRENT_PROJECT_VERSION` to 15.
- Adds the 0.0.11 entry to `CHANGELOG.md`.

## What's in 0.0.11

Homebrew install path and stronger default-handler claims for Markdown files.

### Added
- **Install via Homebrew** — `brew install --cask pluk-inc/tap/markdown-preview` is the new primary install path; `release.sh` auto-bumps the cask in pluk-inc/homebrew-tap after each `amore release`.

### Fixed
- **Default `.md` handler claim is now `Owner`** instead of `Default`, so LaunchServices prefers Markdown Preview over apps that assert a weaker claim (#39).
- **Long-tail markdown extensions are claimed uncontested** via app-private UTIs (`doc.md-preview.*`) for `.mdown`, `.mkd`, `.mkdn`, `.mdwn`, `.mdtxt`, `.mdtext` (#40).

## Test plan

- [ ] Branch matches `release/X.Y.Z` convention and contains only the bump + changelog
- [ ] `./scripts/release.sh` validates the changelog entry for 0.0.11
- [ ] Fresh install on a machine with another markdown app set as default — `.md` and the niche extensions open in Markdown Preview without "Always Open With"
- [ ] Homebrew tap auto-bump runs end-to-end on this release (the unticked item from #41)