### PR TITLE
Release 0.0.14 (18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.14] – 2026-05-06
+
+Quick Look now renders relative images.
+
+### Added
+
+- **Relative images render in Quick Look previews.** When a Markdown file references sibling assets like `![](images/local.png)`, the Quick Look extension now inlines each readable sibling as a `cid:` attachment on the preview reply and rewrites the `<img src>` to match, so local images appear in Finder/Spotlight previews instead of as broken-image glyphs. The extension gained a read-only `temporary-exception.files.absolute-path.read-only` entitlement so the sandboxed preview process can read sibling files (the main app already handles this through its `md-asset://` scheme). Per-image and cumulative byte budgets cap pathological folders; absolute URLs, fragment refs, host-absolute paths, and unreadable files pass through untouched ([#68](https://github.com/pluk-inc/md-preview.app/pull/68)).
+
+### Contributors
+
+Thanks to the external contributor who shipped in this release:
+
+- [@DivineDominion](https://github.com/DivineDominion) — relative images in Quick Look previews ([#68](https://github.com/pluk-inc/md-preview.app/pull/68))
+
 ## [0.0.13] – 2026-05-05
 
 Native printing, plus two rendering fixes.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.13
-CURRENT_PROJECT_VERSION = 17
+MARKETING_VERSION = 0.0.14
+CURRENT_PROJECT_VERSION = 18


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` to `0.0.14` and `CURRENT_PROJECT_VERSION` to `18`.
- Add `CHANGELOG.md` entry for 0.0.14.

## What's in 0.0.14

### Added

- **Relative images render in Quick Look previews.** When a Markdown file references sibling assets like `![](images/local.png)`, the Quick Look extension now inlines each readable sibling as a `cid:` attachment on the preview reply and rewrites the `<img src>` to match, so local images appear in Finder/Spotlight previews instead of as broken-image glyphs. The extension gained a read-only `temporary-exception.files.absolute-path.read-only` entitlement so the sandboxed preview process can read sibling files (the main app already handles this through its `md-asset://` scheme). Per-image and cumulative byte budgets cap pathological folders; absolute URLs, fragment refs, host-absolute paths, and unreadable files pass through untouched (#68).

### Contributors

- [@DivineDominion](https://github.com/DivineDominion) — relative images in Quick Look previews (#68)

## Test plan

- [ ] Quick Look a `.md` file with a relative `![](images/foo.png)` reference (e.g. `tests/fixtures/relative-assets/post.md`) from Finder; sibling image renders inline.
- [ ] Same fixture: URL-encoded-spaces sibling (`images dir/two words.png`) also renders.
- [ ] Same fixture: an `https://` image is left untouched and a missing file falls through to the broken-image glyph without crashing the preview.
- [ ] Open the same document in the main app — existing `md-asset://` rendering still works (no regression from the QL changes).
- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Release build` succeeds with the new `Version.xcconfig` values.
- [ ] After merge: `./scripts/release.sh` runs end-to-end (archive → notarize → DMG → appcast → GitHub release).