### PR TITLE
[codex] Fix sidebar toolbar menu state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.20] – 2026-05-09
+
+The sidebar toolbar menu now stays responsive and shows the correct selected mode after toolbar customization.
+
+### Fixed
+
+- **Sidebar mode menu survives toolbar customization.** The toolbar's Sidebar pull-down no longer lets Customize Toolbar palette copies steal the live menu reference, so Table of Contents and Project Navigator keep responding and their checkmarks stay in sync after closing the native customization sheet.
+
 ## [0.0.19] – 2026-05-09
 
 Syntax highlighting is back without the Shiki startup cost, the sidebar can browse sibling Markdown files, and preview reading controls are easier to reach.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.19
-CURRENT_PROJECT_VERSION = 23
+MARKETING_VERSION = 0.0.20
+CURRENT_PROJECT_VERSION = 24

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -209,7 +209,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
                  itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
                  willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         switch itemIdentifier {
-        case .sidebarMenu: return makeSidebarMenuItem()
+        case .sidebarMenu: return makeSidebarMenuItem(willBeInsertedIntoToolbar: flag)
         case .openWith: return makeOpenWithItem()
         case .inspector: return makeInspectorItem()
         case .share: return makeShareItem()
@@ -221,7 +221,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         }
     }
 
-    private func makeSidebarMenuItem() -> NSToolbarItem {
+    private func makeSidebarMenuItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .sidebarMenu)
         item.label = "Sidebar"
         item.paletteLabel = "Sidebar"
@@ -255,14 +255,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         ])
 
         item.view = container
-        sidebarMenu = menu
-        sidebarPopUpButton = popup
+        if willBeInsertedIntoToolbar {
+            sidebarMenu = menu
+            sidebarPopUpButton = popup
+            syncSidebarMenuState()
+        }
         return item
     }
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         guard menu === sidebarMenu else { return }
         rebuildSidebarMenu(menu)
+        syncSidebarMenuState()
     }
 
     private func rebuildSidebarMenu(_ menu: NSMenu) {
@@ -275,30 +279,52 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         face.image = sidebarFaceImage()
         menu.addItem(face)
 
-        let split = window.contentViewController as? MainSplitViewController
-        let sidebarVisible = split?.isSidebarVisible ?? false
-        let mode = split?.sidebarMode ?? .outline
-
         let hide = NSMenuItem(title: "Hide Sidebar",
                               action: #selector(hideSidebarFromMenu(_:)),
                               keyEquivalent: "")
         hide.target = self
-        hide.state = sidebarVisible ? .off : .on
         menu.addItem(hide)
 
         let outline = NSMenuItem(title: "Table of Contents",
                                  action: #selector(selectOutlineMode(_:)),
                                  keyEquivalent: "")
         outline.target = self
-        outline.state = (sidebarVisible && mode == .outline) ? .on : .off
         menu.addItem(outline)
 
         let files = NSMenuItem(title: "Project Navigator",
                                action: #selector(selectFilesMode(_:)),
                                keyEquivalent: "")
         files.target = self
-        files.state = (sidebarVisible && mode == .files) ? .on : .off
         menu.addItem(files)
+        syncSidebarMenuState(for: menu)
+    }
+
+    private func syncSidebarMenuState() {
+        syncSidebarViewMenuState()
+        if let sidebarMenu {
+            syncSidebarMenuState(for: sidebarMenu)
+        }
+    }
+
+    private func syncSidebarViewMenuState() {
+        let state = currentSidebarMenuState()
+        hideSidebarMenuItem?.state = state.sidebarVisible ? .off : .on
+        outlineMenuItem?.state = (state.sidebarVisible && state.mode == .outline) ? .on : .off
+        filesMenuItem?.state = (state.sidebarVisible && state.mode == .files) ? .on : .off
+    }
+
+    private func syncSidebarMenuState(for menu: NSMenu) {
+        let state = currentSidebarMenuState()
+        menu.items.first { $0.action == #selector(hideSidebarFromMenu(_:)) }?.state = state.sidebarVisible ? .off : .on
+        menu.items.first { $0.action == #selector(selectOutlineMode(_:)) }?.state = (state.sidebarVisible && state.mode == .outline) ? .on : .off
+        menu.items.first { $0.action == #selector(selectFilesMode(_:)) }?.state = (state.sidebarVisible && state.mode == .files) ? .on : .off
+    }
+
+    private func currentSidebarMenuState() -> (sidebarVisible: Bool, mode: SidebarViewController.Mode) {
+        let split = window.contentViewController as? MainSplitViewController
+        let sidebarVisible = split?.isSidebarVisible ?? false
+        let mode = split?.sidebarMode ?? .outline
+        return (sidebarVisible, mode)
     }
 
     private func sidebarFaceImage() -> NSImage {
@@ -310,24 +336,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
 
     @objc private func toggleSidebarFromMenu(_ sender: Any?) {
         (window.contentViewController as? MainSplitViewController)?.toggleSidebar()
+        syncSidebarMenuState()
     }
 
     @objc private func hideSidebarFromMenu(_ sender: Any?) {
         guard let split = window.contentViewController as? MainSplitViewController,
               split.isSidebarVisible else { return }
         split.toggleSidebar()
+        syncSidebarMenuState()
     }
 
     @objc private func selectOutlineMode(_ sender: Any?) {
         guard let split = window.contentViewController as? MainSplitViewController else { return }
         split.setSidebarMode(.outline)
         split.showSidebar()
+        syncSidebarMenuState()
     }
 
     @objc private func selectFilesMode(_ sender: Any?) {
         guard let split = window.contentViewController as? MainSplitViewController else { return }
         split.setSidebarMode(.files)
         split.showSidebar()
+        syncSidebarMenuState()
     }
 
     private func installGoMenu() {
@@ -483,17 +513,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
     }
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        let split = window.contentViewController as? MainSplitViewController
-        let sidebarVisible = split?.isSidebarVisible ?? false
-        let mode = split?.sidebarMode ?? .outline
-
-        if menuItem === hideSidebarMenuItem {
-            menuItem.state = sidebarVisible ? .off : .on
-        } else if menuItem === outlineMenuItem {
-            menuItem.state = (sidebarVisible && mode == .outline) ? .on : .off
-        } else if menuItem === filesMenuItem {
-            menuItem.state = (sidebarVisible && mode == .files) ? .on : .off
-        }
+        syncSidebarMenuState()
         return true
     }
 


### PR DESCRIPTION
## Summary

- keep the live sidebar toolbar pull-down reference from being replaced by Customize Toolbar palette copies
- centralize sidebar menu checkmark syncing for the toolbar pull-down and View menu
- bump the app to 0.0.20 (24) and document the fix in the changelog

## Root Cause

AppKit asks the toolbar delegate for item instances both for real toolbar insertion and for the native customization palette. The sidebar toolbar item factory always stored each generated menu as the live `sidebarMenu`, so customization palette copies could replace the reference used for menu updates and leave the real toolbar menu stale or unresponsive.

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`
