### PR TITLE
Hide warmup article so synthetic mermaid diagram doesn't flash

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -40,7 +40,8 @@ enum MarkdownHTML {
     static func render(markdown: String,
                        allowsScroll: Bool = false,
                        assetBaseHref: String? = nil,
-                       vendorLoading: VendorLoading = .inline) -> RenderedHTML {
+                       vendorLoading: VendorLoading = .inline,
+                       warmup: Bool = false) -> RenderedHTML {
         let body = MarkdownFrontmatter.split(markdown).body
         let footnotes = extractFootnotes(from: body)
         let math = extractMath(from: footnotes.markdown)
@@ -63,6 +64,13 @@ enum MarkdownHTML {
         let mathBlock = containsMath ? katexHead(mode: vendorLoading) : ""
         let mermaidBlock = containsMermaid ? mermaidScript(mode: vendorLoading) : ""
         let highlightBlock = containsCode ? highlightHead(mode: vendorLoading) : ""
+        // Warmup keeps the article in layout (so Mermaid's IntersectionObserver
+        // still fires and the renderer actually executes) but invisible —
+        // otherwise the synthetic diagram flashes on screen before the first
+        // real document arrives. `MdPreview.update` clears the inline style.
+        let articleStyle = warmup
+            ? " style=\"opacity:0;pointer-events:none\""
+            : ""
         let html = """
         <!DOCTYPE html>
         <html>
@@ -78,7 +86,7 @@ enum MarkdownHTML {
         \(highlightBlock)
         </head>
         <body>
-        <article class="markdown-body">
+        <article class="markdown-body"\(articleStyle)>
         \(bodyHTML)
         </article>
         </body>
@@ -800,6 +808,9 @@ enum MarkdownHTML {
             if (!article) return;
             const tStart = perfNow();
             article.innerHTML = articleHTML;
+            // Reveal the article if the warmup render hid it.
+            article.style.opacity = '';
+            article.style.pointerEvents = '';
             if (articleHTML) {
                 for (const fn of reappliers) {
                     try { fn(); } catch (e) { /* one bad apple shouldn't block others */ }

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -97,7 +97,8 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let baseHref = "\(MarkdownAssetScheme.scheme):///"
         let rendered = MarkdownHTML.render(markdown: Self.warmupMarkdown,
                                            assetBaseHref: baseHref,
-                                           vendorLoading: .lazy)
+                                           vendorLoading: .lazy,
+                                           warmup: true)
         loadedFingerprint = RendererFingerprint(
             math: rendered.containsMath,
             mermaid: rendered.containsMermaid,


### PR DESCRIPTION
## Summary

Follow-up to #84 (launch-time warmup). The warmup render exercises every renderer (KaTeX + Mermaid + highlight.js) so the heavy vendor JS is parsed before the user picks a real file — but the synthetic mermaid diagram was visible for a moment before the first real document arrived.

- Adds a `warmup: true` flag to `MarkdownHTML.render` that emits the article with `opacity: 0; pointer-events: none`. Mermaid's `IntersectionObserver` still fires (the figure is in layout), so the renderer actually runs and warms up — nothing just paints.
- `MdPreview.update(articleHTML)` clears `opacity` / `pointer-events` on the first real article swap, so the user-facing render is unaffected.
- `MarkdownWebView.warmupVendors()` passes `warmup: true`.

## Test plan
- [ ] Cold launch the app and pick a markdown file from the open panel — verify no mermaid diagram or KaTeX flash before the chosen doc renders.
- [ ] Open a doc that has Mermaid blocks — confirm the diagram still renders (warmup didn't break the renderer).
- [ ] Open a doc with KaTeX math — confirm math still renders.
- [ ] Open a doc with code blocks — confirm highlight.js still styles them.
- [ ] Switch between files — fast-path (no full reload) still applies.