### PR TITLE
fix(md-preview): remove default placeholder content on launch

### DIFF
--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -36,13 +36,6 @@ final class MainSplitViewController: NSSplitViewController {
         addSplitViewItem(inspector)
 
         splitView.autosaveName = "MainSplitView"
-
-        display(
-            markdown: "# md-preview\n\nWKWebView pipeline is live. Replace this call site once real file loading is wired up.",
-            fileName: "Sample.md",
-            url: nil,
-            assetBaseURL: nil
-        )
     }
 
     func display(markdown: String, fileName: String, url: URL?, assetBaseURL: URL?) {


### PR DESCRIPTION
## Summary
- Removes the `# md-preview / WKWebView pipeline is live...` seed markdown that was shown when the app opened with no document.
- Window now opens blank until a real file is loaded.

## Test plan
- [ ] Launch the app cold — content area is empty, no placeholder.
- [ ] Open a `.md` file via Finder / drag-drop / File menu — renders normally.
- [ ] Sidebar (TOC) and inspector behave correctly with no document open.