### PR TITLE
[codex] Fix toolbar tooltip and TOC title padding

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -615,6 +615,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         )
         group.label = "Zoom"
         group.paletteLabel = "Zoom"
+        group.toolTip = "Zoom"
+        for (subitem, tooltip) in zip(group.subitems, ["Zoom Out", "Zoom In"]) {
+            subitem.toolTip = tooltip
+        }
         // .expanded keeps the two-segment "A A" pair visible like Books / Reader,
         // instead of collapsing into a single button + menu when space is tight.
         group.controlRepresentation = .expanded

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -269,7 +269,7 @@ extension SidebarViewController: NSOutlineViewDelegate {
             cell.textField = textField
 
             NSLayoutConstraint.activate([
-                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
+                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
                 textField.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
                 textField.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
                 textField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -4)


### PR DESCRIPTION
## Summary

- Remove the explicit 4 pt leading inset from the table-of-contents title row so the title aligns flush with its cell.
- Add tooltip metadata to the zoom toolbar group and its Zoom Out / Zoom In subitems, in addition to the existing segmented-control tooltips.

## Why

The TOC title padding needed to be adjusted, and the zoom toolbar buttons were not reliably showing tooltips because the tooltip text was only applied to the backing segmented control view when that view was immediately available. Setting the tooltips on the toolbar group subitems gives AppKit the metadata at the toolbar item level.

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`