### PR TITLE
Find bar mode toggle, sidebar title row, scroll edge effect

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -64,6 +64,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         let toolbar = NSToolbar(identifier: "MainToolbar")
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
+        toolbar.allowsUserCustomization = true
         window.toolbar = toolbar
         window.toolbarStyle = .automatic
 
@@ -343,12 +344,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         bar.onNext = { [weak self] in self?.findFromToolbar(backwards: false) }
         bar.onDone = { [weak self] in self?.dismissFindBar() }
         bar.onModeChanged = { [weak self] mode in self?.searchModeDidChange(mode) }
-
-        // Default `.automatic` — `.hard` deadlocks initial layout against our
-        // nested non-scrolling WKWebView. Find bar's own bottom rule gives
-        // the dividing line either way.
         self.findBar = bar
-        self.findBarAccessory = addBottomTitlebarAccessory(bar)
+        self.findBarAccessory = addBottomTitlebarAccessory(bar) { accessory in
+            if #available(macOS 26.1, *) {
+                accessory.preferredScrollEdgeEffectStyle = .hard
+            }
+        }
     }
 
     private func dismissFindBar() {
@@ -731,11 +732,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         self.accessBannerAccessory = addBottomTitlebarAccessory(banner)
     }
 
-    private func addBottomTitlebarAccessory(_ view: NSView) -> NSTitlebarAccessoryViewController {
+    private func addBottomTitlebarAccessory(
+        _ view: NSView,
+        configure: ((NSTitlebarAccessoryViewController) -> Void)? = nil
+    ) -> NSTitlebarAccessoryViewController {
         let accessory = NSTitlebarAccessoryViewController()
         accessory.layoutAttribute = .bottom
         accessory.view = view
         accessory.isHidden = true
+        configure?(accessory)
         window.addTitlebarAccessoryViewController(accessory)
         return accessory
     }

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -63,8 +63,6 @@ final class ContentViewController: NSViewController {
 
         lastLaidOutSize = laidOutSize
         applyDocumentHeight()
-        // Width changes propagate to body via the WKWebView; the JS-side
-        // ResizeObserver pushes a fresh height back automatically.
     }
 
     func display(markdown: String, assetBaseURL: URL? = nil) {
@@ -89,8 +87,6 @@ final class ContentViewController: NSViewController {
                 if needsScroll {
                     self.scrollDocument(to: top)
                 }
-                // Burst on every navigation. When we just scrolled, delay so
-                // the animation lines up with the match arriving in view.
                 let delay: TimeInterval = needsScroll ? 0.18 : 0
                 let work = DispatchWorkItem { [weak self] in
                     self?.webView.flashCurrentMatch()
@@ -105,9 +101,6 @@ final class ContentViewController: NSViewController {
     private func isMatchVisible(top: CGFloat, bottom: CGFloat) -> Bool {
         guard let scrollView = view as? NSScrollView else { return true }
         let clipView = scrollView.contentView
-        // The toolbar (and any titlebar accessory like the find bar) sits over
-        // the top of the clip view via contentInsets — content under that band
-        // is technically inside bounds but visually hidden, so don't count it.
         let visibleTop = clipView.bounds.origin.y + clipView.contentInsets.top
         let visibleBottom = clipView.bounds.origin.y
             + clipView.bounds.height
@@ -137,10 +130,6 @@ final class ContentViewController: NSViewController {
     private func scrollDocument(to y: CGFloat) {
         guard let scrollView = view as? NSScrollView else { return }
         let clipView = scrollView.contentView
-        // `y` is the heading's position in document coordinates. The clip
-        // view has a top contentInset that matches the unified toolbar (and
-        // any titlebar accessory like the folder-access banner) — without
-        // subtracting it, the heading lands underneath the toolbar.
         let topInset = clipView.contentInsets.top
         let bottomInset = clipView.contentInsets.bottom
         let topMargin: CGFloat = 12

--- a/md-preview/FindBar.swift
+++ b/md-preview/FindBar.swift
@@ -16,7 +16,9 @@ final class FindBar: NSView {
     var onDone: (() -> Void)?
     var onModeChanged: ((SearchMode) -> Void)?
 
-    private let modeControl = NSSegmentedControl()
+    private let modeLabel = NSTextField(labelWithString: "Match:")
+    private let containsButton = NSButton(title: "Contains", target: nil, action: nil)
+    private let beginsWithButton = NSButton(title: "Begins With", target: nil, action: nil)
     private let countLabel = NSTextField(labelWithString: "")
     private let navigationControl = NSSegmentedControl()
     private let doneButton = NSButton(title: "Done", target: nil, action: nil)
@@ -25,11 +27,6 @@ final class FindBar: NSView {
     private enum NavigationSegment: Int {
         case previous = 0
         case next = 1
-    }
-
-    private enum ModeSegment: Int {
-        case contains = 0
-        case beginsWith = 1
     }
 
     override init(frame frameRect: NSRect) {
@@ -59,8 +56,11 @@ final class FindBar: NSView {
         countLabel.alignment = .right
         countLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        configureModeControl()
+        configureModeButtons()
         configureNavigationControl()
+
+        modeLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
+        modeLabel.textColor = .secondaryLabelColor
 
         doneButton.bezelStyle = .rounded
         doneButton.controlSize = .regular
@@ -68,7 +68,7 @@ final class FindBar: NSView {
         doneButton.action = #selector(doneTapped)
         doneButton.translatesAutoresizingMaskIntoConstraints = false
 
-        let leadingStack = NSStackView(views: [modeControl])
+        let leadingStack = NSStackView(views: [modeLabel, containsButton, beginsWithButton])
         leadingStack.orientation = .horizontal
         leadingStack.spacing = 8
         leadingStack.alignment = .centerY
@@ -109,16 +109,19 @@ final class FindBar: NSView {
         ])
     }
 
-    private func configureModeControl() {
-        modeControl.segmentStyle = .automatic
-        modeControl.trackingMode = .selectOne
-        modeControl.segmentCount = 2
-        modeControl.setLabel("Contains", forSegment: ModeSegment.contains.rawValue)
-        modeControl.setLabel("Begins With", forSegment: ModeSegment.beginsWith.rawValue)
-        modeControl.selectedSegment = ModeSegment.contains.rawValue
-        modeControl.target = self
-        modeControl.action = #selector(modeTapped(_:))
-        modeControl.translatesAutoresizingMaskIntoConstraints = false
+    private func configureModeButtons() {
+        for button in [containsButton, beginsWithButton] {
+            button.bezelStyle = .flexiblePush
+            button.controlSize = .small
+            button.showsBorderOnlyWhileMouseInside = true
+            button.setButtonType(.pushOnPushOff)
+            button.setAccessibilitySubrole(.toggle)
+            button.target = self
+            button.action = #selector(modeButtonTapped(_:))
+            button.translatesAutoresizingMaskIntoConstraints = false
+        }
+        containsButton.state = .on
+        beginsWithButton.state = .off
     }
 
     private func configureNavigationControl() {
@@ -155,12 +158,13 @@ final class FindBar: NSView {
         }
     }
 
-    @objc private func modeTapped(_ sender: NSSegmentedControl) {
-        let mode: SearchMode = sender.selectedSegment == ModeSegment.beginsWith.rawValue
-            ? .beginsWith
-            : .contains
+    @objc private func doneTapped() { onDone?() }
+
+    @objc private func modeButtonTapped(_ sender: NSButton) {
+        let mode: SearchMode = sender === beginsWithButton ? .beginsWith : .contains
+        guard containsButton.state != (mode == .contains ? .on : .off) else { return }
+        containsButton.state = mode == .contains ? .on : .off
+        beginsWithButton.state = mode == .beginsWith ? .on : .off
         onModeChanged?(mode)
     }
-
-    @objc private func doneTapped() { onDone?() }
 }

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -43,7 +43,6 @@ enum MarkdownHTML {
         let scrollOverride = allowsScroll ? """
         <style>
         html, body { overflow: auto !important; }
-        ::-webkit-scrollbar { display: initial !important; width: auto !important; height: auto !important; }
         </style>
         """ : ""
         let baseTag = assetBaseHref.map { "<base href=\"\($0)\">" } ?? ""

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -9,23 +9,17 @@ final class SidebarViewController: NSViewController {
 
     var onSelectHeading: ((Int) -> Void)?
 
-    private var titleLabel: NSTextField!
     private var scrollView: NSScrollView!
     private var outlineView: NSOutlineView!
     private var roots: [TOCNode] = []
+    private var titleItem: TitleItem?
+    private var lastRenderedMarkdown: String?
+    private var lastRenderedFileName: String?
+
+    private var titleOffset: Int { titleItem == nil ? 0 : 1 }
 
     override func loadView() {
         let container = NSView()
-
-        titleLabel = NSTextField(labelWithString: "")
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = NSFont.systemFont(ofSize: 12, weight: .semibold)
-        titleLabel.textColor = .secondaryLabelColor
-        titleLabel.lineBreakMode = .byTruncatingMiddle
-        titleLabel.cell?.usesSingleLineMode = true
-        titleLabel.maximumNumberOfLines = 1
-        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        container.addSubview(titleLabel)
 
         scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -39,7 +33,6 @@ final class SidebarViewController: NSViewController {
         outlineView.headerView = nil
         outlineView.allowsMultipleSelection = false
         outlineView.allowsEmptySelection = true
-        outlineView.usesAutomaticRowHeights = true
         outlineView.dataSource = self
         outlineView.delegate = self
         outlineView.target = self
@@ -54,11 +47,7 @@ final class SidebarViewController: NSViewController {
         scrollView.documentView = outlineView
 
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: container.safeAreaLayoutGuide.topAnchor, constant: 8),
-            titleLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
-            titleLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -14),
-
-            scrollView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            scrollView.topAnchor.constraint(equalTo: container.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
@@ -69,8 +58,10 @@ final class SidebarViewController: NSViewController {
 
     func display(markdown: String, fileName: String) {
         loadViewIfNeeded()
-        titleLabel.stringValue = fileName
-        titleLabel.isHidden = fileName.isEmpty
+        guard markdown != lastRenderedMarkdown || fileName != lastRenderedFileName else { return }
+        lastRenderedMarkdown = markdown
+        lastRenderedFileName = fileName
+        titleItem = fileName.isEmpty ? nil : TitleItem(title: fileName)
         roots = MarkdownTOC.parse(markdown).map(TOCNode.init)
         outlineView.reloadData()
         for root in roots {
@@ -83,6 +74,11 @@ final class SidebarViewController: NSViewController {
         guard row >= 0, let node = outlineView.item(atRow: row) as? TOCNode else { return }
         onSelectHeading?(node.headingID)
     }
+}
+
+private final class TitleItem {
+    let title: String
+    init(title: String) { self.title = title }
 }
 
 final class TOCNode {
@@ -103,12 +99,13 @@ extension SidebarViewController: NSOutlineViewDataSource {
 
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
         if let node = item as? TOCNode { return node.children.count }
-        return roots.count
+        return roots.count + titleOffset
     }
 
     func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
         if let node = item as? TOCNode { return node.children[index] }
-        return roots[index]
+        if let titleItem, index == 0 { return titleItem }
+        return roots[index - titleOffset]
     }
 
     func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
@@ -122,6 +119,9 @@ extension SidebarViewController: NSOutlineViewDelegate {
     func outlineView(_ outlineView: NSOutlineView,
                      viewFor tableColumn: NSTableColumn?,
                      item: Any) -> NSView? {
+        if let titleItem = item as? TitleItem {
+            return titleCell(for: titleItem, in: outlineView)
+        }
         guard let node = item as? TOCNode else { return nil }
 
         let identifier = NSUserInterfaceItemIdentifier("TOCCell")
@@ -152,6 +152,45 @@ extension SidebarViewController: NSOutlineViewDelegate {
         }
 
         cell.textField?.stringValue = node.title
+        return cell
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
+        return item is TOCNode
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
+        if item is TitleItem { return 27 }
+        return 29
+    }
+
+    private func titleCell(for titleItem: TitleItem, in outlineView: NSOutlineView) -> NSView {
+        let identifier = NSUserInterfaceItemIdentifier("TitleCell")
+        let cell: NSTableCellView
+        if let recycled = outlineView.makeView(withIdentifier: identifier, owner: self) as? NSTableCellView {
+            cell = recycled
+        } else {
+            cell = NSTableCellView()
+            cell.identifier = identifier
+
+            let textField = NSTextField(labelWithString: "")
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            textField.font = NSFont.systemFont(ofSize: 12, weight: .semibold)
+            textField.textColor = .secondaryLabelColor
+            textField.lineBreakMode = .byTruncatingMiddle
+            textField.cell?.usesSingleLineMode = true
+            textField.maximumNumberOfLines = 1
+            cell.addSubview(textField)
+            cell.textField = textField
+
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+                textField.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+                textField.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
+                textField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -4)
+            ])
+        }
+        cell.textField?.stringValue = titleItem.title
         return cell
     }
 }


### PR DESCRIPTION
## Summary
- Find bar's mode picker swapped from `NSSegmentedControl` to two `NSButton` toggles fronted by a `Match:` label — matches Preview's mode picker (`NSButtonCell`, `AXToggle` subrole). Single click handler dispatches by sender identity with early-return when state is already correct.
- Find-bar accessory opts into the macOS 26.1+ `preferredScrollEdgeEffectStyle = .hard` via a new optional `configure:` closure on `addBottomTitlebarAccessory(_:)`. Toolbar gains `allowsUserCustomization = true`.
- Sidebar file name moved out of a sticky `NSTextField` header into the outline view itself as a non-selectable first row (`TitleItem`), so the title scrolls with the heading list. Switched from `usesAutomaticRowHeights` to fixed heights via `heightOfRowByItem` (27 for title, 29 for TOC nodes).
- `SidebarViewController.display(...)` skips the parse + reload + re-expand cycle when both `markdown` and `fileName` are unchanged.
- `MarkdownHTML.swift` drops the redundant `::-webkit-scrollbar { display: initial !important; … }` line from the `allowsScroll` override; the default stylesheet already omits any `::-webkit-scrollbar` rule, so WebKit reverts to the macOS native overlay scrollbar.

## Test plan
- [ ] Cmd+F opens find bar; \`Match:\` label sits in front of the two toggle buttons
- [ ] Clicking Contains / Begins With swaps the active toggle and triggers a re-search
- [ ] Re-clicking the already-active toggle is a no-op (no redundant search)
- [ ] On macOS 26.1+, find-bar pinned area shows the hard scroll-edge effect (opaque backing, sharp boundary against scrolling content)
- [ ] On macOS 15 / 26.0, behavior is unchanged (no scroll edge effect, no crash on the `#available` branch)
- [ ] Sidebar shows file name as the first scrollable row; scrolls away when the TOC scrolls
- [ ] Title row is not selectable (clicking it does nothing)
- [ ] Re-displaying the same file (e.g. via file watcher refresh with identical content) is a no-op in the sidebar — expansion state preserved, no flicker
- [ ] Sidebar drag, window resize, and native overlay scrollbar still behave correctly