### PR TITLE
Add find bar with match navigation, modes, and burst animation

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -17,7 +17,7 @@ extension NSToolbarItem.Identifier {
 }
 
 @main
-class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate, NSSearchFieldDelegate {
 
     @IBOutlet var window: NSWindow!
 
@@ -39,6 +39,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
     private weak var searchField: NSSearchField?
     private var accessBanner: MissingFolderAccessBanner?
     private var accessBannerAccessory: NSTitlebarAccessoryViewController?
+    private var findBar: FindBar?
+    private var findBarAccessory: NSTitlebarAccessoryViewController?
+    private var searchMode: SearchMode = .contains
+    private var pendingFindWork: DispatchWorkItem?
+    private static let findDebounceDelay: TimeInterval = 0.10
 
     func application(_ application: NSApplication, open urls: [URL]) {
         guard let url = urls.first else { return }
@@ -60,8 +65,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
         window.toolbar = toolbar
-        window.toolbarStyle = .unified
+        window.toolbarStyle = .automatic
 
+        installFindBar()
         installAccessBanner()
 
         hasLaunched = true
@@ -265,13 +271,93 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         item.searchField.sendsSearchStringImmediately = true
         item.searchField.target = self
         item.searchField.action = #selector(searchFieldDidChange(_:))
+        item.searchField.delegate = self
         searchField = item.searchField
         return item
     }
 
     @objc private func searchFieldDidChange(_ sender: NSSearchField) {
+        // Coalesce per-keystroke finds — running the full DOM rewrite + JS
+        // round-trip on every char is the dominant stall source on big docs.
+        // Empty queries (e.g. user cleared the field) bypass the debounce so
+        // the highlight teardown happens immediately.
+        let query = sender.stringValue
+        pendingFindWork?.cancel()
+        if query.isEmpty {
+            pendingFindWork = nil
+            runFind(query: query)
+            return
+        }
+        let work = DispatchWorkItem { [weak self] in
+            self?.runFind(query: query)
+        }
+        pendingFindWork = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.findDebounceDelay, execute: work
+        )
+    }
+
+    private func runFind(query: String, backwards: Bool = false) {
+        // Explicit nav (Enter / prev / next / mode change) flushes any pending
+        // debounce so the user navigates the freshest results.
+        pendingFindWork?.cancel()
+        pendingFindWork = nil
         (window.contentViewController as? MainSplitViewController)?
-            .find(sender.stringValue)
+            .find(query, backwards: backwards, mode: searchMode) { [weak self] result in
+                self?.applyFindResult(result, query: query)
+            }
+    }
+
+    func control(_ control: NSControl,
+                 textView: NSTextView,
+                 doCommandBy commandSelector: Selector) -> Bool {
+        guard control === searchField,
+              commandSelector == #selector(NSResponder.insertNewline(_:)) else {
+            return false
+        }
+        let backwards = NSEvent.modifierFlags.contains(.shift)
+        findFromToolbar(backwards: backwards)
+        return true
+    }
+
+    private func applyFindResult(_ result: FindResult, query: String) {
+        if query.isEmpty {
+            setFindBarVisible(false)
+            return
+        }
+        findBar?.update(matchCount: result.total, currentIndex: result.index)
+        setFindBarVisible(true)
+    }
+
+    private func setFindBarVisible(_ visible: Bool) {
+        guard let accessory = findBarAccessory, accessory.isHidden == visible else { return }
+        accessory.isHidden = !visible
+    }
+
+    private func installFindBar() {
+        let bar = FindBar(
+            frame: NSRect(x: 0, y: 0, width: 600, height: FindBar.preferredHeight)
+        )
+        bar.autoresizingMask = [.width]
+        bar.onPrevious = { [weak self] in self?.findFromToolbar(backwards: true) }
+        bar.onNext = { [weak self] in self?.findFromToolbar(backwards: false) }
+        bar.onDone = { [weak self] in self?.dismissFindBar() }
+        bar.onModeChanged = { [weak self] mode in self?.searchModeDidChange(mode) }
+
+        // Default `.automatic` — `.hard` deadlocks initial layout against our
+        // nested non-scrolling WKWebView. Find bar's own bottom rule gives
+        // the dividing line either way.
+        self.findBar = bar
+        self.findBarAccessory = addBottomTitlebarAccessory(bar)
+    }
+
+    private func dismissFindBar() {
+        searchField?.stringValue = ""
+        if let editor = searchField?.currentEditor(),
+           window.firstResponder === editor {
+            window.makeFirstResponder(nil)
+        }
+        runFind(query: "")
     }
 
     @IBAction func performFindPanelAction(_ sender: Any?) {
@@ -302,8 +388,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
             focusToolbarSearch()
             return
         }
-        (window.contentViewController as? MainSplitViewController)?
-            .find(query, backwards: backwards)
+        runFind(query: query, backwards: backwards)
+    }
+
+    private func searchModeDidChange(_ mode: SearchMode) {
+        guard mode != searchMode else { return }
+        searchMode = mode
+        guard findBarAccessory?.isHidden == false,
+              let query = searchField?.stringValue, !query.isEmpty else { return }
+        runFind(query: query)
     }
 
     private func focusToolbarSearch() {
@@ -634,14 +727,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         banner.autoresizingMask = [.width]
         banner.onAllow = { [weak self] in self?.grantAccessForCurrentDocument() }
 
+        self.accessBanner = banner
+        self.accessBannerAccessory = addBottomTitlebarAccessory(banner)
+    }
+
+    private func addBottomTitlebarAccessory(_ view: NSView) -> NSTitlebarAccessoryViewController {
         let accessory = NSTitlebarAccessoryViewController()
         accessory.layoutAttribute = .bottom
-        accessory.view = banner
+        accessory.view = view
         accessory.isHidden = true
         window.addTitlebarAccessoryViewController(accessory)
-
-        self.accessBanner = banner
-        self.accessBannerAccessory = accessory
+        return accessory
     }
 
     private func updateAccessBanner(visible: Bool, folderName: String) {

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -12,6 +12,7 @@ final class ContentViewController: NSViewController {
     private var webViewHeightConstraint: NSLayoutConstraint!
     private var measuredDocumentHeight: CGFloat = 1
     private var lastLaidOutSize: NSSize = .zero
+    private var pendingFlashWork: DispatchWorkItem?
 
     override func loadView() {
         let scrollView = NSScrollView()
@@ -69,11 +70,48 @@ final class ContentViewController: NSViewController {
         webView.display(markdown: markdown, assetBaseURL: assetBaseURL)
     }
 
-    func find(_ query: String, backwards: Bool = false) {
+    func find(_ query: String,
+              backwards: Bool = false,
+              mode: SearchMode = .contains,
+              completion: ((FindResult) -> Void)? = nil) {
         let pasteboard = NSPasteboard(name: .find)
         pasteboard.declareTypes([.string], owner: nil)
         pasteboard.setString(query, forType: .string)
-        webView.find(query, backwards: backwards)
+        pendingFlashWork?.cancel()
+        webView.find(query, backwards: backwards, mode: mode) { [weak self] result in
+            guard let self else {
+                completion?(result)
+                return
+            }
+            if let top = result.top, let bottom = result.bottom {
+                let needsScroll = !self.isMatchVisible(top: top, bottom: bottom)
+                if needsScroll {
+                    self.scrollDocument(to: top)
+                }
+                // Burst on every navigation. When we just scrolled, delay so
+                // the animation lines up with the match arriving in view.
+                let delay: TimeInterval = needsScroll ? 0.18 : 0
+                let work = DispatchWorkItem { [weak self] in
+                    self?.webView.flashCurrentMatch()
+                }
+                self.pendingFlashWork = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+            }
+            completion?(result)
+        }
+    }
+
+    private func isMatchVisible(top: CGFloat, bottom: CGFloat) -> Bool {
+        guard let scrollView = view as? NSScrollView else { return true }
+        let clipView = scrollView.contentView
+        // The toolbar (and any titlebar accessory like the find bar) sits over
+        // the top of the clip view via contentInsets — content under that band
+        // is technically inside bounds but visually hidden, so don't count it.
+        let visibleTop = clipView.bounds.origin.y + clipView.contentInsets.top
+        let visibleBottom = clipView.bounds.origin.y
+            + clipView.bounds.height
+            - clipView.contentInsets.bottom
+        return top >= visibleTop && bottom <= visibleBottom
     }
 
     func printDocument() {

--- a/md-preview/FindBar.swift
+++ b/md-preview/FindBar.swift
@@ -1,0 +1,166 @@
+//
+//  FindBar.swift
+//  md-preview
+//
+
+import Cocoa
+
+/// Slim bar shown beneath the toolbar while searching: match count,
+/// previous / next chevrons, and a Done button.
+final class FindBar: NSView {
+
+    static let preferredHeight: CGFloat = 36
+
+    var onPrevious: (() -> Void)?
+    var onNext: (() -> Void)?
+    var onDone: (() -> Void)?
+    var onModeChanged: ((SearchMode) -> Void)?
+
+    private let modeControl = NSSegmentedControl()
+    private let countLabel = NSTextField(labelWithString: "")
+    private let navigationControl = NSSegmentedControl()
+    private let doneButton = NSButton(title: "Done", target: nil, action: nil)
+    private let bottomSeparator = NSBox()
+
+    private enum NavigationSegment: Int {
+        case previous = 0
+        case next = 1
+    }
+
+    private enum ModeSegment: Int {
+        case contains = 0
+        case beginsWith = 1
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUp()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setUp()
+    }
+
+    func update(matchCount: Int, currentIndex: Int) {
+        if matchCount == 0 {
+            countLabel.stringValue = "Not found"
+        } else {
+            countLabel.stringValue = "\(currentIndex) of \(matchCount)"
+        }
+        let hasMatches = matchCount > 0
+        navigationControl.setEnabled(hasMatches, forSegment: NavigationSegment.previous.rawValue)
+        navigationControl.setEnabled(hasMatches, forSegment: NavigationSegment.next.rawValue)
+    }
+
+    private func setUp() {
+        countLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.alignment = .right
+        countLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        configureModeControl()
+        configureNavigationControl()
+
+        doneButton.bezelStyle = .rounded
+        doneButton.controlSize = .regular
+        doneButton.target = self
+        doneButton.action = #selector(doneTapped)
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let leadingStack = NSStackView(views: [modeControl])
+        leadingStack.orientation = .horizontal
+        leadingStack.spacing = 8
+        leadingStack.alignment = .centerY
+        leadingStack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(leadingStack)
+
+        let trailingStack = NSStackView(views: [countLabel, navigationControl, doneButton])
+        trailingStack.orientation = .horizontal
+        trailingStack.spacing = 12
+        trailingStack.alignment = .centerY
+        trailingStack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(trailingStack)
+
+        // macOS 26 dropped the system-drawn separators around titlebar
+        // accessories, so we draw our own bottom rule. macOS 15 still draws
+        // them, so hiding ours avoids a doubled line there.
+        let needsManualSeparator: Bool = {
+            if #available(macOS 26.0, *) { return true }
+            return false
+        }()
+
+        bottomSeparator.boxType = .separator
+        bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
+        bottomSeparator.isHidden = !needsManualSeparator
+        addSubview(bottomSeparator)
+
+        NSLayoutConstraint.activate([
+            leadingStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            leadingStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            trailingStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            trailingStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            bottomSeparator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomSeparator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomSeparator.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomSeparator.heightAnchor.constraint(equalToConstant: 1)
+        ])
+    }
+
+    private func configureModeControl() {
+        modeControl.segmentStyle = .automatic
+        modeControl.trackingMode = .selectOne
+        modeControl.segmentCount = 2
+        modeControl.setLabel("Contains", forSegment: ModeSegment.contains.rawValue)
+        modeControl.setLabel("Begins With", forSegment: ModeSegment.beginsWith.rawValue)
+        modeControl.selectedSegment = ModeSegment.contains.rawValue
+        modeControl.target = self
+        modeControl.action = #selector(modeTapped(_:))
+        modeControl.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func configureNavigationControl() {
+        let previous = NSImage(systemSymbolName: "chevron.left",
+                               accessibilityDescription: "Previous match") ?? NSImage()
+        let next = NSImage(systemSymbolName: "chevron.right",
+                           accessibilityDescription: "Next match") ?? NSImage()
+        previous.isTemplate = true
+        next.isTemplate = true
+
+        navigationControl.segmentStyle = .rounded
+        navigationControl.trackingMode = .momentary
+        navigationControl.segmentCount = 2
+        navigationControl.setImage(previous, forSegment: NavigationSegment.previous.rawValue)
+        navigationControl.setImage(next, forSegment: NavigationSegment.next.rawValue)
+        navigationControl.setImageScaling(.scaleProportionallyDown,
+                                          forSegment: NavigationSegment.previous.rawValue)
+        navigationControl.setImageScaling(.scaleProportionallyDown,
+                                          forSegment: NavigationSegment.next.rawValue)
+        navigationControl.target = self
+        navigationControl.action = #selector(navigationTapped(_:))
+        navigationControl.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: Self.preferredHeight)
+    }
+
+    @objc private func navigationTapped(_ sender: NSSegmentedControl) {
+        switch NavigationSegment(rawValue: sender.selectedSegment) {
+        case .previous: onPrevious?()
+        case .next: onNext?()
+        case .none: break
+        }
+    }
+
+    @objc private func modeTapped(_ sender: NSSegmentedControl) {
+        let mode: SearchMode = sender.selectedSegment == ModeSegment.beginsWith.rawValue
+            ? .beginsWith
+            : .contains
+        onModeChanged?(mode)
+    }
+
+    @objc private func doneTapped() { onDone?() }
+}

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -44,8 +44,11 @@ final class MainSplitViewController: NSSplitViewController {
         inspectorViewController?.display(metadata: DocumentMetadata.make(url: url, markdown: markdown))
     }
 
-    func find(_ query: String, backwards: Bool = false) {
-        contentViewController?.find(query, backwards: backwards)
+    func find(_ query: String,
+              backwards: Bool = false,
+              mode: SearchMode = .contains,
+              completion: ((FindResult) -> Void)? = nil) {
+        contentViewController?.find(query, backwards: backwards, mode: mode, completion: completion)
     }
 
     // Custom selector (instead of `print:`) so AppKit's inherited

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -825,6 +825,38 @@ enum MarkdownHTML {
     mark.md-search-highlight-current {
         background: #ffbf00;
     }
+    .md-search-burst {
+        position: absolute;
+        pointer-events: none;
+        background: rgba(255, 191, 0, 0.5);
+        border-radius: 6px;
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.12),
+                    0 2px 6px rgba(0, 0, 0, 0.15);
+        z-index: 9999;
+        transform-origin: center center;
+        will-change: transform;
+        animation: md-search-burst 250ms forwards;
+    }
+    /* Per-segment timing: accelerate into the peak (cubic-bezier ease-in),
+       then decelerate out of it (strong ease-out). High matching velocity
+       at the peak means the motion flows through without pausing — the
+       "stuck" feel of multi-stop ease-out keyframes. */
+    @keyframes md-search-burst {
+        0% {
+            transform: scale(1.0);
+            animation-timing-function: cubic-bezier(0.55, 0, 1, 0.45);
+        }
+        50% {
+            transform: scale(1.32);
+            animation-timing-function: cubic-bezier(0, 0.55, 0.45, 1);
+        }
+        100% {
+            transform: scale(1.0);
+        }
+    }
+    @media (prefers-reduced-motion: reduce) {
+        .md-search-burst { animation-duration: 1ms; }
+    }
     html, body {
         margin: 0;
         padding: 0;

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -6,6 +6,20 @@
 import Cocoa
 import WebKit
 
+enum SearchMode {
+    case contains
+    case beginsWith
+}
+
+struct FindResult {
+    let top: CGFloat?
+    let bottom: CGFloat?
+    let index: Int
+    let total: Int
+
+    static let none = FindResult(top: nil, bottom: nil, index: 0, total: 0)
+}
+
 final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     let webView: WKWebView
@@ -94,8 +108,42 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         }
     }
 
-    func find(_ query: String, backwards: Bool = false) {
-        highlightMatches(for: query, backwards: backwards)
+    func find(_ query: String,
+              backwards: Bool = false,
+              mode: SearchMode = .contains,
+              completion: ((FindResult) -> Void)? = nil) {
+        highlightMatches(for: query, backwards: backwards, mode: mode, completion: completion)
+    }
+
+    /// Flashes the macOS-style "burst" animation over the current match —
+    /// a yellow rounded rect that starts large and shrinks down to the match.
+    func flashCurrentMatch() {
+        let script = """
+        (() => {
+            const root = document.querySelector('.markdown-body') || document.body;
+            const marks = root.querySelectorAll('mark.md-search-highlight');
+            const index = window.__mdPreviewSearchIndex;
+            if (!Number.isInteger(index) || index < 0 || index >= marks.length) return;
+            // Drop any in-flight burst so fast typing doesn't pile elements
+            // on the body waiting to fire animationend.
+            document.querySelectorAll('.md-search-burst').forEach(b => b.remove());
+            const target = marks[index];
+            const rect = target.getBoundingClientRect();
+            const scrollX = window.scrollX || document.documentElement.scrollLeft || 0;
+            const scrollY = window.scrollY || document.documentElement.scrollTop || 0;
+            const padX = 6;
+            const padY = 4;
+            const burst = document.createElement('span');
+            burst.className = 'md-search-burst';
+            burst.style.left = (rect.left + scrollX - padX) + 'px';
+            burst.style.top = (rect.top + scrollY - padY) + 'px';
+            burst.style.width = (rect.width + padX * 2) + 'px';
+            burst.style.height = (rect.height + padY * 2) + 'px';
+            document.body.appendChild(burst);
+            burst.addEventListener('animationend', () => burst.remove(), { once: true });
+        })();
+        """
+        webView.evaluateJavaScript(script) { _, _ in }
     }
 
     func printDocument(from window: NSWindow) {
@@ -150,35 +198,67 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         }
     }
 
-    private func highlightMatches(for query: String, backwards: Bool) {
+    private func highlightMatches(for query: String,
+                                  backwards: Bool,
+                                  mode: SearchMode,
+                                  completion: ((FindResult) -> Void)?) {
+        let beginsWith = mode == .beginsWith
         let script = """
         (() => {
             const root = document.querySelector('.markdown-body') || document.body;
             const previousQuery = window.__mdPreviewSearchQuery || '';
-            const sameQuery = previousQuery === \(javaScriptStringLiteral(query));
+            const previousBeginsWith = window.__mdPreviewSearchBeginsWith === true;
+            const beginsWith = \(beginsWith ? "true" : "false");
+            const sameQuery = previousQuery === \(javaScriptStringLiteral(query))
+                && previousBeginsWith === beginsWith;
 
-            root.querySelectorAll('mark.md-search-highlight').forEach((mark) => {
-                mark.replaceWith(document.createTextNode(mark.textContent));
-            });
-            root.normalize();
+            // Tear down prior highlights, but only normalize() the parents we
+            // actually touched — root.normalize() is O(N) over the entire
+            // document subtree, which is the dominant stall on big docs.
+            const priorMarks = root.querySelectorAll('mark.md-search-highlight');
+            if (priorMarks.length > 0) {
+                const dirty = new Set();
+                priorMarks.forEach((mark) => {
+                    const parent = mark.parentNode;
+                    if (parent) dirty.add(parent);
+                    mark.replaceWith(document.createTextNode(mark.textContent));
+                });
+                dirty.forEach((parent) => parent.normalize());
+            }
 
             const query = \(javaScriptStringLiteral(query));
             window.__mdPreviewSearchQuery = query;
+            window.__mdPreviewSearchBeginsWith = beginsWith;
             if (!query) {
                 window.__mdPreviewSearchIndex = -1;
-                return 0;
+                return { top: null, bottom: null, index: 0, total: 0 };
             }
+            const isWordChar = (ch) => /[A-Za-z0-9_]/.test(ch);
 
             const needle = query.toLocaleLowerCase();
+            // checkVisibility() forces layout, and KaTeX/Mermaid pages have
+            // many text nodes per parent — cache by parent so we hit it once.
+            const visibilityCache = new WeakMap();
             const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
                 acceptNode(node) {
                     const parent = node.parentElement;
                     if (!parent || parent.closest('script, style, textarea, mark.md-search-highlight')) {
                         return NodeFilter.FILTER_REJECT;
                     }
-                    return node.nodeValue.toLocaleLowerCase().includes(needle)
-                        ? NodeFilter.FILTER_ACCEPT
-                        : NodeFilter.FILTER_REJECT;
+                    // KaTeX/Mermaid stash hidden MathML / source mirrors with
+                    // getBoundingClientRect.top===0 — scrolling to those would
+                    // jump the doc to the top with nothing visible.
+                    let visible = visibilityCache.get(parent);
+                    if (visible === undefined) {
+                        visible = typeof parent.checkVisibility !== 'function'
+                            || parent.checkVisibility();
+                        visibilityCache.set(parent, visible);
+                    }
+                    if (!visible) return NodeFilter.FILTER_REJECT;
+                    // Don't double-lowercase here; the inner loop already does
+                    // one .toLocaleLowerCase() per node and an .indexOf, which
+                    // short-circuits cheaply on non-matching text.
+                    return NodeFilter.FILTER_ACCEPT;
                 }
             });
 
@@ -191,28 +271,42 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                 const lower = text.toLocaleLowerCase();
                 const fragment = document.createDocumentFragment();
                 let offset = 0;
-                let matchIndex = lower.indexOf(needle);
+                let searchFrom = 0;
+                let matchIndex = lower.indexOf(needle, searchFrom);
+                let nodeHasMatch = false;
 
                 while (matchIndex !== -1) {
-                    fragment.append(document.createTextNode(text.slice(offset, matchIndex)));
+                    const prevChar = matchIndex === 0 ? '' : text[matchIndex - 1];
+                    const isBoundary = matchIndex === 0 || !isWordChar(prevChar);
 
-                    const mark = document.createElement('mark');
-                    mark.className = 'md-search-highlight';
-                    mark.textContent = text.slice(matchIndex, matchIndex + query.length);
-                    fragment.append(mark);
-                    marks.push(mark);
+                    if (!beginsWith || isBoundary) {
+                        fragment.append(document.createTextNode(text.slice(offset, matchIndex)));
 
-                    offset = matchIndex + query.length;
-                    matchIndex = lower.indexOf(needle, offset);
+                        const mark = document.createElement('mark');
+                        mark.className = 'md-search-highlight';
+                        mark.textContent = text.slice(matchIndex, matchIndex + query.length);
+                        fragment.append(mark);
+                        marks.push(mark);
+
+                        offset = matchIndex + query.length;
+                        searchFrom = offset;
+                        nodeHasMatch = true;
+                    } else {
+                        // Skip this match, but keep scanning the same text node.
+                        searchFrom = matchIndex + 1;
+                    }
+                    matchIndex = lower.indexOf(needle, searchFrom);
                 }
 
-                fragment.append(document.createTextNode(text.slice(offset)));
-                node.replaceWith(fragment);
+                if (nodeHasMatch) {
+                    fragment.append(document.createTextNode(text.slice(offset)));
+                    node.replaceWith(fragment);
+                }
             }
 
             if (marks.length === 0) {
                 window.__mdPreviewSearchIndex = -1;
-                return 0;
+                return { top: null, bottom: null, index: 0, total: 0 };
             }
 
             const previousIndex = Number.isInteger(window.__mdPreviewSearchIndex)
@@ -230,13 +324,32 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             }
 
             window.__mdPreviewSearchIndex = index;
-            marks[index].classList.add('md-search-highlight-current');
-            marks[index].scrollIntoView({ block: 'center', inline: 'nearest' });
+            const current = marks[index];
+            current.classList.add('md-search-highlight-current');
 
-            return marks.length;
+            // The WKWebView host disables internal scrolling and forwards it to
+            // an outer NSScrollView, so scrollIntoView() is a no-op. Hand the
+            // document-space bounds back so AppKit can scroll the clip view —
+            // and only when the match isn't already on screen.
+            const rect = current.getBoundingClientRect();
+            const scrollY = window.scrollY || document.documentElement.scrollTop || 0;
+            return {
+                top: rect.top + scrollY,
+                bottom: rect.bottom + scrollY,
+                index: index + 1,
+                total: marks.length
+            };
         })();
         """
-        webView.evaluateJavaScript(script) { _, _ in }
+        webView.evaluateJavaScript(script) { result, _ in
+            guard let completion else { return }
+            let dict = result as? [String: Any]
+            let top = (dict?["top"] as? NSNumber).map { CGFloat(truncating: $0) }
+            let bottom = (dict?["bottom"] as? NSNumber).map { CGFloat(truncating: $0) }
+            let index = (dict?["index"] as? NSNumber)?.intValue ?? 0
+            let total = (dict?["total"] as? NSNumber)?.intValue ?? 0
+            completion(FindResult(top: top, bottom: bottom, index: index, total: total))
+        }
     }
 
     private func javaScriptStringLiteral(_ string: String) -> String {


### PR DESCRIPTION
## Summary

Adds a slim find bar below the toolbar that appears while searching:
match count on the right, prev/next navigation, Done button, and a
"Contains / Begins With" mode toggle on the left.

Closes #72.

## What's in this PR

- **Enter / Shift+Enter cycle matches** — the original issue. Search field
  uses `NSSearchFieldDelegate.control(_:textView:doCommandBy:)` so Return
  on an unchanged query advances to the next match instead of no-opping.
- **Find bar UI** (new `FindBar.swift`, registered as a bottom titlebar
  accessory) — `"X of N"` count, `NSSegmentedControl` chevrons, Done
  button, and a leading `NSSegmentedControl` for Contains / Begins With.
  Hidden by default; shows when the search field has text and disappears
  when cleared or Done is pressed.
- **Burst animation on each match** — a yellow rounded pill scale-pulses
  over the current `<mark>` (CSS keyframes; opacity fixed, transform-only
  for compositor-only animation). Honors `prefers-reduced-motion`.
- **Scroll only when needed** — find skips the scroll when the match is
  already inside the un-occluded visible area; otherwise routes through
  the existing `scrollDocument(to:)` so toolbar/banner inset clearance
  and the smooth clip-view animation are reused.
- **Begins-With mode** — the JS gates matches by the preceding character
  (`!/\[A-Za-z0-9_]/`).
- **Hidden-subtree filter** — TreeWalker uses `checkVisibility()` and
  caches it per parent in a `WeakMap`, so KaTeX MathML mirrors and
  Mermaid source nodes don't appear as phantom matches that scroll the
  doc to the top.

## Performance

- 100 ms keystroke debounce on `searchFieldDidChange`; explicit nav
  (Enter / chevrons / mode change) flushes the pending work.
- Highlight teardown calls `parent.normalize()` only on the parents that
  actually held prior marks (was `root.normalize()` over the whole
  `.markdown-body` subtree).
- Removed double-lowercase in TreeWalker filter — inner loop already
  does it once.
- Pending burst dispatch is cancelled when a new find runs, so fast
  typing doesn't queue up `flashCurrentMatch()` round-trips.

## Test plan

- [ ] Open a doc with a repeated word; type — first match highlights and
      pulses, count says `1 of N`.
- [ ] Press Enter — advances to next match, pulses there. Wraps around.
- [ ] Shift+Enter — goes back; wraps around.
- [ ] Toggle Begins With — only word-start matches highlight; toggle back
      to Contains and the full set returns.
- [ ] Cycle through matches that are already on screen — no scroll.
- [ ] Cycle to a far-away match — scrolls smoothly, burst lands as the
      word arrives.
- [ ] Cmd-F focuses the toolbar search field; system Find Next /
      Previous menu items work.
- [ ] Press Done — clears the highlights and hides the bar.
- [ ] Type fast — find bar count stays current, no UI lag, no leftover
      bursts.
- [ ] Open a doc with KaTeX math or Mermaid — searching for content that
      appears in the rendered text gives the right count and never
      jumps to the top of the doc on a phantom match.