### PR TITLE
Feat/scrollspy and folder watcher

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -123,9 +123,32 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
 
     private func startWatching(_ url: URL) {
         fileWatcher?.cancel()
-        fileWatcher = FileWatcher(url: url) { [weak self] in
+        let watcher = FileWatcher(url: url) { [weak self] in
             guard let self, self.currentFileURL == url else { return }
             self.loadFile(at: url, silentOnFailure: true)
+        }
+        watcher.onRename = { [weak self] newURL in
+            self?.handleRename(to: newURL)
+        }
+        fileWatcher = watcher
+    }
+
+    /// The currently-open file moved (Finder rename, editor save-as, etc).
+    /// Update the open URL and propagate it to the title, recent docs,
+    /// Open With list, sidebar selection, and inspector — without
+    /// re-rendering the WebView, since the markdown content didn't change.
+    private func handleRename(to newURL: URL) {
+        guard currentFileURL != nil else { return }
+        currentFileURL = newURL
+        window.title = newURL.lastPathComponent
+        NSDocumentController.shared.noteNewRecentDocumentURL(newURL)
+        refreshOpenWithItem()
+        startWatching(newURL)
+        if let markdown = currentMarkdown {
+            (window.contentViewController as? MainSplitViewController)?
+                .openFileURLDidChange(newURL, markdown: markdown)
+        } else {
+            loadFile(at: newURL, silentOnFailure: true)
         }
     }
 
@@ -1230,6 +1253,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
 private final class FileWatcher {
     private let url: URL
     private let onChange: () -> Void
+    /// Fired when the watched file is renamed or moved (in Finder, by an
+    /// editor, etc.). Detected via `F_GETPATH` on the still-open FD —
+    /// the inode follows the file, so the descriptor resolves to the
+    /// new path. Plain deletes don't fire this (path unchanged).
+    var onRename: ((URL) -> Void)?
     private var source: DispatchSourceFileSystemObject?
     private var fileDescriptor: Int32 = -1
     private var debounce: DispatchWorkItem?
@@ -1253,12 +1281,18 @@ private final class FileWatcher {
         source.setEventHandler { [weak self] in
             guard let self, let source = self.source else { return }
             let event = source.data
-            self.scheduleChange()
             // Atomic-rename saves (Vim, VS Code, etc.) replace the inode;
             // re-open the watcher against the path so we keep tracking.
+            // For an actual user-visible rename, the FD's resolved path
+            // differs from the watcher's URL — surface that to the host.
             if !event.intersection([.delete, .rename, .revoke]).isEmpty {
+                if let newURL = self.currentPath(),
+                   newURL.standardizedFileURL != self.url.standardizedFileURL {
+                    self.onRename?(newURL)
+                }
                 self.reopen()
             }
+            self.scheduleChange()
         }
         source.setCancelHandler { [weak self] in
             guard let self else { return }
@@ -1277,6 +1311,15 @@ private final class FileWatcher {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             self?.open()
         }
+    }
+
+    private func currentPath() -> URL? {
+        guard fileDescriptor >= 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        guard fcntl(fileDescriptor, F_GETPATH, &buffer) == 0 else { return nil }
+        return URL(fileURLWithFileSystemRepresentation: buffer,
+                   isDirectory: false,
+                   relativeTo: nil)
     }
 
     private func scheduleChange() {

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -16,6 +16,28 @@ final class ContentViewController: NSViewController {
     private var lastLaidOutSize: NSSize = .zero
     private var pendingFlashWork: DispatchWorkItem?
 
+    // Heading top offsets in CSS pixels, indexed by heading id. Compared in
+    // CSS units so page zoom doesn't invalidate them.
+    private var headingOffsetsCSS: [CGFloat] = []
+    private var lastActiveHeadingID: Int?
+    private var pendingHeadingOffsetsRefresh: DispatchWorkItem?
+
+    // Sidebar-click pin. Bounds events are ignored until `holdUntil`
+    // (covers our own animation); the next bounds event after that is
+    // user input → release. No bounds event ever firing (short doc, no
+    // movement) → pin stays, which is the desired feedback.
+    private var sticky: StickyPin?
+    private struct StickyPin {
+        let headingID: Int
+        let holdUntil: DispatchTime
+    }
+    /// Covers `scrollDocument`'s 0.25s animation plus JS round-trip;
+    /// short enough that a scroll kicked off right after a click still
+    /// feels responsive.
+    private static let stickyHoldDuration: DispatchTimeInterval = .milliseconds(350)
+
+    var activeHeadingDidChange: ((Int?) -> Void)?
+
     override func loadView() {
         let scrollView = NSScrollView()
         scrollView.drawsBackground = false
@@ -33,15 +55,40 @@ final class ContentViewController: NSViewController {
                   abs(height - self.measuredDocumentHeight) > 0.5 else { return }
             self.measuredDocumentHeight = height
             self.applyDocumentHeight()
+            // Image load / font reflow shifted layout — re-measure offsets.
+            self.scheduleHeadingOffsetsRefresh()
         }
         webView.fragmentLinkActivated = { [weak self] fragment in
             self?.scrollToElement(id: fragment)
+        }
+        webView.userScrollDidStart = { [weak self] in
+            self?.clearStickyAndReevaluate()
         }
         webView.enablePersistentZoom(defaultsKey: Self.pageZoomDefaultsKey)
 
         documentView.addSubview(webView)
         scrollView.documentView = documentView
         view = scrollView
+
+        // The WKWebView is sized to full document height with internal
+        // scrolling disabled — all scroll happens at the clip view, so the
+        // scrollspy listens here. queue: .main lets `assumeIsolated` hop
+        // cleanly under Swift 6.
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.evaluateActiveHeading() }
+        }
+        NotificationCenter.default.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.clearStickyAndReevaluate() }
+        }
 
         documentHeightConstraint = documentView.heightAnchor.constraint(equalToConstant: 1)
         webViewHeightConstraint = webView.heightAnchor.constraint(equalToConstant: 1)
@@ -70,11 +117,28 @@ final class ContentViewController: NSViewController {
     }
 
     func display(markdown: String, assetBaseURL: URL? = nil) {
+        resetScrollspy()
         webView.display(markdown: markdown, assetBaseURL: assetBaseURL)
+        scheduleHeadingOffsetsRefresh()
     }
 
     func clearContent() {
+        resetScrollspy()
         webView.clearContent()
+    }
+
+    /// Drops scrollspy state before a doc swap so the previous doc's
+    /// heading doesn't briefly stay marked.
+    private func resetScrollspy() {
+        headingOffsetsCSS = []
+        sticky = nil
+        notifyActiveHeading(nil)
+    }
+
+    private func notifyActiveHeading(_ headingID: Int?) {
+        guard headingID != lastActiveHeadingID else { return }
+        lastActiveHeadingID = headingID
+        activeHeadingDidChange?(headingID)
     }
 
     func find(_ query: String,
@@ -133,6 +197,21 @@ final class ContentViewController: NSViewController {
         }
     }
 
+    /// Pin a heading active immediately so even a no-op scroll (last
+    /// heading on a short doc) gives feedback. Released on the next
+    /// bounds change after the click-animation window expires.
+    func markHeadingActiveFromClick(_ headingID: Int) {
+        sticky = StickyPin(headingID: headingID,
+                           holdUntil: .now() + Self.stickyHoldDuration)
+        notifyActiveHeading(headingID)
+    }
+
+    private func clearStickyAndReevaluate() {
+        guard sticky != nil else { return }
+        sticky = nil
+        evaluateActiveHeading()
+    }
+
     private func scrollToElement(id: String) {
         webView.elementOffset(id: id) { [weak self] offset in
             guard let self, let offset else { return }
@@ -163,6 +242,71 @@ final class ContentViewController: NSViewController {
         documentHeightConstraint.constant = resolvedHeight
         webViewHeightConstraint.constant = resolvedHeight
         clampScrollPosition(toDocumentHeight: resolvedHeight)
+    }
+
+    // MARK: - Scrollspy
+
+    private static let headingOffsetsRefreshDelay: TimeInterval = 0.05
+    /// CSS-px window from the doc top in which a heading counts as the
+    /// "lead" — close enough that body padding alone is what kept it
+    /// below the activation line at scroll-top. Past this, the heading
+    /// must earn its highlight by being scrolled past.
+    private static let leadHeadingThreshold: CGFloat = 80
+
+    private func scheduleHeadingOffsetsRefresh() {
+        pendingHeadingOffsetsRefresh?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.refreshHeadingOffsets()
+        }
+        pendingHeadingOffsetsRefresh = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.headingOffsetsRefreshDelay, execute: work
+        )
+    }
+
+    private func refreshHeadingOffsets() {
+        webView.collectHeadingOffsets { [weak self] offsets in
+            guard let self else { return }
+            self.headingOffsetsCSS = offsets
+            self.evaluateActiveHeading()
+        }
+    }
+
+    private func evaluateActiveHeading() {
+        if let pin = sticky {
+            if DispatchTime.now() < pin.holdUntil { return }
+            // Hold expired and a bounds change still arrived → user input,
+            // release the pin and follow the new position.
+            sticky = nil
+        }
+        notifyActiveHeading(computeActiveHeadingID())
+    }
+
+    /// Last heading whose top has scrolled above the activation line.
+    /// Lead-heading bump handles the doc-starts-with-a-heading case;
+    /// short-doc-last-heading is handled by `markHeadingActiveFromClick`.
+    private func computeActiveHeadingID() -> Int? {
+        guard !headingOffsetsCSS.isEmpty,
+              let scrollView = view as? NSScrollView else { return nil }
+        let clipView = scrollView.contentView
+        let zoom = max(webView.pageZoom, 0.001)
+        let topMargin: CGFloat = 12
+        var activationLine = (clipView.bounds.origin.y
+                              + clipView.contentInsets.top
+                              + topMargin
+                              + 8) / zoom
+
+        if let firstOffset = headingOffsetsCSS.first,
+           firstOffset <= Self.leadHeadingThreshold,
+           activationLine < firstOffset + 1 {
+            activationLine = firstOffset + 1
+        }
+
+        var active: Int?
+        for (index, offset) in headingOffsetsCSS.enumerated() {
+            if offset <= activationLine { active = index } else { break }
+        }
+        return active
     }
 
     private func clampScrollPosition(toDocumentHeight documentHeight: CGFloat) {

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -23,18 +23,23 @@ final class ContentViewController: NSViewController {
     private var pendingHeadingOffsetsRefresh: DispatchWorkItem?
 
     // Sidebar-click pin. Bounds events are ignored until `holdUntil`
-    // (covers our own animation); the next bounds event after that is
-    // user input → release. No bounds event ever firing (short doc, no
-    // movement) → pin stays, which is the desired feedback.
+    // (covers our own animation), then we measure scroll distance from
+    // `anchor` (the click's target scroll position). Tiny moves —
+    // rubber-band, small scrolls on near-fitting docs — stay below the
+    // release threshold so the pin survives them. A doc that can't scroll
+    // at all never even fires bounds events, so the pin sits forever.
     private var sticky: StickyPin?
     private struct StickyPin {
         let headingID: Int
         let holdUntil: DispatchTime
+        let anchor: CGFloat
     }
-    /// Covers `scrollDocument`'s 0.25s animation plus JS round-trip;
-    /// short enough that a scroll kicked off right after a click still
-    /// feels responsive.
+    /// Covers `scrollDocument`'s 0.25s animation plus JS round-trip.
     private static let stickyHoldDuration: DispatchTimeInterval = .milliseconds(350)
+    /// Viewport fraction the user must scroll past the pin's anchor to
+    /// release it. ⅓ feels sticky enough for incidental moves but lets
+    /// genuine page-scrolls take over.
+    private static let stickyReleaseFraction: CGFloat = 1.0 / 3.0
 
     var activeHeadingDidChange: ((Int?) -> Void)?
 
@@ -61,9 +66,6 @@ final class ContentViewController: NSViewController {
         webView.fragmentLinkActivated = { [weak self] fragment in
             self?.scrollToElement(id: fragment)
         }
-        webView.userScrollDidStart = { [weak self] in
-            self?.clearStickyAndReevaluate()
-        }
         webView.enablePersistentZoom(defaultsKey: Self.pageZoomDefaultsKey)
 
         documentView.addSubview(webView)
@@ -71,9 +73,11 @@ final class ContentViewController: NSViewController {
         view = scrollView
 
         // The WKWebView is sized to full document height with internal
-        // scrolling disabled — all scroll happens at the clip view, so the
-        // scrollspy listens here. queue: .main lets `assumeIsolated` hop
-        // cleanly under Swift 6.
+        // scrolling disabled — all scroll happens at the clip view. The
+        // scrollspy listens for actual position changes (not gesture-begin
+        // signals), so a trackpad gesture that can't scroll the doc — short
+        // doc — leaves a click pin intact. queue: .main lets `assumeIsolated`
+        // hop cleanly under Swift 6.
         scrollView.contentView.postsBoundsChangedNotifications = true
         NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,
@@ -81,13 +85,6 @@ final class ContentViewController: NSViewController {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.evaluateActiveHeading() }
-        }
-        NotificationCenter.default.addObserver(
-            forName: NSScrollView.willStartLiveScrollNotification,
-            object: scrollView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.clearStickyAndReevaluate() }
         }
 
         documentHeightConstraint = documentView.heightAnchor.constraint(equalToConstant: 1)
@@ -198,18 +195,36 @@ final class ContentViewController: NSViewController {
     }
 
     /// Pin a heading active immediately so even a no-op scroll (last
-    /// heading on a short doc) gives feedback. Released on the next
-    /// bounds change after the click-animation window expires.
+    /// heading on a short doc) gives feedback. The pin survives small
+    /// scroll movements; only a viewport-fraction scroll away from where
+    /// the click landed releases it.
     func markHeadingActiveFromClick(_ headingID: Int) {
+        let anchor = expectedScrollPosition(forHeading: headingID)
+            ?? (view as? NSScrollView)?.contentView.bounds.origin.y
+            ?? 0
         sticky = StickyPin(headingID: headingID,
-                           holdUntil: .now() + Self.stickyHoldDuration)
+                           holdUntil: .now() + Self.stickyHoldDuration,
+                           anchor: anchor)
         notifyActiveHeading(headingID)
     }
 
-    private func clearStickyAndReevaluate() {
-        guard sticky != nil else { return }
-        sticky = nil
-        evaluateActiveHeading()
+    /// Where `scrollDocument` would land for `headingID` — the same
+    /// clamped target the click animation aims at. Used as the pin's
+    /// distance reference.
+    private func expectedScrollPosition(forHeading headingID: Int) -> CGFloat? {
+        guard headingID >= 0,
+              headingID < headingOffsetsCSS.count,
+              let scrollView = view as? NSScrollView else { return nil }
+        let clipView = scrollView.contentView
+        let zoom = max(webView.pageZoom, 0.001)
+        let topInset = clipView.contentInsets.top
+        let bottomInset = clipView.contentInsets.bottom
+        let topMargin: CGFloat = 12
+        let y = headingOffsetsCSS[headingID] * zoom
+        let minY = -topInset
+        let maxY = max(documentHeightConstraint.constant - clipView.bounds.height + bottomInset,
+                       minY)
+        return max(minY, min(y - topInset - topMargin, maxY))
     }
 
     private func scrollToElement(id: String) {
@@ -275,11 +290,17 @@ final class ContentViewController: NSViewController {
     private func evaluateActiveHeading() {
         if let pin = sticky {
             if DispatchTime.now() < pin.holdUntil { return }
-            // Hold expired and a bounds change still arrived → user input,
-            // release the pin and follow the new position.
+            if !hasMovedFar(from: pin.anchor) { return }
             sticky = nil
         }
         notifyActiveHeading(computeActiveHeadingID())
+    }
+
+    private func hasMovedFar(from anchor: CGFloat) -> Bool {
+        guard let scrollView = view as? NSScrollView else { return true }
+        let clipView = scrollView.contentView
+        let delta = abs(clipView.bounds.origin.y - anchor)
+        return delta >= clipView.bounds.height * Self.stickyReleaseFraction
     }
 
     /// Last heading whose top has scrolled above the activation line.

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -16,6 +16,8 @@ final class MainSplitViewController: NSSplitViewController {
 
         let sidebarVC = SidebarViewController()
         sidebarVC.onSelectHeading = { [weak self] index in
+            // Pin before scrolling so a no-op scroll still confirms the click.
+            self?.contentViewController?.markHeadingActiveFromClick(index)
             self?.contentViewController?.scrollToHeading(index: index)
         }
         sidebarVC.onSelectFile = { [weak self] url in
@@ -41,6 +43,11 @@ final class MainSplitViewController: NSSplitViewController {
         addSplitViewItem(inspector)
 
         splitView.autosaveName = "MainSplitView"
+
+        // Wired after addSplitViewItem so the accessors are non-nil.
+        contentViewController?.activeHeadingDidChange = { [weak self] headingID in
+            self?.sidebarViewController?.setActiveHeading(headingID)
+        }
     }
 
     func display(markdown: String, fileName: String, url: URL?, assetBaseURL: URL?) {

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -56,6 +56,14 @@ final class MainSplitViewController: NSSplitViewController {
         inspectorViewController?.display(metadata: DocumentMetadata.make(url: url, markdown: markdown))
     }
 
+    /// URL-only refresh after a rename. Skips the content re-render so
+    /// the preview, scroll position, and active-heading highlight stay
+    /// put.
+    func openFileURLDidChange(_ newURL: URL, markdown: String) {
+        sidebarViewController?.openFileURLDidChange(newURL)
+        inspectorViewController?.display(metadata: DocumentMetadata.make(url: newURL, markdown: markdown))
+    }
+
     func clearContent() {
         contentViewController?.clearContent()
     }

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -31,10 +31,6 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     let webView: WKWebView
     var heightDidChange: ((CGFloat) -> Void)?
     var fragmentLinkActivated: ((String) -> Void)?
-    /// Keyboard / menu-driven scroll. Trackpad and wheel are not reported
-    /// here — observe `NSScrollView.willStartLiveScrollNotification` for
-    /// those. Programmatic scrolls (TOC click, find) bypass this entirely.
-    var userScrollDidStart: (() -> Void)?
     private let assetScheme = MarkdownAssetScheme()
     private var currentAssetBase: URL?
     private let messageBridge = HostBridge()
@@ -590,8 +586,6 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     @discardableResult
     func performScrollAction(_ action: ScrollAction) -> Bool {
         guard let scrollView = enclosingScrollView else { return false }
-        // Sole entry point for keyboard / menu scroll actions.
-        userScrollDidStart?()
         let clipView = scrollView.contentView
         let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
         let topInset = clipView.contentInsets.top

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -31,6 +31,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     let webView: WKWebView
     var heightDidChange: ((CGFloat) -> Void)?
     var fragmentLinkActivated: ((String) -> Void)?
+    /// Keyboard / menu-driven scroll. Trackpad and wheel are not reported
+    /// here — observe `NSScrollView.willStartLiveScrollNotification` for
+    /// those. Programmatic scrolls (TOC click, find) bypass this entirely.
+    var userScrollDidStart: (() -> Void)?
     private let assetScheme = MarkdownAssetScheme()
     private var currentAssetBase: URL?
     private let messageBridge = HostBridge()
@@ -356,6 +360,26 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         operation.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
     }
 
+    /// Top offsets in CSS pixels for every `md-heading-N`, in document
+    /// order. Index matches `TOCNode.headingID`.
+    func collectHeadingOffsets(completion: @escaping ([CGFloat]) -> Void) {
+        webView.evaluateJavaScript(Self.headingOffsetsScript) { result, _ in
+            guard let raw = result as? [NSNumber] else {
+                completion([])
+                return
+            }
+            completion(raw.map { CGFloat(truncating: $0) })
+        }
+    }
+
+    private static let headingOffsetsScript = """
+    (() => {
+        const els = document.querySelectorAll('[id^="md-heading-"]');
+        const scroll = window.scrollY || document.documentElement.scrollTop || 0;
+        return Array.from(els).map(el => el.getBoundingClientRect().top + scroll);
+    })();
+    """
+
     func headingOffset(index: Int, completion: @escaping (CGFloat?) -> Void) {
         let script = """
         (() => {
@@ -566,6 +590,8 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     @discardableResult
     func performScrollAction(_ action: ScrollAction) -> Bool {
         guard let scrollView = enclosingScrollView else { return false }
+        // Sole entry point for keyboard / menu scroll actions.
+        userScrollDidStart?()
         let clipView = scrollView.contentView
         let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
         let topInset = clipView.contentInsets.top
@@ -632,14 +658,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let bottomInset = clipView.contentInsets.bottom
         let viewportTop = clipView.bounds.origin.y + topInset
 
-        let script = """
-        (() => {
-            const els = document.querySelectorAll('[id^="md-heading-"]');
-            const scroll = window.scrollY || document.documentElement.scrollTop || 0;
-            return Array.from(els).map(el => el.getBoundingClientRect().top + scroll);
-        })();
-        """
-        webView.evaluateJavaScript(script) { [weak self, weak scrollView] result, _ in
+        webView.evaluateJavaScript(Self.headingOffsetsScript) { [weak self, weak scrollView] result, _ in
             guard let self,
                   let scrollView,
                   let raw = result as? [NSNumber] else { return }

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -139,7 +139,14 @@ final class SidebarViewController: NSViewController {
 
         // Defer folder enumeration until the user actually switches to the
         // Project Navigator — saves the disk walk on every TOC-mode open.
-        pendingFolderURL = fileURL?.deletingLastPathComponent()
+        // Keep the existing root if the new file is a descendant; otherwise
+        // reset so File → Open of an unrelated file still updates the tree.
+        let parent = fileURL?.deletingLastPathComponent()
+        if let parent, let current = loadedFolderURL, parent.isDescendantOrSame(of: current) {
+            pendingFolderURL = current
+        } else {
+            pendingFolderURL = parent
+        }
         pendingFileURL = fileURL
         if currentMode == .files {
             refreshNavigatorIfNeeded()
@@ -154,6 +161,53 @@ final class SidebarViewController: NSViewController {
         for root in roots {
             outlineView.expandItem(root, expandChildren: true)
         }
+        outlineView.deselectAll(nil)
+    }
+
+    /// Highlights the matching TOC row. Selecting via the API doesn't
+    /// dispatch the outline's action, so this won't loop back into
+    /// `onSelectHeading`. We don't `scrollRowToVisible` — yanking the
+    /// sidebar while the user scrolls the doc feels jumpy.
+    func setActiveHeading(_ headingID: Int?) {
+        loadViewIfNeeded()
+        guard let headingID,
+              let node = findNode(withID: headingID, in: roots) else {
+            outlineView.deselectAll(nil)
+            return
+        }
+        for ancestor in ancestors(of: node, in: roots) {
+            outlineView.expandItem(ancestor)
+        }
+        let row = outlineView.row(forItem: node)
+        guard row >= 0, outlineView.selectedRow != row else { return }
+        outlineView.selectRowIndexes(IndexSet(integer: row),
+                                     byExtendingSelection: false)
+    }
+
+    private func findNode(withID id: Int, in nodes: [TOCNode]) -> TOCNode? {
+        for node in nodes {
+            if node.headingID == id { return node }
+            if let hit = findNode(withID: id, in: node.children) { return hit }
+        }
+        return nil
+    }
+
+    private func ancestors(of target: TOCNode, in nodes: [TOCNode]) -> [TOCNode] {
+        var path: [TOCNode] = []
+        func walk(_ node: TOCNode) -> Bool {
+            if node === target { return true }
+            for child in node.children {
+                path.append(node)
+                if walk(child) { return true }
+                path.removeLast()
+            }
+            return false
+        }
+        for root in nodes {
+            path = []
+            if walk(root) { return path }
+        }
+        return []
     }
 
     @objc private func rowClicked(_ sender: Any?) {
@@ -296,6 +350,11 @@ private final class FileNode {
 
     var displayName: String { url.lastPathComponent }
 
+    /// Children if `children()` has populated the cache; nil otherwise.
+    var cachedChildren: [FileNode]? { loadedChildren }
+
+    func invalidateCache() { loadedChildren = nil }
+
     func children() -> [FileNode] {
         if let cached = loadedChildren { return cached }
         guard isDirectory else {
@@ -328,6 +387,9 @@ final class ProjectNavigatorView: NSView {
     private let scrollView = NSScrollView()
     private let outlineView = NSOutlineView()
     private var rootNode: FileNode?
+    // One watcher per loaded directory; kept in sync with which FileNodes
+    // currently have a populated children cache.
+    private var watchers: [URL: DirectoryWatcher] = [:]
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -379,11 +441,117 @@ final class ProjectNavigatorView: NSView {
     }
 
     func setRoot(_ url: URL?) {
+        cancelAllWatchers()
         rootNode = url.map { FileNode(url: $0, isDirectory: true) }
         outlineView.reloadData()
         if let rootNode {
             outlineView.expandItem(rootNode)
+            syncWatchers()
         }
+    }
+
+    // MARK: - Folder watching
+
+    private func syncWatchers() {
+        var live: Set<URL> = []
+        if let rootNode { collectLoadedDirectories(rootNode, into: &live) }
+        for url in live where watchers[url] == nil {
+            watchers[url] = DirectoryWatcher(url: url) { [weak self] in
+                self?.handleFolderChange()
+            }
+        }
+        for (url, watcher) in watchers where !live.contains(url) {
+            watcher.cancel()
+            watchers.removeValue(forKey: url)
+        }
+    }
+
+    private func collectLoadedDirectories(_ node: FileNode, into set: inout Set<URL>) {
+        guard node.isDirectory else { return }
+        set.insert(node.url.standardizedFileURL)
+        guard let kids = node.cachedChildren else { return }
+        for child in kids where child.isDirectory {
+            collectLoadedDirectories(child, into: &set)
+        }
+    }
+
+    private func cancelAllWatchers() {
+        for watcher in watchers.values { watcher.cancel() }
+        watchers.removeAll()
+    }
+
+    private func handleFolderChange() {
+        // Snapshot expansion and selection so the user's view survives the reload.
+        let expandedURLs = collectExpandedURLs()
+        let selectedURL = currentlySelectedURL()
+
+        if let rootNode { invalidateCaches(rootNode) }
+        outlineView.reloadData()
+
+        if let rootNode {
+            outlineView.expandItem(rootNode)
+            reExpand(rootNode, expanded: expandedURLs)
+        }
+        if let selectedURL,
+           let rootNode,
+           let target = findNode(in: rootNode, matching: selectedURL) {
+            let row = outlineView.row(forItem: target)
+            if row >= 0 {
+                outlineView.selectRowIndexes(IndexSet(integer: row),
+                                             byExtendingSelection: false)
+            }
+        }
+        syncWatchers()
+    }
+
+    private func invalidateCaches(_ node: FileNode) {
+        guard node.isDirectory, let kids = node.cachedChildren else { return }
+        for child in kids where child.isDirectory {
+            invalidateCaches(child)
+        }
+        node.invalidateCache()
+    }
+
+    private func collectExpandedURLs() -> Set<URL> {
+        var result: Set<URL> = []
+        func walk(_ item: Any?) {
+            let count = outlineView.numberOfChildren(ofItem: item)
+            for i in 0..<count {
+                let child = outlineView.child(i, ofItem: item)
+                if let node = child as? FileNode, outlineView.isItemExpanded(node) {
+                    result.insert(node.url.standardizedFileURL)
+                    walk(child)
+                }
+            }
+        }
+        walk(nil)
+        return result
+    }
+
+    private func currentlySelectedURL() -> URL? {
+        let row = outlineView.selectedRow
+        guard row >= 0,
+              let node = outlineView.item(atRow: row) as? FileNode else { return nil }
+        return node.url.standardizedFileURL
+    }
+
+    private func reExpand(_ node: FileNode, expanded: Set<URL>) {
+        guard node.isDirectory else { return }
+        for child in node.children() where child.isDirectory {
+            if expanded.contains(child.url.standardizedFileURL) {
+                outlineView.expandItem(child)
+                reExpand(child, expanded: expanded)
+            }
+        }
+    }
+
+    private func findNode(in node: FileNode, matching target: URL) -> FileNode? {
+        if node.url.standardizedFileURL == target { return node }
+        guard node.isDirectory, let kids = node.cachedChildren else { return nil }
+        for child in kids {
+            if let hit = findNode(in: child, matching: target) { return hit }
+        }
+        return nil
     }
 
     func setCurrentFile(_ url: URL?) {
@@ -412,11 +580,8 @@ final class ProjectNavigatorView: NSView {
     private func collectPath(to targetURL: URL,
                              from root: FileNode,
                              into path: inout [FileNode]) -> Bool {
-        // Skip whole subtrees that can't contain the target — avoids enumerating
-        // sibling folders just to highlight one row.
-        let rootPath = root.url.standardizedFileURL.path
-        let target = targetURL.path
-        guard target == rootPath || target.hasPrefix(rootPath + "/") else { return false }
+        // Skip subtrees that can't contain the target.
+        guard targetURL.isDescendantOrSame(of: root.url) else { return false }
 
         for child in root.children() {
             if child.url.standardizedFileURL == targetURL {
@@ -588,5 +753,62 @@ extension ProjectNavigatorView: NSOutlineViewDelegate {
 
     func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
         return 24
+    }
+
+    func outlineViewItemDidExpand(_ notification: Notification) {
+        // Newly-loaded subtree needs its own watcher.
+        syncWatchers()
+    }
+}
+
+private extension URL {
+    func isDescendantOrSame(of other: URL) -> Bool {
+        let mine = standardizedFileURL.path
+        let root = other.standardizedFileURL.path
+        return mine == root || mine.hasPrefix(root + "/")
+    }
+}
+
+private final class DirectoryWatcher {
+    private let onChange: () -> Void
+    private var source: DispatchSourceFileSystemObject?
+    private var fileDescriptor: Int32 = -1
+    private var debounce: DispatchWorkItem?
+
+    init(url: URL, onChange: @escaping () -> Void) {
+        self.onChange = onChange
+        let fd = Darwin.open(url.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        fileDescriptor = fd
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .delete, .rename, .revoke],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in self?.scheduleChange() }
+        source.setCancelHandler { [weak self] in
+            guard let self else { return }
+            if self.fileDescriptor >= 0 {
+                Darwin.close(self.fileDescriptor)
+                self.fileDescriptor = -1
+            }
+        }
+        self.source = source
+        source.resume()
+    }
+
+    /// FS events arrive in bursts (Finder rewrites + xattr updates). Coalesce.
+    private func scheduleChange() {
+        debounce?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.onChange() }
+        debounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
+    }
+
+    func cancel() {
+        debounce?.cancel()
+        source?.cancel()
+        source = nil
     }
 }

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -136,21 +136,7 @@ final class SidebarViewController: NSViewController {
 
     func display(markdown: String, fileName: String, fileURL: URL?) {
         loadViewIfNeeded()
-
-        // Defer folder enumeration until the user actually switches to the
-        // Project Navigator — saves the disk walk on every TOC-mode open.
-        // Keep the existing root if the new file is a descendant; otherwise
-        // reset so File → Open of an unrelated file still updates the tree.
-        let parent = fileURL?.deletingLastPathComponent()
-        if let parent, let current = loadedFolderURL, parent.isDescendantOrSame(of: current) {
-            pendingFolderURL = current
-        } else {
-            pendingFolderURL = parent
-        }
-        pendingFileURL = fileURL
-        if currentMode == .files {
-            refreshNavigatorIfNeeded()
-        }
+        setOpenFileURL(fileURL)
 
         guard markdown != lastRenderedMarkdown || fileName != lastRenderedFileName else { return }
         lastRenderedMarkdown = markdown
@@ -162,6 +148,30 @@ final class SidebarViewController: NSViewController {
             outlineView.expandItem(root, expandChildren: true)
         }
         outlineView.deselectAll(nil)
+    }
+
+    /// Update the tracked file URL after a rename — keeps the navigator
+    /// selection on the open file without rebuilding the TOC.
+    func openFileURLDidChange(_ newURL: URL) {
+        loadViewIfNeeded()
+        setOpenFileURL(newURL)
+    }
+
+    /// Defers folder enumeration until the user is actually in the
+    /// navigator (saves disk walks on every TOC-mode open). Keeps the
+    /// existing root if the new file is a descendant; otherwise resets
+    /// so an unrelated File → Open updates the tree.
+    private func setOpenFileURL(_ fileURL: URL?) {
+        let parent = fileURL?.deletingLastPathComponent()
+        if let parent, let current = loadedFolderURL, parent.isDescendantOrSame(of: current) {
+            pendingFolderURL = current
+        } else {
+            pendingFolderURL = parent
+        }
+        pendingFileURL = fileURL
+        if currentMode == .files {
+            refreshNavigatorIfNeeded()
+        }
     }
 
     /// Highlights the matching TOC row. Selecting via the API doesn't
@@ -481,25 +491,20 @@ final class ProjectNavigatorView: NSView {
     }
 
     private func handleFolderChange() {
-        // Snapshot expansion and selection so the user's view survives the reload.
-        let expandedURLs = collectExpandedURLs()
         let selectedURL = currentlySelectedURL()
+        refreshTree()
+        if let selectedURL { setCurrentFile(selectedURL) }
+    }
 
+    /// Reloads the outline from disk while preserving expansion state.
+    /// Selection is left to the caller.
+    private func refreshTree() {
+        let expandedURLs = collectExpandedURLs()
         if let rootNode { invalidateCaches(rootNode) }
         outlineView.reloadData()
-
         if let rootNode {
             outlineView.expandItem(rootNode)
             reExpand(rootNode, expanded: expandedURLs)
-        }
-        if let selectedURL,
-           let rootNode,
-           let target = findNode(in: rootNode, matching: selectedURL) {
-            let row = outlineView.row(forItem: target)
-            if row >= 0 {
-                outlineView.selectRowIndexes(IndexSet(integer: row),
-                                             byExtendingSelection: false)
-            }
         }
         syncWatchers()
     }
@@ -545,15 +550,6 @@ final class ProjectNavigatorView: NSView {
         }
     }
 
-    private func findNode(in node: FileNode, matching target: URL) -> FileNode? {
-        if node.url.standardizedFileURL == target { return node }
-        guard node.isDirectory, let kids = node.cachedChildren else { return nil }
-        for child in kids {
-            if let hit = findNode(in: child, matching: target) { return hit }
-        }
-        return nil
-    }
-
     func setCurrentFile(_ url: URL?) {
         guard let url, let rootNode else {
             outlineView.deselectAll(nil)
@@ -561,9 +557,16 @@ final class ProjectNavigatorView: NSView {
         }
         let target = url.standardizedFileURL
         var path: [FileNode] = []
-        guard collectPath(to: target, from: rootNode, into: &path) else {
-            outlineView.deselectAll(nil)
-            return
+        if !collectPath(to: target, from: rootNode, into: &path) {
+            // Cache might be stale (file was just renamed and our
+            // DirectoryWatcher hasn't fired yet). Refresh from disk once
+            // and retry before giving up.
+            refreshTree()
+            path = []
+            guard collectPath(to: target, from: rootNode, into: &path) else {
+                outlineView.deselectAll(nil)
+                return
+            }
         }
         for ancestor in path.dropLast() {
             outlineView.expandItem(ancestor)


### PR DESCRIPTION
 ## Summary

  - **TOC scrollspy**: outline highlights the heading the user is currently
    reading, and follows scroll.
  - **Project Navigator folder watcher**: files added/renamed/deleted in
    any visible folder show up within ~150 ms.
  - **Stable navigator root**: opening a deeper file under the current
    root no longer narrows the navigator's root.

## Preview

### Scrollspy

https://github.com/user-attachments/assets/a5baac4e-e709-4f1f-b378-3608658be258



### Folder Watcher


https://github.com/user-attachments/assets/53925423-4b98-4224-bb40-62ab03945a13



  ## Test plan

  - [x] Scroll a long doc -> outline follows.
  - [x] Click a heading -> highlight pins, then resumes following on next
    scroll.
  - [x] Click the last heading on a short doc that can't scroll further ->
    highlight sticks, no glitch.
  - [x] Add / rename / delete a `.md` in Finder (root and inside an
    expanded subfolder) -> navigator updates.
  - [x] Open `notes/A.md`, click `notes/sub/B.md` in navigator -> root
    stays at `notes/`.
  - [x] File: Open an unrelated file in a different folder -> root
    resets.
