### PR TITLE
[codex] Fix markdown footnote rendering

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -30,6 +30,9 @@ final class ContentViewController: NSViewController {
             self.measuredDocumentHeight = height
             self.applyDocumentHeight()
         }
+        webView.fragmentLinkActivated = { [weak self] fragment in
+            self?.scrollToElement(id: fragment)
+        }
 
         documentView.addSubview(webView)
         scrollView.documentView = documentView
@@ -75,6 +78,13 @@ final class ContentViewController: NSViewController {
 
     func scrollToHeading(index: Int) {
         webView.headingOffset(index: index) { [weak self] offset in
+            guard let self, let offset else { return }
+            self.scrollDocument(to: offset)
+        }
+    }
+
+    private func scrollToElement(id: String) {
+        webView.elementOffset(id: id) { [weak self] offset in
             guard let self, let offset else { return }
             self.scrollDocument(to: offset)
         }

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -26,12 +26,15 @@ enum MarkdownHTML {
                        allowsScroll: Bool = false,
                        assetBaseHref: String? = nil) -> RenderedHTML {
         let body = MarkdownFrontmatter.split(markdown).body
-        let math = extractMath(from: body)
+        let footnotes = extractFootnotes(from: body)
+        let math = extractMath(from: footnotes.markdown)
         let formatted = EscapingHTMLFormatter.format(math.processedMarkdown)
         let mermaidResult = renderMermaidBlocks(in: formatted)
         let shikiResult = detectHighlightableCode(in: mermaidResult.html)
         let mathResult = renderMathBlocks(in: shikiResult.html, with: math)
-        let bodyHTML = injectHeadingIDs(in: mathResult.html)
+        let footnoteReferenceHTML = renderFootnoteReferences(in: mathResult.html, with: footnotes)
+        let footnoteDefinitions = renderFootnoteDefinitions(footnotes)
+        let bodyHTML = injectHeadingIDs(in: footnoteReferenceHTML + footnoteDefinitions.html)
         let scrollOverride = allowsScroll ? """
         <style>
         html, body { overflow: auto !important; }
@@ -48,9 +51,9 @@ enum MarkdownHTML {
         \(baseTag)
         <style>\(stylesheet)</style>
         \(scrollOverride)
-        \(mathResult.containsMath ? katexHead : "")
-        \(mermaidResult.containsMermaid ? mermaidScript : "")
-        \(shikiResult.containsHighlightedCode ? shikiScript : "")
+        \(mathResult.containsMath || footnoteDefinitions.containsMath ? katexHead : "")
+        \(mermaidResult.containsMermaid || footnoteDefinitions.containsMermaid ? mermaidScript : "")
+        \(shikiResult.containsHighlightedCode || footnoteDefinitions.containsHighlightedCode ? shikiScript : "")
         </head>
         <body>
         <article class="markdown-body">
@@ -61,9 +64,9 @@ enum MarkdownHTML {
         """
         return RenderedHTML(
             html: html,
-            containsMath: mathResult.containsMath,
-            containsMermaid: mermaidResult.containsMermaid,
-            containsHighlightedCode: shikiResult.containsHighlightedCode
+            containsMath: mathResult.containsMath || footnoteDefinitions.containsMath,
+            containsMermaid: mermaidResult.containsMermaid || footnoteDefinitions.containsMermaid,
+            containsHighlightedCode: shikiResult.containsHighlightedCode || footnoteDefinitions.containsHighlightedCode
         )
     }
 
@@ -97,6 +100,297 @@ enum MarkdownHTML {
         result += nsHtml.substring(from: cursor)
         return result
     }
+
+    // MARK: - Footnotes
+
+    private struct FootnoteExtraction {
+        let markdown: String
+        let definitions: [FootnoteDefinition]
+        let references: [FootnoteReference]
+    }
+
+    private struct FootnoteDefinition {
+        let key: String
+        let label: String
+        let content: String
+        let number: Int
+    }
+
+    private struct FootnoteReference {
+        let token: String
+        let number: Int
+        let ordinal: Int
+    }
+
+    private struct FootnoteDefinitionRenderResult {
+        let html: String
+        let containsMath: Bool
+        let containsMermaid: Bool
+        let containsHighlightedCode: Bool
+    }
+
+    private static let footnoteDefinitionRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"^[ \t]{0,3}\[\^([^\]\n]+)\]:[ \t]*(.*)$"#)
+    }()
+
+    private static let footnoteReferenceRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"\[\^([^\]\n]+)\]"#)
+    }()
+
+    private static func extractFootnotes(from markdown: String) -> FootnoteExtraction {
+        let split = splitFootnoteDefinitions(from: markdown)
+        var protected: [String] = []
+
+        let afterFences = replaceFullMatches(of: codeFenceRegex, in: split.markdown) { full in
+            protected.append(full)
+            return "MdPreviewFootnoteProtect\(protected.count - 1)Token"
+        }
+        let afterInlineCode = replaceFullMatches(of: inlineCodeRegex, in: afterFences) { full in
+            protected.append(full)
+            return "MdPreviewFootnoteProtect\(protected.count - 1)Token"
+        }
+
+        var orderedDefinitions: [FootnoteDefinition] = []
+        var referenceOrdinalsByNumber: [Int: Int] = [:]
+        var references: [FootnoteReference] = []
+
+        let replacedReferences = replaceFootnoteReferenceMatches(in: afterInlineCode) { label, full in
+            let key = normalizeFootnoteKey(label)
+            guard let stored = split.definitions[key] else { return full }
+
+            let definition: FootnoteDefinition
+            if let existing = orderedDefinitions.first(where: { $0.key == key }) {
+                definition = existing
+            } else {
+                definition = FootnoteDefinition(
+                    key: key,
+                    label: stored.label,
+                    content: stored.content,
+                    number: orderedDefinitions.count + 1
+                )
+                orderedDefinitions.append(definition)
+            }
+
+            let ordinal = (referenceOrdinalsByNumber[definition.number] ?? 0) + 1
+            referenceOrdinalsByNumber[definition.number] = ordinal
+            let token = "MdPreviewFootnoteRef\(references.count)Token"
+            references.append(FootnoteReference(token: token, number: definition.number, ordinal: ordinal))
+            return token
+        }
+
+        var restored = replacedReferences
+        for (i, original) in protected.enumerated() {
+            restored = restored.replacingOccurrences(
+                of: "MdPreviewFootnoteProtect\(i)Token",
+                with: original
+            )
+        }
+
+        return FootnoteExtraction(
+            markdown: restored,
+            definitions: orderedDefinitions,
+            references: references
+        )
+    }
+
+    private static func splitFootnoteDefinitions(from markdown: String) -> (
+        markdown: String,
+        definitions: [String: (label: String, content: String)]
+    ) {
+        let lines = markdown.components(separatedBy: "\n")
+        var output: [String] = []
+        var definitions: [String: (label: String, content: String)] = [:]
+        var index = 0
+
+        while index < lines.count {
+            let line = lines[index]
+            if let match = firstMatch(of: footnoteDefinitionRegex, in: line) {
+                let nsLine = line as NSString
+                let label = nsLine.substring(with: match.range(at: 1))
+                var contentLines = [nsLine.substring(with: match.range(at: 2))]
+                index += 1
+
+                while index < lines.count {
+                    let continuation = lines[index]
+                    if continuation.trimmingCharacters(in: .whitespaces).isEmpty {
+                        if index + 1 < lines.count, isIndentedFootnoteContinuation(lines[index + 1]) {
+                            contentLines.append("")
+                            index += 1
+                            continue
+                        }
+                        break
+                    }
+                    guard isIndentedFootnoteContinuation(continuation) else { break }
+                    contentLines.append(stripFootnoteContinuationIndent(from: continuation))
+                    index += 1
+                }
+
+                definitions[normalizeFootnoteKey(label)] = (
+                    label: label,
+                    content: contentLines.joined(separator: "\n")
+                )
+            } else {
+                output.append(line)
+                index += 1
+            }
+        }
+
+        return (output.joined(separator: "\n"), definitions)
+    }
+
+    private static func firstMatch(of regex: NSRegularExpression,
+                                   in source: String) -> NSTextCheckingResult? {
+        let nsSource = source as NSString
+        return regex.firstMatch(
+            in: source,
+            range: NSRange(location: 0, length: nsSource.length)
+        )
+    }
+
+    private static func isIndentedFootnoteContinuation(_ line: String) -> Bool {
+        if line.hasPrefix("\t") { return true }
+        return line.count >= 4 && line.prefix(4).allSatisfy { $0 == " " }
+    }
+
+    private static func stripFootnoteContinuationIndent(from line: String) -> String {
+        if line.hasPrefix("\t") {
+            return String(line.dropFirst())
+        }
+        if line.count >= 4 && line.prefix(4).allSatisfy({ $0 == " " }) {
+            return String(line.dropFirst(4))
+        }
+        return line
+    }
+
+    private static func normalizeFootnoteKey(_ label: String) -> String {
+        label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func replaceFootnoteReferenceMatches(in source: String,
+                                                        transform: (String, String) -> String) -> String {
+        let nsSource = source as NSString
+        let matches = footnoteReferenceRegex.matches(
+            in: source,
+            range: NSRange(location: 0, length: nsSource.length)
+        )
+        guard !matches.isEmpty else { return source }
+
+        var result = ""
+        result.reserveCapacity(source.count)
+        var cursor = 0
+        for match in matches {
+            result += nsSource.substring(with: NSRange(
+                location: cursor,
+                length: match.range.location - cursor
+            ))
+            let full = nsSource.substring(with: match.range)
+            let label = nsSource.substring(with: match.range(at: 1))
+            result += transform(label, full)
+            cursor = match.range.location + match.range.length
+        }
+        result += nsSource.substring(from: cursor)
+        return result
+    }
+
+    private static func renderFootnoteReferences(in html: String,
+                                                 with footnotes: FootnoteExtraction) -> String {
+        guard !footnotes.references.isEmpty else { return html }
+        var rendered = html
+        for reference in footnotes.references {
+            let refID = footnoteReferenceID(number: reference.number, ordinal: reference.ordinal)
+            let footnoteID = footnoteDefinitionID(number: reference.number)
+            let replacement = """
+            <sup class="footnote-ref"><a id="\(refID)" href="#\(footnoteID)" aria-label="Footnote \(reference.number)">\(reference.number)</a></sup>
+            """
+            rendered = rendered.replacingOccurrences(of: reference.token, with: replacement)
+        }
+        return rendered
+    }
+
+    private static func renderFootnoteDefinitions(_ footnotes: FootnoteExtraction) -> FootnoteDefinitionRenderResult {
+        guard !footnotes.definitions.isEmpty else {
+            return FootnoteDefinitionRenderResult(
+                html: "",
+                containsMath: false,
+                containsMermaid: false,
+                containsHighlightedCode: false
+            )
+        }
+
+        var containsMath = false
+        var containsMermaid = false
+        var containsHighlightedCode = false
+        let referencesByNumber = Dictionary(grouping: footnotes.references, by: { $0.number })
+        let items = footnotes.definitions.map { definition -> String in
+            let renderedContent = renderFootnoteDefinitionContent(definition.content)
+            containsMath = containsMath || renderedContent.containsMath
+            containsMermaid = containsMermaid || renderedContent.containsMermaid
+            containsHighlightedCode = containsHighlightedCode || renderedContent.containsHighlightedCode
+            let backrefs = (referencesByNumber[definition.number] ?? []).map { reference in
+                """
+                <a href="#\(footnoteReferenceID(number: reference.number, ordinal: reference.ordinal))" class="footnote-backref" aria-label="Back to reference \(reference.number)">&#8617;</a>
+                """
+            }.joined(separator: " ")
+            let contentHTML = appendFootnoteBackrefs(backrefs, to: renderedContent.html)
+
+            return """
+            <li id="\(footnoteDefinitionID(number: definition.number))">
+            \(contentHTML)
+            </li>
+            """
+        }.joined(separator: "\n")
+
+        return FootnoteDefinitionRenderResult(
+            html: """
+
+            <section class="footnotes" role="doc-endnotes">
+            <hr />
+            <ol>
+            \(items)
+            </ol>
+            </section>
+            """,
+            containsMath: containsMath,
+            containsMermaid: containsMermaid,
+            containsHighlightedCode: containsHighlightedCode
+        )
+    }
+
+    private static func appendFootnoteBackrefs(_ backrefs: String, to html: String) -> String {
+        guard !backrefs.isEmpty else { return html }
+        let inlineBackrefs = "<span class=\"footnote-backrefs\">\(backrefs)</span>"
+        if let range = html.range(of: "</p>", options: .backwards) {
+            var updated = html
+            updated.replaceSubrange(range, with: " \(inlineBackrefs)</p>")
+            return updated
+        }
+        return html + inlineBackrefs
+    }
+
+    private static func renderFootnoteDefinitionContent(_ markdown: String) -> FootnoteDefinitionRenderResult {
+        let math = extractMath(from: markdown.trimmingCharacters(in: .whitespacesAndNewlines))
+        let formatted = EscapingHTMLFormatter.format(math.processedMarkdown)
+        let mermaidResult = renderMermaidBlocks(in: formatted)
+        let shikiResult = detectHighlightableCode(in: mermaidResult.html)
+        let mathResult = renderMathBlocks(in: shikiResult.html, with: math)
+        return FootnoteDefinitionRenderResult(
+            html: mathResult.html,
+            containsMath: mathResult.containsMath,
+            containsMermaid: mermaidResult.containsMermaid,
+            containsHighlightedCode: shikiResult.containsHighlightedCode
+        )
+    }
+
+    private static func footnoteDefinitionID(number: Int) -> String {
+        "fn-\(number)"
+    }
+
+    private static func footnoteReferenceID(number: Int, ordinal: Int) -> String {
+        ordinal == 1 ? "fnref-\(number)" : "fnref-\(number)-\(ordinal)"
+    }
+
     // MARK: - Math (KaTeX)
 
     private struct MathExtraction {
@@ -571,6 +865,51 @@ enum MarkdownHTML {
 
     a { color: var(--link); text-decoration: none; }
     a:hover { text-decoration: underline; }
+    .footnote-ref {
+        font-size: 0.75em;
+        line-height: 0;
+        vertical-align: super;
+    }
+    .footnote-ref a {
+        padding: 0 0.12em;
+    }
+    .footnotes {
+        margin-top: 2.35em;
+        color: var(--text);
+        font-size: 0.9em;
+        line-height: 1.45;
+    }
+    .footnotes hr {
+        margin: 0 0 1em;
+    }
+    .footnotes ol {
+        margin-top: 0;
+        padding-left: 1.45em;
+    }
+    .footnotes li {
+        margin-top: 0.72em;
+        padding-left: 0.12em;
+    }
+    .footnotes li:first-child {
+        margin-top: 0;
+    }
+    .footnotes li > p:first-child {
+        margin-top: 0;
+    }
+    .footnote-backrefs {
+        display: inline-flex;
+        gap: 0.28em;
+        margin-left: 0.28em;
+        white-space: nowrap;
+    }
+    .footnote-backref {
+        font-size: 0.78em;
+        opacity: 0.65;
+        vertical-align: baseline;
+    }
+    .footnote-backref:hover {
+        opacity: 1;
+    }
 
     code {
         font-family: ui-monospace, "SF Mono", Menlo, monospace;

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -10,6 +10,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     let webView: WKWebView
     var heightDidChange: ((CGFloat) -> Void)?
+    var fragmentLinkActivated: ((String) -> Void)?
     private let assetScheme = MarkdownAssetScheme()
     private var currentAssetBase: URL?
     private var scheduledHeightUpdates: [DispatchWorkItem] = []
@@ -101,6 +102,24 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let script = """
         (() => {
             const el = document.getElementById('md-heading-\(index)');
+            if (!el) return null;
+            const rect = el.getBoundingClientRect();
+            return rect.top + (window.scrollY || document.documentElement.scrollTop || 0);
+        })();
+        """
+        webView.evaluateJavaScript(script) { result, _ in
+            if let number = result as? NSNumber {
+                completion(CGFloat(truncating: number))
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
+    func elementOffset(id: String, completion: @escaping (CGFloat?) -> Void) {
+        let script = """
+        (() => {
+            const el = document.getElementById(\(javaScriptStringLiteral(id)));
             if (!el) return null;
             const rect = el.getBoundingClientRect();
             return rect.top + (window.scrollY || document.documentElement.scrollTop || 0);
@@ -276,7 +295,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void) {
         if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
-            if url.scheme == MarkdownAssetScheme.scheme,
+            if let fragment = sameDocumentFragmentID(from: url) {
+                fragmentLinkActivated?(fragment)
+            } else if url.scheme == MarkdownAssetScheme.scheme,
                let base = currentAssetBase,
                let resolved = MarkdownAssetScheme.resolve(url, against: base) {
                 NSWorkspace.shared.open(resolved)
@@ -292,6 +313,25 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         neutralizeWebKitScrollEdgeInsets()
         recalculateDocumentHeight()
+    }
+
+    private func sameDocumentFragmentID(from url: URL) -> String? {
+        guard let fragment = url.fragment?.removingPercentEncoding,
+              !fragment.isEmpty,
+              url.query == nil else { return nil }
+
+        if url.scheme == nil {
+            return fragment
+        }
+        if url.scheme == "about", url.absoluteString.hasPrefix("about:blank#") {
+            return fragment
+        }
+        if url.scheme == MarkdownAssetScheme.scheme,
+           (url.host == nil || url.host == ""),
+           (url.path.isEmpty || url.path == "/") {
+            return fragment
+        }
+        return nil
     }
 }
 

--- a/samples/long-footnotes.md
+++ b/samples/long-footnotes.md
@@ -1,0 +1,127 @@
+# Long Footnote Jump Test
+
+Use this file to test whether footnote references jump to the footnote section
+and whether backlinks return to the original reference on a long page.
+
+## Section 1
+
+This opening section has the first footnote reference.[^first] Clicking it
+should jump near the bottom of the document.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a
+ante venenatis dapibus posuere velit aliquet. Donec ullamcorper nulla non metus
+auctor fringilla.
+
+Curabitur blandit tempus porttitor. Maecenas faucibus mollis interdum. Etiam
+porta sem malesuada magna mollis euismod. Vestibulum id ligula porta felis
+euismod semper.
+
+## Section 2
+
+This section intentionally has no footnotes. It gives the page enough height to
+make anchor jumps obvious.
+
+- Item one has enough text to wrap on narrower windows and make the page taller.
+- Item two should remain ordinary Markdown content.
+- Item three gives the list a little more vertical weight.
+
+Sed posuere consectetur est at lobortis. Aenean lacinia bibendum nulla sed
+consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
+
+## Section 3
+
+A second footnote appears here.[^middle] After clicking it, use the backlink in
+the footnote section to confirm it returns to this exact part of the page.
+
+```swift
+let literalFootnoteMarker = "[^middle]"
+print(literalFootnoteMarker)
+```
+
+The marker inside the code block above should not become a footnote link.
+
+Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Morbi leo
+risus, porta ac consectetur ac, vestibulum at eros.
+
+## Section 4
+
+More filler content follows. Scroll position should move clearly when you click
+footnote links from this document.
+
+Donec sed odio dui. Nulla vitae elit libero, a pharetra augue. Integer posuere
+erat a ante venenatis dapibus posuere velit aliquet.
+
+Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Fusce
+dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.
+
+## Section 5
+
+This section references the same footnote twice.[^repeat-long] The first backlink
+should return here, and the second backlink should return to the next paragraph.
+
+Here is the second reference to the same footnote.[^repeat-long] It should create
+a second inline backlink in the footnote definition.
+
+`[^repeat-long]` inside inline code should stay literal.
+
+## Section 6
+
+This is another spacer section.
+
+1. Ordered list item one.
+2. Ordered list item two.
+3. Ordered list item three.
+4. Ordered list item four.
+
+Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean
+imperdiet. Etiam ultricies nisi vel augue.
+
+## Section 7
+
+A multiline footnote reference lives here.[^multi-long] Its definition includes
+multiple paragraphs and a nested list.
+
+Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus
+viverra nulla ut metus varius laoreet. Quisque rutrum.
+
+## Section 8
+
+More text to make the page long enough for jump testing.
+
+Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec
+odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus.
+
+Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo.
+Sed fringilla mauris sit amet nibh.
+
+## Section 9
+
+One final footnote appears near the end of the body.[^near-end] This should still
+jump down, but the scroll distance will be shorter than the first reference.
+
+Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue
+velit cursus nunc, quis gravida magna mi a libero.
+
+## Section 10
+
+End of the long body. The footnote section should appear below this paragraph.
+
+Click each backlink arrow in the footnotes and confirm it returns to the matching
+reference location.
+
+[^first]: First footnote. Use the backlink to confirm the page jumps back to
+    Section 1.
+
+[^middle]: Middle footnote with **bold text** and a [link](https://md-preview.app).
+
+[^repeat-long]: Repeated footnote. This should show two backlinks inline at the
+    end of this definition.
+
+[^multi-long]: Multiline footnote first paragraph.
+
+    Second paragraph in the same footnote.
+
+    - Nested bullet one.
+    - Nested bullet two with inline math: $a^2 + b^2 = c^2$.
+
+[^near-end]: Footnote referenced near the end of the document.


### PR DESCRIPTION
## Summary
- Render Markdown footnote references as clickable superscript links instead of raw `[^label]` text
- Collect footnote definitions into a styled endnotes section with inline backlinks
- Route same-document fragment links through the outer scroll view so footnote jumps work in long documents
- Add `samples/long-footnotes.md` for manual jump/backlink testing

## Root Cause
`swift-markdown` in this app does not expose footnote parsing through the current wrapper, and the web view delegate cancelled all clicked links before same-page `#fragment` anchors could scroll.

## Validation
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`

Fixes #47