### PR TITLE
[codex] Render inline markup in headings

### DIFF
--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -58,7 +58,9 @@ struct EscapingHTMLFormatter: MarkupWalker {
     }
 
     mutating func visitHeading(_ heading: Heading) {
-        result += "<h\(heading.level)>\(escapeText(heading.plainText))</h\(heading.level)>\n"
+        result += "<h\(heading.level)>"
+        descendInto(heading)
+        result += "</h\(heading.level)>\n"
     }
 
     mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {


### PR DESCRIPTION
## Summary

- Render heading contents by walking inline child nodes instead of flattening to plain text.
- Preserves inline code, emphasis, links, and other inline markup inside ATX headings.

## Root Cause

The custom escaping formatter rendered headings from `heading.plainText`, which stripped inline markdown elements before HTML generation. Inline code such as `200 OK` therefore lost its `<code>` wrapper in headings.

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`
- Direct formatter check: `### Success — `200 OK`` emits `<h3>Success — <code>200 OK</code></h3>`.

Fixes #50
