### PR TITLE
Release 0.0.13 (17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.0.13] – 2026-05-05
+
+Native printing, plus two rendering fixes.
+
+### Added
+
+- **Print the rendered Markdown.** File → Print (⌘P) now prints the previewed document through WKWebView with horizontal fit pagination, instead of falling through to AppKit's generic `print:` and printing the sidebar and window chrome. The app gained the `com.apple.security.print` entitlement so this works in the sandbox.
+
+### Fixed
+
+- **GFM task lists render inline without a duplicate bullet.** Task list items were drawing both a list marker and a checkbox with the label wrapping to a new line below. Task `<li>`s and their checkboxes are now tagged with GitHub's `task-list-item` / `task-list-item-checkbox` class names, so CSS suppresses the marker and the first paragraph stays inline next to the checkbox ([#63](https://github.com/pluk-inc/md-preview.app/issues/63)).
+- **No placeholder content on launch.** Removed the leftover "WKWebView pipeline is live" sample that the split view rendered at startup, so the app opens with an empty preview area until you load a document.
+
 ## [0.0.12] – 2026-05-05
 
 Code highlighting, richer Markdown heading and footnote rendering, and README sponsor updates.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.12
-CURRENT_PROJECT_VERSION = 16
+MARKETING_VERSION = 0.0.13
+CURRENT_PROJECT_VERSION = 17


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` to **0.0.13** and `CURRENT_PROJECT_VERSION` to **17**.
- Add `CHANGELOG.md` entry for 0.0.13 — native printing plus two rendering fixes.

## What's in 0.0.13

### Added

- **Print the rendered Markdown.** File → Print (⌘P) now prints the previewed document through WKWebView with horizontal fit pagination, instead of falling through to AppKit's generic `print:` and printing the sidebar and window chrome. App gained the `com.apple.security.print` entitlement so this works under the sandbox. (#58)

### Fixed

- **GFM task lists render inline without a duplicate bullet.** Task list items were drawing both a list marker and a checkbox with the label wrapping to a new line below. Task `<li>`s and their checkboxes now carry GitHub's `task-list-item` / `task-list-item-checkbox` class names so CSS suppresses the marker and keeps the first paragraph inline next to the checkbox. (#64, fixes #63)
- **No placeholder content on launch.** Removed the leftover "WKWebView pipeline is live" sample that the split view rendered at startup, so the app opens with an empty preview area until a document is loaded. (#65)

## Test plan

- [ ] Build & run `md-preview` scheme on macOS 15 and macOS 26.
- [ ] Open a Markdown file, hit ⌘P — print panel renders the document body (no sidebar, no toolbar) and pagination fits horizontally.
- [ ] Open a doc with `- [ ]` / `- [x]` task lists — checkboxes inline with their labels, no extra bullet marker.
- [ ] Launch app with no document — preview area is empty (no "WKWebView pipeline is live" stub).
- [ ] Quick Look extension still renders correctly for `.md`.
- [ ] `./scripts/release.sh` validates the new changelog entry without complaint.