### PR TITLE
Fix window collapse from NSBox separator in titlebar accessory

### DIFF
--- a/md-preview/FindBar.swift
+++ b/md-preview/FindBar.swift
@@ -22,7 +22,7 @@ final class FindBar: NSView {
     private let countLabel = NSTextField(labelWithString: "")
     private let navigationControl = NSSegmentedControl()
     private let doneButton = NSButton(title: "Done", target: nil, action: nil)
-    private let bottomSeparator = NSBox()
+    private let bottomSeparator = HairlineSeparator()
 
     private enum NavigationSegment: Int {
         case previous = 0
@@ -85,12 +85,15 @@ final class FindBar: NSView {
         // macOS 26 dropped the system-drawn separators around titlebar
         // accessories, so we draw our own bottom rule. macOS 15 still draws
         // them, so hiding ours avoids a doubled line there.
+        // NSBox(.separator) inside a bottom titlebar accessory triggers a macOS
+        // 26 layout regression that bypasses the window's contentMinSize and
+        // collapses the window to the toolbar's natural minimum width — use a
+        // plain NSView with a 1pt separator-colored layer instead.
         let needsManualSeparator: Bool = {
             if #available(macOS 26.0, *) { return true }
             return false
         }()
 
-        bottomSeparator.boxType = .separator
         bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
         bottomSeparator.isHidden = !needsManualSeparator
         addSubview(bottomSeparator)

--- a/md-preview/HairlineSeparator.swift
+++ b/md-preview/HairlineSeparator.swift
@@ -1,0 +1,33 @@
+//
+//  HairlineSeparator.swift
+//  md-preview
+//
+
+import Cocoa
+
+/// 1pt separator-colored hairline. Replacement for `NSBox(.separator)` —
+/// `NSBox.separator` inside a bottom `NSTitlebarAccessoryViewController`
+/// triggers a macOS 26 layout regression that bypasses the window's
+/// `contentMinSize` and collapses the window to the toolbar's natural
+/// minimum width.
+final class HairlineSeparator: NSView {
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+
+    private func configure() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.separatorColor.cgColor
+    }
+
+    override func updateLayer() {
+        layer?.backgroundColor = NSColor.separatorColor.cgColor
+    }
+}

--- a/md-preview/MissingFolderAccessBanner.swift
+++ b/md-preview/MissingFolderAccessBanner.swift
@@ -15,8 +15,8 @@ final class MissingFolderAccessBanner: NSView {
 
     private let messageLabel = NSTextField(labelWithString: "")
     private let allowButton = NSButton(title: "Allow Access", target: nil, action: nil)
-    private let topSeparator = NSBox()
-    private let bottomSeparator = NSBox()
+    private let topSeparator = HairlineSeparator()
+    private let bottomSeparator = HairlineSeparator()
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -71,12 +71,10 @@ final class MissingFolderAccessBanner: NSView {
             return false
         }()
 
-        topSeparator.boxType = .separator
         topSeparator.translatesAutoresizingMaskIntoConstraints = false
         topSeparator.isHidden = !needsManualSeparators
         addSubview(topSeparator)
 
-        bottomSeparator.boxType = .separator
         bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
         bottomSeparator.isHidden = !needsManualSeparators
         addSubview(bottomSeparator)


### PR DESCRIPTION
## Summary

Fixes #79 — on macOS 26, the app launches with a ~169pt-wide window that only resizes vertically, and toggling the sidebar makes the window disappear.

## Root cause

An `NSBox` with `boxType = .separator` placed inside a bottom `NSTitlebarAccessoryViewController` view triggers a macOS 26 layout regression that bypasses the window's `contentMinSize` and snaps the window to the toolbar's natural minimum width (~169pt) on launch.

Bisect:

| Variant | Saved frame |
|---|---|
| No find-bar accessory | 1100 × 720 (default) |
| Empty `NSView` accessory | 700 × 720 (clamped to `contentMinSize`) |
| `NSBox` w/ default boxType | 700 × 720 |
| Plain `NSView` w/ same constraints | 700 × 720 |
| **`NSBox` w/ `.separator` boxType** | **169 × 720** (`contentMinSize` bypassed) |

## Fix

Introduce `HairlineSeparator` — a 1pt `NSView` whose layer is filled with `NSColor.separatorColor`. Same look as `NSBox(.separator)` but doesn't trip the regression. Apply it to:

- `FindBar.bottomSeparator` — the actual trigger.
- `MissingFolderAccessBanner.topSeparator` / `bottomSeparator` — precautionary; same pattern, hasn't been observed to trigger but no reason to keep the foot-gun.

## Test plan

- [x] Verified fresh-install launch on macOS 26.4.1 / Dark Mode opens at 1100 × 720 instead of 169 × 720
- [x] Horizontal resize works
- [x] Toggling sidebar widens the window instead of clipping
- [x] Find bar still renders correctly when invoked (Cmd-F)
- [x] Access banner separators render correctly when banner is shown