### PR TITLE
Fix inline KaTeX math direction in RTL paragraphs

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1512,6 +1512,7 @@ enum MarkdownHTML {
     @media (prefers-color-scheme: dark) {
         .math-error { color: #ff6e6e; }
     }
+    .katex { direction: ltr !important; unicode-bidi: isolate; }
 
     blockquote {
         margin: 1.6em 0 0;


### PR DESCRIPTION
## Summary

Adds CSS rule to preserve LTR direction for KaTeX math when embedded in RTL paragraphs. 

**Before**: 
<img width="286" height="42" alt="Screenshot 2026-05-07 at 2 03 18" src="https://github.com/user-attachments/assets/c5992248-af9b-47d8-aa65-ac6505b1de21" />

**After**:
<img width="271" height="37" alt="Screenshot 2026-05-07 at 2 03 29" src="https://github.com/user-attachments/assets/9d203eeb-7c6a-4bec-afce-85fb3b4f0eb6" />

## What changed

A one liner `.katex { direction: ltr !important; unicode-bidi: isolate; }` to the stylesheet to prevent math from inheriting RTL direction from surrounding text.

## Test plan

- [ ] Open the [test file](https://github.com/user-attachments/files/27460359/3.md) (Hebrew + inline math)
- [ ] Verify math renders LTR (e.g.,  $f(x)=x^2$ ), and not like that:  $f(x) = ^2x$
- [ ] Confirm surrounding Hebrew text still flows RTL


