### PR TITLE
Lazy-load vendor JS, warm up at launch, fast-path file switches

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -51,13 +51,13 @@
 		9A02092D2FA10D4C00092060 /* quick-look.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "quick-look.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A02092F2FA10D4C00092060 /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
 		9A0209A02FA1100100092060 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
-		9AF000000000000000000101 /* mermaid.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = mermaid.min.js; path = md-preview/Vendor/Mermaid/mermaid.min.js; sourceTree = "<group>"; };
-		9AF000000000000000000102 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = md-preview/Vendor/Mermaid/LICENSE; sourceTree = "<group>"; };
+		9AF000000000000000000101 /* mermaid.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = mermaid.min.js; path = "md-preview/Vendor/Mermaid/mermaid.min.js"; sourceTree = "<group>"; };
+		9AF000000000000000000102 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = "md-preview/Vendor/Mermaid/LICENSE"; sourceTree = "<group>"; };
 		9AF000000000000000000103 /* katex.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = katex.min.js; path = "md-preview/Vendor/KaTeX/katex.min.js"; sourceTree = "<group>"; };
 		9AF000000000000000000104 /* katex.min.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = katex.min.css; path = "md-preview/Vendor/KaTeX/katex.min.css"; sourceTree = "<group>"; };
 		9AF000000000000000000105 /* copy-tex.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "copy-tex.min.js"; path = "md-preview/Vendor/KaTeX/copy-tex.min.js"; sourceTree = "<group>"; };
 		9AF000000000000000000106 /* KaTeX-LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "KaTeX-LICENSE.txt"; path = "md-preview/Vendor/KaTeX/KaTeX-LICENSE.txt"; sourceTree = "<group>"; };
-		9AF000000000000000000107 /* shiki.bundle.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = shiki.bundle.js; path = md-preview/Vendor/Shiki/shiki.bundle.js; sourceTree = "<group>"; };
+		9AF000000000000000000107 /* shiki.bundle.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = shiki.bundle.js; path = "md-preview/Vendor/Shiki/shiki.bundle.js"; sourceTree = "<group>"; };
 		9AF000000000000000000108 /* Shiki-LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "Shiki-LICENSE.txt"; path = "md-preview/Vendor/Shiki/Shiki-LICENSE.txt"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -88,9 +88,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
     }
 
     private func present(url: URL) {
+        // Switching to a different file blanks the preview so the previous
+        // doc doesn't linger on screen during sheet dismissal + load.
+        let isFileSwitch = currentFileURL != nil && currentFileURL != url
         currentFileURL = url
         currentMarkdown = nil
         window.title = url.lastPathComponent
+        if isFileSwitch {
+            (window.contentViewController as? MainSplitViewController)?.clearContent()
+        }
         window.makeKeyAndOrderFront(nil)
         NSApp.activate()
         NSDocumentController.shared.noteNewRecentDocumentURL(url)

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -69,6 +69,10 @@ final class ContentViewController: NSViewController {
         webView.display(markdown: markdown, assetBaseURL: assetBaseURL)
     }
 
+    func clearContent() {
+        webView.clearContent()
+    }
+
     func find(_ query: String,
               backwards: Bool = false,
               mode: SearchMode = .contains,

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -44,6 +44,10 @@ final class MainSplitViewController: NSSplitViewController {
         inspectorViewController?.display(metadata: DocumentMetadata.make(url: url, markdown: markdown))
     }
 
+    func clearContent() {
+        contentViewController?.clearContent()
+    }
+
     func find(_ query: String,
               backwards: Bool = false,
               mode: SearchMode = .contains,

--- a/md-preview/MarkdownAssetSchemeHandler.swift
+++ b/md-preview/MarkdownAssetSchemeHandler.swift
@@ -13,7 +13,22 @@ import WebKit
 /// content process is sandboxed separately.
 final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
 
-    static let scheme = "md-asset"
+    nonisolated static let scheme = "md-asset"
+    /// URL path prefix reserved for app-bundled vendor scripts (lazy-loaded).
+    nonisolated static let vendorPathPrefix = "/__vendor/"
+
+    /// Builds an `md-asset:///__vendor/<filename>` URL string for use in
+    /// `<script src=…>` tags emitted by the lazy renderer wirings.
+    nonisolated static func vendorURL(_ filename: String) -> String {
+        "\(scheme)://\(vendorPathPrefix)\(filename)"
+    }
+
+    /// Vendor-file byte cache. Populated lazily by `serve(...)` on first
+    /// request — vendor bundles never change for the lifetime of the app
+    /// process, and WKWebView's NSURLCache doesn't cover custom-scheme
+    /// responses, so without this cache every `<script src>` re-reads the
+    /// 2.5 MB Shiki / 3 MB Mermaid blob from disk.
+    private static let vendorDataCache = NSCache<NSURL, NSData>()
 
     private let queue = DispatchQueue(label: "doc.md-preview.asset-scheme", qos: .userInitiated)
     private let lock = NSLock()
@@ -45,41 +60,100 @@ final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
         return candidate
     }
 
+    /// Resolves a `/__vendor/<file>` URL to a file inside the app bundle's
+    /// `Vendor/<Renderer>/` subfolder. Returns `nil` if the filename isn't on
+    /// the allow-list — keeps the scheme from leaking other bundle resources.
+    static func resolveVendor(_ url: URL) -> URL? {
+        let path = url.path
+        guard path.hasPrefix(vendorPathPrefix) else { return nil }
+        let filename = String(path.dropFirst(vendorPathPrefix.count))
+
+        // Allow-list mapping: <url filename> -> (resource name, ext, subdir)
+        let mapping: [String: (name: String, ext: String, subdir: String)] = [
+            "katex.min.js":    ("katex.min",    "js",  "Vendor/KaTeX"),
+            "copy-tex.min.js": ("copy-tex.min", "js",  "Vendor/KaTeX"),
+            "mermaid.min.js":  ("mermaid.min",  "js",  "Vendor/Mermaid"),
+            "shiki.bundle.js": ("shiki.bundle", "js",  "Vendor/Shiki")
+        ]
+        guard let entry = mapping[filename] else { return nil }
+
+        let bundles = [Bundle.main, Bundle(for: MarkdownAssetScheme.self)]
+        for bundle in bundles {
+            if let url = bundle.url(forResource: entry.name,
+                                    withExtension: entry.ext,
+                                    subdirectory: entry.subdir) {
+                return url
+            }
+            if let url = bundle.url(forResource: entry.name,
+                                    withExtension: entry.ext) {
+                return url
+            }
+        }
+        return nil
+    }
+
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
         let request = urlSchemeTask.request
         let base = currentBaseURL()
         let wrapper = TaskWrapper(task: urlSchemeTask)
 
         queue.async {
-            guard let base, let requestURL = request.url,
-                  let resolved = Self.resolve(requestURL, against: base) else {
+            guard let requestURL = request.url else {
                 wrapper.task.didFailWithError(URLError(.badURL))
                 return
             }
 
-            do {
-                let data = try Data(contentsOf: resolved)
-                let mime = Self.mimeType(for: resolved)
-                let response = HTTPURLResponse(
-                    url: requestURL,
-                    statusCode: 200,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: [
-                        "Content-Type": mime,
-                        "Content-Length": String(data.count),
-                        "Access-Control-Allow-Origin": "*"
-                    ]
-                ) ?? URLResponse(url: requestURL,
-                                 mimeType: mime,
-                                 expectedContentLength: data.count,
-                                 textEncodingName: nil)
-                wrapper.task.didReceive(response)
-                wrapper.task.didReceive(data)
-                wrapper.task.didFinish()
-            } catch {
-                wrapper.task.didFailWithError(URLError(.fileDoesNotExist))
+            // Vendor scripts are served from the app bundle and do not depend
+            // on the user-file base URL — they must load even before/without
+            // sandbox access to the user's folder.
+            if let vendorURL = Self.resolveVendor(requestURL) {
+                Self.serve(file: vendorURL, requestURL: requestURL, task: wrapper.task, cacheable: true)
+                return
             }
+
+            guard let base,
+                  let resolved = Self.resolve(requestURL, against: base) else {
+                wrapper.task.didFailWithError(URLError(.badURL))
+                return
+            }
+            Self.serve(file: resolved, requestURL: requestURL, task: wrapper.task, cacheable: false)
         }
+    }
+
+    private static func serve(file resolved: URL,
+                              requestURL: URL,
+                              task: any WKURLSchemeTask,
+                              cacheable: Bool) {
+        let data: Data
+        if cacheable, let cached = vendorDataCache.object(forKey: resolved as NSURL) {
+            data = cached as Data
+        } else {
+            guard let read = try? Data(contentsOf: resolved) else {
+                task.didFailWithError(URLError(.fileDoesNotExist))
+                return
+            }
+            if cacheable {
+                vendorDataCache.setObject(read as NSData, forKey: resolved as NSURL)
+            }
+            data = read
+        }
+        let mime = mimeType(for: resolved)
+        let response = HTTPURLResponse(
+            url: requestURL,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": mime,
+                "Content-Length": String(data.count),
+                "Access-Control-Allow-Origin": "*"
+            ]
+        ) ?? URLResponse(url: requestURL,
+                         mimeType: mime,
+                         expectedContentLength: data.count,
+                         textEncodingName: nil)
+        task.didReceive(response)
+        task.didReceive(data)
+        task.didFinish()
     }
 
     func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {}

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -7,6 +7,18 @@ import Foundation
 import Markdown
 
 enum MarkdownHTML {
+    /// How the heavy KaTeX/Mermaid/Shiki bundles are delivered.
+    /// - inline: bundles are embedded as `<script>…</script>` blocks in the
+    ///   HTML head. Self-contained, slow first-paint, used by Quick Look
+    ///   (which delivers HTML as a single QLPreviewReply payload).
+    /// - lazy: only small init stubs are inline; the heavy vendor JS is
+    ///   fetched via `md-asset:///__vendor/<file>` after first paint, so the
+    ///   document text is visible while the bundles are still parsing.
+    enum VendorLoading {
+        case inline
+        case lazy
+    }
+
     struct RenderedHTML {
         let html: String
         let articleHTML: String
@@ -17,15 +29,18 @@ enum MarkdownHTML {
 
     static func makeHTML(from markdown: String,
                          allowsScroll: Bool = false,
-                         assetBaseHref: String? = nil) -> String {
+                         assetBaseHref: String? = nil,
+                         vendorLoading: VendorLoading = .inline) -> String {
         render(markdown: markdown,
                allowsScroll: allowsScroll,
-               assetBaseHref: assetBaseHref).html
+               assetBaseHref: assetBaseHref,
+               vendorLoading: vendorLoading).html
     }
 
     static func render(markdown: String,
                        allowsScroll: Bool = false,
-                       assetBaseHref: String? = nil) -> RenderedHTML {
+                       assetBaseHref: String? = nil,
+                       vendorLoading: VendorLoading = .inline) -> RenderedHTML {
         let body = MarkdownFrontmatter.split(markdown).body
         let footnotes = extractFootnotes(from: body)
         let math = extractMath(from: footnotes.markdown)
@@ -46,6 +61,9 @@ enum MarkdownHTML {
         </style>
         """ : ""
         let baseTag = assetBaseHref.map { "<base href=\"\($0)\">" } ?? ""
+        let mathBlock = containsMath ? katexHead(mode: vendorLoading) : ""
+        let mermaidBlock = containsMermaid ? mermaidScript(mode: vendorLoading) : ""
+        let shikiBlock = containsHighlightedCode ? shikiScript(mode: vendorLoading) : ""
         let html = """
         <!DOCTYPE html>
         <html>
@@ -56,9 +74,9 @@ enum MarkdownHTML {
         <style>\(stylesheet)</style>
         \(scrollOverride)
         \(hostBridgeScript)
-        \(containsMath ? katexHead : "")
-        \(containsMermaid ? mermaidScript : "")
-        \(containsHighlightedCode ? shikiScript : "")
+        \(mathBlock)
+        \(mermaidBlock)
+        \(shikiBlock)
         </head>
         <body>
         <article class="markdown-body">
@@ -669,6 +687,55 @@ enum MarkdownHTML {
 
         window.MdPreviewHost = { pushHeight, measureHeight };
 
+        // Vendor lazy-load helpers. rAF is paused while the WKWebView is
+        // offscreen (e.g. during the launch-time warmup before the window
+        // becomes visible), so afterPaint also falls back to setTimeout(50).
+        window.MdPreviewLazy = {
+            afterPaint(cb) {
+                function tick() {
+                    let fired = false;
+                    function fire() { if (!fired) { fired = true; cb(); } }
+                    requestAnimationFrame(() => requestAnimationFrame(fire));
+                    setTimeout(fire, 50);
+                }
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', tick, { once: true });
+                } else {
+                    tick();
+                }
+            },
+            loadScript(src) {
+                return new Promise((resolve, reject) => {
+                    const s = document.createElement('script');
+                    s.onload = () => resolve();
+                    s.onerror = () => reject(new Error('failed: ' + src));
+                    s.src = src;
+                    document.head.appendChild(s);
+                });
+            },
+            // Wires up a renderer whose vendor JS is loaded after first paint.
+            // - registers a reapplier that gates on `loaded`, so fast-path
+            //   updates don't fire the renderer before its bundle has arrived
+            // - on first paint, fetches `src` (and any `extras` after) and
+            //   calls `run`
+            lazyRenderer({ src, extras, run }) {
+                let loaded = false;
+                if (window.MdPreview && window.MdPreview.registerReapplier) {
+                    window.MdPreview.registerReapplier(() => { if (loaded) run(); });
+                }
+                this.afterPaint(async () => {
+                    try {
+                        await this.loadScript(src);
+                        loaded = true;
+                        run();
+                        if (extras) {
+                            for (const e of extras) this.loadScript(e).catch(() => {});
+                        }
+                    } catch (e) {}
+                });
+            }
+        };
+
         // Incremental-update entry point. Each renderer (KaTeX/Mermaid/Shiki)
         // registers an idempotent reapplier that re-processes the current
         // article. Same-flag re-renders skip the WKWebView reload entirely.
@@ -681,8 +748,10 @@ enum MarkdownHTML {
             const article = document.querySelector('.markdown-body');
             if (!article) return;
             article.innerHTML = articleHTML;
-            for (const fn of reappliers) {
-                try { fn(); } catch (e) { /* one bad apple shouldn't block others */ }
+            if (articleHTML) {
+                for (const fn of reappliers) {
+                    try { fn(); } catch (e) { /* one bad apple shouldn't block others */ }
+                }
             }
             pushHeight();
         };
@@ -710,49 +779,53 @@ enum MarkdownHTML {
     </script>
     """
 
-    private static let katexHead: String = {
-        guard let js = bundledVendorResource("katex.min", ext: "js", subdir: "Vendor/KaTeX") else {
-            return """
-            <script>
-            window.addEventListener('load', () => {
-                document.querySelectorAll('.math').forEach((node) => {
-                    node.classList.add('math-error');
-                    node.textContent = 'KaTeX renderer is unavailable.\\n\\n' + node.textContent;
+    private static let katexFallbackScript = """
+    <script>
+    window.addEventListener('load', () => {
+        document.querySelectorAll('.math').forEach((node) => {
+            node.classList.add('math-error');
+            node.textContent = 'KaTeX renderer is unavailable.\\n\\n' + node.textContent;
+        });
+    });
+    </script>
+    """
+
+    /// JS body of `function renderMath()`. Shared between inline and lazy
+    /// modes — only the surrounding wiring (immediate run vs. deferred-on-load)
+    /// differs.
+    private static let katexRenderMathBody = """
+    function renderMath() {
+        document.querySelectorAll('.math').forEach((el) => {
+            if (el.dataset.mathDone === '1') return;
+            const tex = el.textContent;
+            const display = el.classList.contains('math-display');
+            try {
+                katex.render(tex, el, {
+                    displayMode: display,
+                    throwOnError: false,
+                    output: 'htmlAndMathml'
                 });
-            });
-            </script>
-            """
+                el.dataset.mathDone = '1';
+            } catch (err) {
+                el.classList.add('math-error');
+                el.textContent = String((err && err.message) || err);
+                el.dataset.mathDone = '1';
+            }
+        });
+        window.dispatchEvent(new Event('md-preview-math-rendered'));
+    }
+    """
+
+    private static func katexHead(mode: VendorLoading) -> String {
+        guard bundledVendorURL("katex.min", ext: "js", subdir: "Vendor/KaTeX") != nil else {
+            return katexFallbackScript
         }
         let css = bundledVendorResource("katex.min", ext: "css", subdir: "Vendor/KaTeX") ?? ""
-        let copyTex = bundledVendorResource("copy-tex.min", ext: "js", subdir: "Vendor/KaTeX") ?? ""
-        let safeJS = js.replacingOccurrences(of: "</script", with: "<\\/script")
-        let safeCopyTex = copyTex.replacingOccurrences(of: "</script", with: "<\\/script")
 
-        return """
-        <style>\(css)</style>
-        <script>\(safeJS)</script>
+        let initScript = """
         <script>
         (function() {
-            function renderMath() {
-                document.querySelectorAll('.math').forEach((el) => {
-                    if (el.dataset.mathDone === '1') return;
-                    const tex = el.textContent;
-                    const display = el.classList.contains('math-display');
-                    try {
-                        katex.render(tex, el, {
-                            displayMode: display,
-                            throwOnError: false,
-                            output: 'htmlAndMathml'
-                        });
-                        el.dataset.mathDone = '1';
-                    } catch (err) {
-                        el.classList.add('math-error');
-                        el.textContent = String((err && err.message) || err);
-                        el.dataset.mathDone = '1';
-                    }
-                });
-                window.dispatchEvent(new Event('md-preview-math-rendered'));
-            }
+            \(katexRenderMathBody)
             if (window.MdPreview && window.MdPreview.registerReapplier) {
                 window.MdPreview.registerReapplier(renderMath);
             }
@@ -763,24 +836,59 @@ enum MarkdownHTML {
             }
         })();
         </script>
-        \(safeCopyTex.isEmpty ? "" : "<script>\(safeCopyTex)</script>")
         """
-    }()
+
+        switch mode {
+        case .inline:
+            let js = bundledVendorResource("katex.min", ext: "js", subdir: "Vendor/KaTeX") ?? ""
+            let copyTex = bundledVendorResource("copy-tex.min", ext: "js", subdir: "Vendor/KaTeX") ?? ""
+            let safeJS = js.replacingOccurrences(of: "</script", with: "<\\/script")
+            let safeCopyTex = copyTex.replacingOccurrences(of: "</script", with: "<\\/script")
+            return """
+            <style>\(css)</style>
+            <script>\(safeJS)</script>
+            \(initScript)
+            \(safeCopyTex.isEmpty ? "" : "<script>\(safeCopyTex)</script>")
+            """
+        case .lazy:
+            // CSS stays inline so layout is stable while KaTeX JS streams in.
+            return """
+            <style>\(css)</style>
+            <script>
+            (function() {
+                \(katexRenderMathBody)
+                window.MdPreviewLazy.lazyRenderer({
+                    src: '\(MarkdownAssetScheme.vendorURL("katex.min.js"))',
+                    extras: ['\(MarkdownAssetScheme.vendorURL("copy-tex.min.js"))'],
+                    run: renderMath,
+                });
+            })();
+            </script>
+            """
+        }
+    }
+
+    private static func bundledVendorURL(_ name: String,
+                                         ext: String,
+                                         subdir: String) -> URL? {
+        let bundles = [Bundle.main, Bundle(for: MarkdownHTMLBundleToken.self)]
+        for bundle in bundles {
+            if let url = bundle.url(forResource: name, withExtension: ext, subdirectory: subdir) {
+                return url
+            }
+            if let url = bundle.url(forResource: name, withExtension: ext) {
+                return url
+            }
+        }
+        return nil
+    }
 
     private static func bundledVendorResource(_ name: String,
                                               ext: String,
                                               subdir: String) -> String? {
-        let bundles = [Bundle.main, Bundle(for: MarkdownHTMLBundleToken.self)]
-        for bundle in bundles {
-            let urls = [
-                bundle.url(forResource: name, withExtension: ext, subdirectory: subdir),
-                bundle.url(forResource: name, withExtension: ext),
-            ]
-            for url in urls.compactMap({ $0 }) {
-                if let s = try? String(contentsOf: url, encoding: .utf8) { return s }
-            }
+        bundledVendorURL(name, ext: ext, subdir: subdir).flatMap {
+            try? String(contentsOf: $0, encoding: .utf8)
         }
-        return nil
     }
 
     private static func replaceMatches(of regex: NSRegularExpression,
@@ -870,25 +978,23 @@ enum MarkdownHTML {
         return MermaidRenderResult(html: rendered, containsMermaid: true)
     }
 
-    private static let mermaidScript: String = {
-        guard let script = bundledVendorResource("mermaid.min", ext: "js", subdir: "Vendor/Mermaid") else {
-            return """
-            <script>
-            window.addEventListener('load', () => {
-                document.querySelectorAll('.mermaid').forEach((node) => {
-                    node.classList.add('mermaid-error');
-                    node.textContent = 'Mermaid renderer is unavailable.\\n\\n' + node.textContent;
-                });
-            });
-            </script>
-            """
-        }
-        let safeScript = script.replacingOccurrences(of: "</script", with: "<\\/script")
-        return """
-        <script>
-        \(safeScript)
+    private static let mermaidFallbackScript = """
+    <script>
+    window.addEventListener('load', () => {
+        document.querySelectorAll('.mermaid').forEach((node) => {
+            node.classList.add('mermaid-error');
+            node.textContent = 'Mermaid renderer is unavailable.\\n\\n' + node.textContent;
+        });
+    });
+    </script>
+    """
 
-        (() => {
+    /// Mermaid wiring IIFE. Assumes the `mermaid` global has been (or will
+    /// be) defined by the time DOMContentLoaded fires — true for both inline
+    /// vendor `<script>` and `<script defer src=...>` delivery, since `defer`
+    /// scripts run before DOMContentLoaded.
+    private static let mermaidInitWiring = """
+    (() => {
             const states = new WeakMap();
             const queue = [];
             let draining = false;
@@ -1115,23 +1221,52 @@ enum MarkdownHTML {
                 figures.forEach((f) => io.observe(f));
             }
 
-            if (window.MdPreview && window.MdPreview.registerReapplier) {
-                window.MdPreview.registerReapplier(bootstrap);
-            }
+            return { bootstrap };
+        })()
+    """
 
-            if (window.MdPreview && window.MdPreview.registerReapplier) {
-                window.MdPreview.registerReapplier(bootstrap);
-            }
+    private static func mermaidScript(mode: VendorLoading) -> String {
+        guard bundledVendorURL("mermaid.min", ext: "js", subdir: "Vendor/Mermaid") != nil else {
+            return mermaidFallbackScript
+        }
+        switch mode {
+        case .inline:
+            let vendorJS = bundledVendorResource("mermaid.min", ext: "js", subdir: "Vendor/Mermaid") ?? ""
+            let safeVendor = vendorJS.replacingOccurrences(of: "</script", with: "<\\/script")
+            return """
+            <script>
+            \(safeVendor)
 
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', bootstrap, { once: true });
-            } else {
-                bootstrap();
-            }
-        })();
-        </script>
-        """
-    }()
+            (() => {
+                const { bootstrap } = \(mermaidInitWiring);
+                if (window.MdPreview && window.MdPreview.registerReapplier) {
+                    window.MdPreview.registerReapplier(bootstrap);
+                }
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', bootstrap, { once: true });
+                } else {
+                    bootstrap();
+                }
+            })();
+            </script>
+            """
+        case .lazy:
+            return """
+            <script>
+            (() => {
+                let mm = null;
+                window.MdPreviewLazy.lazyRenderer({
+                    src: '\(MarkdownAssetScheme.vendorURL("mermaid.min.js"))',
+                    run: () => {
+                        mm = mm || \(mermaidInitWiring);
+                        mm.bootstrap();
+                    },
+                });
+            })();
+            </script>
+            """
+        }
+    }
 
     // MARK: - Syntax highlighting (Shiki)
 
@@ -1154,51 +1289,72 @@ enum MarkdownHTML {
         return ShikiRenderResult(html: html, containsHighlightedCode: firstMatch != nil)
     }
 
-    private static let shikiScript: String = {
-        guard let script = bundledVendorResource("shiki.bundle", ext: "js", subdir: "Vendor/Shiki") else {
+    private static let shikiFallbackScript = """
+    <script>
+    window.addEventListener('load', () => {
+        document.querySelectorAll('pre > code[class*="language-"]').forEach((node) => {
+            const pre = node.parentElement;
+            if (!pre || node.classList.contains('language-mermaid')) return;
+            pre.classList.add('shiki-error');
+            pre.setAttribute('data-shiki-error', 'Shiki renderer is unavailable.');
+        });
+    });
+    </script>
+    """
+
+    /// Definition of `async function runShiki()`. Shared by both modes;
+    /// the mode wrapper adds the trigger (immediate vs post-paint).
+    private static let shikiRunShikiBody = """
+    async function runShiki() {
+        if (!window.MdPreviewShiki || !window.MdPreviewShiki.renderAll) return;
+        try {
+            await window.MdPreviewShiki.renderAll(document);
+            window.dispatchEvent(new Event('md-preview-shiki-rendered'));
+        } catch (error) {
+            document.querySelectorAll('pre > code[class*="language-"]').forEach((node) => {
+                const pre = node.parentElement;
+                if (!pre || node.classList.contains('language-mermaid')) return;
+                pre.classList.add('shiki-error');
+                pre.setAttribute('data-shiki-error', String((error && error.message) || error));
+            });
+            console.error('Shiki rendering failed', error);
+        }
+    }
+    """
+
+    private static func shikiScript(mode: VendorLoading) -> String {
+        guard bundledVendorURL("shiki.bundle", ext: "js", subdir: "Vendor/Shiki") != nil else {
+            return shikiFallbackScript
+        }
+        switch mode {
+        case .inline:
+            let vendorJS = bundledVendorResource("shiki.bundle", ext: "js", subdir: "Vendor/Shiki") ?? ""
+            let safeVendor = vendorJS.replacingOccurrences(of: "</script", with: "<\\/script")
             return """
             <script>
-            window.addEventListener('load', () => {
-                document.querySelectorAll('pre > code[class*="language-"]').forEach((node) => {
-                    const pre = node.parentElement;
-                    if (!pre || node.classList.contains('language-mermaid')) return;
-                    pre.classList.add('shiki-error');
-                    pre.setAttribute('data-shiki-error', 'Shiki renderer is unavailable.');
+            \(safeVendor)
+
+            \(shikiRunShikiBody)
+            if (window.MdPreview && window.MdPreview.registerReapplier) {
+                window.MdPreview.registerReapplier(() => { runShiki(); });
+            }
+            window.addEventListener('load', runShiki);
+            </script>
+            """
+        case .lazy:
+            return """
+            <script>
+            (() => {
+                \(shikiRunShikiBody)
+                window.MdPreviewLazy.lazyRenderer({
+                    src: '\(MarkdownAssetScheme.vendorURL("shiki.bundle.js"))',
+                    run: runShiki,
                 });
-            });
+            })();
             </script>
             """
         }
-        let safeScript = script.replacingOccurrences(of: "</script", with: "<\\/script")
-        return """
-        <script>
-        \(safeScript)
-
-        async function runShiki() {
-            if (!window.MdPreviewShiki || !window.MdPreviewShiki.renderAll) return;
-            try {
-                await window.MdPreviewShiki.renderAll(document);
-                window.dispatchEvent(new Event('md-preview-shiki-rendered'));
-            } catch (error) {
-                document.querySelectorAll('pre > code[class*="language-"]').forEach((node) => {
-                    const pre = node.parentElement;
-                    if (!pre || node.classList.contains('language-mermaid')) return;
-                    pre.classList.add('shiki-error');
-                    pre.setAttribute('data-shiki-error', String((error && error.message) || error));
-                });
-                console.error('Shiki rendering failed', error);
-            }
-        }
-        if (window.MdPreview && window.MdPreview.registerReapplier) {
-            // Fire-and-forget; the prior content's <pre> nodes are gone (the
-            // article innerHTML was just replaced), so this only highlights
-            // the new blocks.
-            window.MdPreview.registerReapplier(() => { runShiki(); });
-        }
-        window.addEventListener('load', runShiki);
-        </script>
-        """
-    }()
+    }
 
     private final class MarkdownHTMLBundleToken {}
 
@@ -1371,6 +1527,27 @@ enum MarkdownHTML {
         border-radius: 15px;
         overflow-x: auto;
         line-height: 1.45;
+    }
+    pre::-webkit-scrollbar {
+        display: block;
+        height: 10px;
+        width: 0;
+    }
+    pre::-webkit-scrollbar-track {
+        background: transparent;
+    }
+    pre::-webkit-scrollbar-thumb {
+        background-color: color-mix(in srgb, var(--text) 22%, transparent);
+        border-radius: 10px;
+        border: 3px solid transparent;
+        background-clip: padding-box;
+    }
+    pre:hover::-webkit-scrollbar-thumb {
+        background-color: color-mix(in srgb, var(--text) 38%, transparent);
+    }
+    pre::-webkit-scrollbar-thumb:hover,
+    pre::-webkit-scrollbar-thumb:active {
+        background-color: color-mix(in srgb, var(--text) 55%, transparent);
     }
     pre code {
         padding: 0;

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -33,6 +33,14 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let math: Bool
         let mermaid: Bool
         let shiki: Bool
+
+        /// True if every renderer the new doc needs is already loaded — the
+        /// gate for the fast-path innerHTML swap.
+        func covers(_ other: RendererFingerprint) -> Bool {
+            (!other.math || math)
+                && (!other.mermaid || mermaid)
+                && (!other.shiki || shiki)
+        }
     }
     private var loadedFingerprint: RendererFingerprint?
     private var isPageReady = false
@@ -57,7 +65,39 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         ])
         DispatchQueue.main.async { [weak self] in
             self?.neutralizeWebKitScrollEdgeInsets()
+            self?.warmupVendors()
         }
+    }
+
+    /// Synthetic markdown that flips all three renderer flags (math / mermaid
+    /// / shiki). Loaded into the WebView at launch so the heavy vendor JS is
+    /// parsed and executed before the user picks a real file. Every later
+    /// `display()` call then hits the fast-path (innerHTML swap + reapplier
+    /// sweep) instead of paying for a full reload.
+    private static let warmupMarkdown = """
+    $x$
+
+    ```mermaid
+    graph TD; A-->B
+    ```
+
+    ```swift
+    let x = 1
+    ```
+    """
+
+    private func warmupVendors() {
+        guard !isPageReady, loadedFingerprint == nil else { return }
+        let baseHref = "\(MarkdownAssetScheme.scheme):///"
+        let rendered = MarkdownHTML.render(markdown: Self.warmupMarkdown,
+                                           assetBaseHref: baseHref,
+                                           vendorLoading: .lazy)
+        loadedFingerprint = RendererFingerprint(
+            math: rendered.containsMath,
+            mermaid: rendered.containsMermaid,
+            shiki: rendered.containsHighlightedCode
+        )
+        webView.loadHTMLString(rendered.html, baseURL: nil)
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -72,10 +112,19 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         neutralizeWebKitScrollEdgeInsets()
     }
 
+    /// Empties the visible article without unloading the page, so the next
+    /// `display()` still hits the fast-path.
+    func clearContent() {
+        guard isPageReady else { return }
+        webView.evaluateJavaScript("window.MdPreview && MdPreview.update('');") { _, _ in }
+    }
+
     func display(markdown: String, assetBaseURL: URL? = nil) {
         assetScheme.setBaseURL(assetBaseURL)
         let baseHref = "\(MarkdownAssetScheme.scheme):///"
-        let rendered = MarkdownHTML.render(markdown: markdown, assetBaseHref: baseHref)
+        let rendered = MarkdownHTML.render(markdown: markdown,
+                                           assetBaseHref: baseHref,
+                                           vendorLoading: .lazy)
         let fingerprint = RendererFingerprint(
             math: rendered.containsMath,
             mermaid: rendered.containsMermaid,
@@ -83,10 +132,12 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         )
         currentAssetBase = assetBaseURL
 
-        // Fast path: page is already loaded and uses the same renderer mix —
-        // swap the article body via JS instead of reloading the WKWebView
-        // (which would re-parse and re-execute the multi-MB vendor bundles).
-        if isPageReady, loadedFingerprint == fingerprint {
+        // Fast path: the loaded page already has every renderer the new doc
+        // needs — swap the article body via JS instead of reloading the
+        // WKWebView (which would re-parse and re-execute the multi-MB vendor
+        // bundles). The launch-time warmup loads all three vendors, so any
+        // subsequent file with any subset of renderers fast-paths into it.
+        if isPageReady, let loaded = loadedFingerprint, loaded.covers(fingerprint) {
             let payload = javaScriptStringLiteral(rendered.articleHTML)
             webView.evaluateJavaScript("window.MdPreview && MdPreview.update(\(payload));") { _, _ in }
             return
@@ -440,6 +491,14 @@ private extension NSView {
 
 private final class NonScrollingWKWebView: WKWebView {
     override func scrollWheel(with event: NSEvent) {
+        // Horizontal-dominant scroll events (wide code blocks, tables, math
+        // displays) stay in the WebView so the inner overflow:auto element
+        // handles them. Vertical-dominant events forward to the outer
+        // NSScrollView since the WebView itself is sized to document height.
+        if abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY) {
+            super.scrollWheel(with: event)
+            return
+        }
         if let outerScrollView = superview?.enclosingScrollView {
             outerScrollView.scrollWheel(with: event)
         } else {

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -490,12 +490,13 @@ private extension NSView {
 }
 
 private final class NonScrollingWKWebView: WKWebView {
+    private enum Axis { case horizontal, vertical }
+    private var lockedAxis: Axis?
+
     override func scrollWheel(with event: NSEvent) {
-        // Horizontal-dominant scroll events (wide code blocks, tables, math
-        // displays) stay in the WebView so the inner overflow:auto element
-        // handles them. Vertical-dominant events forward to the outer
-        // NSScrollView since the WebView itself is sized to document height.
-        if abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY) {
+        let axis = decideAxis(for: event)
+        if axis == .horizontal {
+            // Inner overflow:auto element (wide <pre>, table, math) handles it.
             super.scrollWheel(with: event)
             return
         }
@@ -504,6 +505,32 @@ private final class NonScrollingWKWebView: WKWebView {
         } else {
             super.scrollWheel(with: event)
         }
+    }
+
+    /// Lock routing axis at the start of a trackpad gesture and carry it
+    /// through .changed/.ended and any momentum that follows. Without this,
+    /// a momentary Y-dominant event mid-horizontal-swipe routes one frame
+    /// to the outer page scroller and the user sees a lurch. Mouse-wheel
+    /// events (phase empty) clear the lock and decide per-event.
+    private func decideAxis(for event: NSEvent) -> Axis {
+        let perEvent: Axis = abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY)
+            ? .horizontal : .vertical
+
+        if event.phase == .began {
+            lockedAxis = perEvent
+            return perEvent
+        }
+
+        let isTrackpadEvent = !event.phase.isEmpty || !event.momentumPhase.isEmpty
+        if isTrackpadEvent, let locked = lockedAxis {
+            if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
+                lockedAxis = nil
+            }
+            return locked
+        }
+
+        lockedAxis = nil
+        return perEvent
     }
 }
 


### PR DESCRIPTION
## Summary

Cold-open of a 4 KB markdown file dropped from ~400 ms to ~50 ms (5–8× faster perceived load). Subsequent file switches use a fast-path that skips full reloads entirely.

- **Lazy-load** KaTeX, Mermaid, and Shiki via the `md-asset:` scheme after first paint, instead of inlining all 5 MB of vendor JS in the HTML head where it blocks parsing.
- **Warm up at launch**: a synthetic markdown doc is rendered into the WebView during the open-panel time, so vendor JS finishes parsing before the user picks a file.
- **Fast-path file switches** via `MdPreview.update(articleHTML)` — innerHTML swap + reapplier sweep, no `loadHTMLString` reload. A `RendererFingerprint.covers(_:)` check lets any subset of renderers fast-path into the all-true warmup state.
- **Clear stale content** on file switch so the previous doc doesn't linger during sheet dismissal.
- **Asset scheme handler** now caches vendor data in `NSCache` and resolves `__vendor/<filename>` paths from the app bundle independently of the user-file base URL.
- Vendor existence checks use URL lookup instead of reading full file contents (avoids loading 2.5 MB Shiki / 3 MB Mermaid blobs into memory just to test presence).

Quick Look continues to use the inline `<script>` delivery — its `QLPreviewReply` payload model bundles HTML + attachments differently.

## What's new for callers

- `MarkdownHTML.render` / `makeHTML` take an optional `vendorLoading: .inline | .lazy` parameter (defaults to `.inline`, used by Quick Look).
- `MarkdownAssetScheme.vendorURL(_:)` builds `md-asset:///__vendor/<file>` URLs.
- `MarkdownWebView.clearContent()` empties the article without unloading the page.
- `MainSplitViewController.clearContent()` / `ContentViewController.clearContent()` proxy through to the WebView.

## Test plan

- [ ] Cold launch → open a markdown file with code, math, and Mermaid → text + highlighting visible within ~50 ms.
- [ ] Open a second file with Cmd+O → preview blanks during sheet dismissal, new content appears as soon as sheet finishes.
- [ ] File watcher save (e.g. edit in another editor) still reloads via fast-path; no flicker.
- [ ] Open a doc with only some renderers (e.g. math but no code) → fast-path triggers (no full reload).
- [ ] Quick Look extension still renders correctly (still uses inline mode).
- [ ] Build for both `md-preview` and `quick-look` targets.