### PR TITLE
Release 0.0.18 (22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.18] – 2026-05-07
+
+A faster cold launch and snappier file switches.
+
+### Added
+
+- **Vendor JS warms up at launch.** A synthetic markdown doc renders into the WebView while the open panel is still on screen, so KaTeX, Mermaid, and Shiki finish parsing before the user picks a file. By the time the picked file lands, the renderers are already ready ([#84](https://github.com/pluk-inc/md-preview.app/pull/84)).
+
+### Changed
+
+- **Cold-open of a 4 KB markdown file dropped from ~400 ms to ~50 ms (5–8× faster perceived load).** Vendor JS (KaTeX, Mermaid, Shiki — ~5 MB total) used to be inlined in the HTML head, blocking the parser on every load. It now lazy-loads after first paint via the `md-asset:` scheme, so the article is visible before the bundles finish downloading. The asset-scheme handler caches vendor blobs in `NSCache` and resolves `__vendor/<file>` paths from the app bundle independently of the user-file base URL. Quick Look continues to use inline delivery because its `QLPreviewReply` payload model bundles HTML and attachments differently ([#84](https://github.com/pluk-inc/md-preview.app/pull/84)).
+- **Switching files takes a fast path instead of a full WebView reload.** When the renderer mix matches what's already loaded, the article body is swapped in place via `MdPreview.update(articleHTML)` and each renderer's idempotent reapplier re-runs — no `loadHTMLString` reload, no vendor re-parse. A `RendererFingerprint.covers(_:)` check lets any subset of renderers fast-path into the all-true warmup state ([#84](https://github.com/pluk-inc/md-preview.app/pull/84)).
+- **Stale content clears while sheets are dismissing.** Opening a new file now blanks the preview during sheet dismissal so the previous doc doesn't linger behind the open panel ([#84](https://github.com/pluk-inc/md-preview.app/pull/84)).
+
 ## [0.0.17] – 2026-05-07
 
 Two macOS 26 fixes — the window opens at full size again, and inline math renders correctly in RTL paragraphs.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.17
-CURRENT_PROJECT_VERSION = 21
+MARKETING_VERSION = 0.0.18
+CURRENT_PROJECT_VERSION = 22

--- a/md-preview/MarkdownAssetSchemeHandler.swift
+++ b/md-preview/MarkdownAssetSchemeHandler.swift
@@ -11,7 +11,7 @@ import WebKit
 /// parent folder. The host process holds the security-scoped extension for
 /// the folder, so FileManager reads succeed even though the WKWebView's
 /// content process is sandboxed separately.
-final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
+nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
 
     nonisolated static let scheme = "md-asset"
     /// URL path prefix reserved for app-bundled vendor scripts (lazy-loaded).
@@ -28,7 +28,7 @@ final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
     /// process, and WKWebView's NSURLCache doesn't cover custom-scheme
     /// responses, so without this cache every `<script src>` re-reads the
     /// 2.5 MB Shiki / 3 MB Mermaid blob from disk.
-    private static let vendorDataCache = NSCache<NSURL, NSData>()
+    private nonisolated static let vendorDataCache = VendorDataCache()
 
     private let queue = DispatchQueue(label: "doc.md-preview.asset-scheme", qos: .userInitiated)
     private let lock = NSLock()
@@ -46,7 +46,7 @@ final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
 
     /// Resolves an `md-asset://…` URL against `base`, rejecting path-traversal
     /// that escapes the granted folder. Returns `nil` for malformed input.
-    static func resolve(_ assetURL: URL, against base: URL) -> URL? {
+    nonisolated static func resolve(_ assetURL: URL, against base: URL) -> URL? {
         var path = assetURL.path
         while path.hasPrefix("/") { path.removeFirst() }
         guard !path.isEmpty else { return nil }
@@ -63,7 +63,7 @@ final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
     /// Resolves a `/__vendor/<file>` URL to a file inside the app bundle's
     /// `Vendor/<Renderer>/` subfolder. Returns `nil` if the filename isn't on
     /// the allow-list — keeps the scheme from leaking other bundle resources.
-    static func resolveVendor(_ url: URL) -> URL? {
+    nonisolated static func resolveVendor(_ url: URL) -> URL? {
         let path = url.path
         guard path.hasPrefix(vendorPathPrefix) else { return nil }
         let filename = String(path.dropFirst(vendorPathPrefix.count))
@@ -120,20 +120,20 @@ final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
         }
     }
 
-    private static func serve(file resolved: URL,
-                              requestURL: URL,
-                              task: any WKURLSchemeTask,
-                              cacheable: Bool) {
+    private nonisolated static func serve(file resolved: URL,
+                                          requestURL: URL,
+                                          task: any WKURLSchemeTask,
+                                          cacheable: Bool) {
         let data: Data
-        if cacheable, let cached = vendorDataCache.object(forKey: resolved as NSURL) {
-            data = cached as Data
+        if cacheable, let cached = vendorDataCache.data(for: resolved) {
+            data = cached
         } else {
             guard let read = try? Data(contentsOf: resolved) else {
                 task.didFailWithError(URLError(.fileDoesNotExist))
                 return
             }
             if cacheable {
-                vendorDataCache.setObject(read as NSData, forKey: resolved as NSURL)
+                vendorDataCache.set(read, for: resolved)
             }
             data = read
         }
@@ -158,11 +158,30 @@ final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
 
     func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {}
 
+    // `WKURLSchemeTask` is an Objective-C protocol without useful Sendable
+    // annotations. The handler immediately moves work onto its private serial
+    // queue and reports results for the same task from there, which matches
+    // WKURLSchemeHandler's callback-style contract.
     private struct TaskWrapper: @unchecked Sendable {
         let task: any WKURLSchemeTask
     }
 
-    private static func mimeType(for url: URL) -> String {
+    // `NSCache` is internally synchronized but is not annotated Sendable by
+    // Foundation. Keep that unchecked assumption behind a tiny value API so the
+    // rest of the scheme handler never shares the cache object directly.
+    private final class VendorDataCache: @unchecked Sendable {
+        private let cache = NSCache<NSURL, NSData>()
+
+        nonisolated func data(for url: URL) -> Data? {
+            cache.object(forKey: url as NSURL) as Data?
+        }
+
+        nonisolated func set(_ data: Data, for url: URL) {
+            cache.setObject(data as NSData, forKey: url as NSURL)
+        }
+    }
+
+    private nonisolated static func mimeType(for url: URL) -> String {
         UTType(filenameExtension: url.pathExtension)?.preferredMIMEType
             ?? "application/octet-stream"
     }


### PR DESCRIPTION
## Summary

Version bump to 0.0.18 (build 22) and changelog entry for the perf release.

## What's in 0.0.18

A faster cold launch and snappier file switches.

### Added

- **Vendor JS warms up at launch.** A synthetic markdown doc renders into the WebView while the open panel is still on screen, so KaTeX, Mermaid, and Shiki finish parsing before the user picks a file (#84).

### Changed

- **Cold-open of a 4 KB markdown file dropped from ~400 ms to ~50 ms (5–8× faster perceived load).** Vendor JS (~5 MB) lazy-loads after first paint via the `md-asset:` scheme instead of being inlined in the HTML head. Quick Look continues to use inline delivery (#84).
- **File switches take a fast path instead of a full WebView reload.** Article HTML is swapped in place via `MdPreview.update(articleHTML)` and renderer reappliers re-run — no `loadHTMLString`, no vendor re-parse (#84).
- **Stale content clears while sheets are dismissing.** Opening a new file blanks the preview during sheet dismissal so the previous doc doesn't linger (#84).

## Test plan

- [ ] Cold launch → open a markdown file with code, math, and Mermaid → text + highlighting visible within ~50 ms
- [ ] Open a second file with Cmd+O → preview blanks during sheet dismissal, new content appears as soon as sheet finishes
- [ ] File watcher save still reloads via fast-path; no flicker
- [ ] Open a doc with only some renderers (e.g. math but no code) → fast-path triggers
- [ ] Quick Look extension still renders correctly
- [ ] Build for both `md-preview` and `quick-look` targets