### PR TITLE
Fix GFM task list rendering

### DIFF
--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -73,13 +73,15 @@ struct EscapingHTMLFormatter: MarkupWalker {
     }
 
     mutating func visitListItem(_ listItem: ListItem) {
-        result += "<li>"
         if let checkbox = listItem.checkbox {
-            result += "<input type=\"checkbox\" disabled=\"\""
+            result += "<li class=\"task-list-item\">"
+            result += "<input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\""
             if checkbox == .checked {
                 result += " checked=\"\""
             }
             result += " /> "
+        } else {
+            result += "<li>"
         }
         descendInto(listItem)
         result += "</li>\n"

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1007,6 +1007,13 @@ enum MarkdownHTML {
     li > ul, li > ol { margin-top: 0.4em; }
     li > p:first-child { margin-top: 0; }
 
+    li.task-list-item { list-style: none; }
+    li.task-list-item > p:first-of-type { display: inline; margin-top: 0; }
+    .task-list-item-checkbox {
+        margin: 0 0.4em 0.18em -1.4em;
+        vertical-align: middle;
+    }
+
     table {
         margin: 1.6em 0 0;
         border-collapse: collapse;


### PR DESCRIPTION
## Summary
- Tag task-list `<li>` and `<input>` elements with `task-list-item` / `task-list-item-checkbox` classes so they can be styled.
- Add CSS that suppresses the default list bullet and inlines the first paragraph of the label so the checkbox sits next to its text.

Fixes #63.

## What was wrong
Task list items rendered with both a bullet and a checkbox, and the label wrapped to a new line below the checkbox — the `<li>` kept its default marker, and `descendInto` wrapped the label in a block-level `<p>`.

## Test plan
- [ ] Render a doc with `- [x]` / `- [ ]` items and confirm the bullet is gone and the checkbox sits inline next to the label.
- [ ] Mixed list (regular bullets + task items in the same `<ul>`): bullets still render for non-task items.
- [ ] Loose task-list item (multiple paragraphs): first paragraph inlines next to the checkbox; subsequent paragraphs wrap onto new lines as before.
- [ ] Nested task lists indent correctly.
- [ ] Light and dark mode both look right.