### PR TITLE
Fix codeblock metadata breaking mermaid/math decorators

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		9A0209432FA10E6600092060 /* Exceptions for "md-preview" folder in "quick-look" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				CodeFenceInfo.swift,
 				EscapingHTMLFormatter.swift,
 				MarkdownAssetSchemeHandler.swift,
 				MarkdownFrontmatter.swift,

--- a/md-preview/CodeFenceInfo.swift
+++ b/md-preview/CodeFenceInfo.swift
@@ -1,0 +1,39 @@
+//
+//  CodeFenceInfo.swift
+//  md-preview
+//
+
+import Foundation
+
+/// Parsed components of a CommonMark fenced code block info string.
+///
+/// CommonMark trims the info string of surrounding whitespace; by convention
+/// its first whitespace-separated token is the language identifier and
+/// anything after is implementation-defined metadata (e.g. a mermaid diagram
+/// name, GFM `title="foo.ts"`).
+nonisolated struct CodeFenceInfo: Equatable {
+    /// First whitespace-separated token of the info string, lowercased.
+    /// Empty when the info string is missing or whitespace-only.
+    let language: String
+
+    /// Remainder of the info string after the language word, with surrounding
+    /// whitespace trimmed. Empty when there is no metadata.
+    let metadata: String
+
+    init(rawInfoString: String?) {
+        guard let raw = rawInfoString else {
+            self.language = ""
+            self.metadata = ""
+            return
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let split = trimmed.firstIndex(where: { $0.isWhitespace }) else {
+            self.language = trimmed.lowercased()
+            self.metadata = ""
+            return
+        }
+        self.language = trimmed[..<split].lowercased()
+        self.metadata = trimmed[split...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -48,12 +48,10 @@ nonisolated struct EscapingHTMLFormatter: MarkupWalker {
     }
 
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
-        let languageAttr: String
-        if let language = codeBlock.language {
-            languageAttr = " class=\"language-\(escapeAttribute(language))\""
-        } else {
-            languageAttr = ""
-        }
+        let info = CodeFenceInfo(rawInfoString: codeBlock.language)
+        let languageAttr = info.language.isEmpty
+            ? ""
+            : " class=\"language-\(escapeAttribute(info.language))\""
         result += "<pre><code\(languageAttr)>\(escapeText(codeBlock.code))</code></pre>\n"
     }
 

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -576,11 +576,10 @@ nonisolated enum MarkdownHTML {
                 location: fenceCursor,
                 length: match.range.location - fenceCursor
             ))
-            let info = nsMarkdown
-                .substring(with: match.range(at: 2))
-                .trimmingCharacters(in: .whitespaces)
-                .lowercased()
-            if info == "math" {
+            let info = CodeFenceInfo(
+                rawInfoString: nsMarkdown.substring(with: match.range(at: 2))
+            )
+            if info.language == "math" {
                 let body = nsMarkdown.substring(with: match.range(at: 3))
                 blocks.append(body)
                 // Surround with blank lines so swift-markdown wraps the standalone

--- a/tests/swift-tests/Package.swift
+++ b/tests/swift-tests/Package.swift
@@ -1,23 +1,38 @@
 // swift-tools-version:6.0
 //
-// Local test scaffold for the Quick Look extension's pure-Foundation
-// helpers. The Xcode project is the source of truth — `InlineLocalAssets.swift`
-// lives at `quick-look/InlineLocalAssets.swift` and is symlinked into
-// `Sources/QuickLookHelpers/` so SPM can compile it without duplicating
-// the file.
+// Local test scaffold for pure-Foundation helpers from the app and the
+// Quick Look extension. The Xcode project is the source of truth — source
+// files live under `quick-look/` and `md-preview/` and are symlinked into
+// `Sources/<Target>/` so SPM can compile them without duplication.
 //
 // Run: `swift test --package-path tests/swift-tests`
 //
 import PackageDescription
 
 let package = Package(
-    name: "QuickLookHelperTests",
+    name: "MdPreviewHelperTests",
     platforms: [.macOS(.v15)],
+    dependencies: [
+        .package(
+            url: "https://github.com/swiftlang/swift-markdown.git",
+            from: "0.7.3"
+        ),
+    ],
     targets: [
         .target(name: "QuickLookHelpers"),
         .testTarget(
             name: "QuickLookHelperTests",
             dependencies: ["QuickLookHelpers"]
+        ),
+        .target(
+            name: "MarkdownHelpers",
+            dependencies: [
+                .product(name: "Markdown", package: "swift-markdown"),
+            ]
+        ),
+        .testTarget(
+            name: "MarkdownHelpersTests",
+            dependencies: ["MarkdownHelpers"]
         ),
     ]
 )

--- a/tests/swift-tests/Sources/MarkdownHelpers/CodeFenceInfo.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/CodeFenceInfo.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/CodeFenceInfo.swift

--- a/tests/swift-tests/Sources/MarkdownHelpers/EscapingHTMLFormatter.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/EscapingHTMLFormatter.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/EscapingHTMLFormatter.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/CodeFenceInfoTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/CodeFenceInfoTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import MarkdownHelpers
+
+final class CodeFenceInfoTests: XCTestCase {
+
+    // MARK: - Language extraction
+
+    func testBareLanguageBecomesLowercaseLanguageWithEmptyMetadata() {
+        let info = CodeFenceInfo(rawInfoString: "Swift")
+        XCTAssertEqual(info.language, "swift")
+        XCTAssertEqual(info.metadata, "")
+    }
+
+    func testFirstWhitespaceSeparatedTokenIsTheLanguage() {
+        // ```mermaid some-name → language is mermaid; rest is metadata.
+        let info = CodeFenceInfo(rawInfoString: "mermaid some-name")
+        XCTAssertEqual(info.language, "mermaid")
+        XCTAssertEqual(info.metadata, "some-name")
+    }
+
+    func testTabsAlsoSeparateLanguageFromMetadata() {
+        let info = CodeFenceInfo(rawInfoString: "ts\ttitle=\"foo.ts\"")
+        XCTAssertEqual(info.language, "ts")
+        XCTAssertEqual(info.metadata, "title=\"foo.ts\"")
+    }
+
+    func testMetadataPreservesInternalWhitespaceAndCasing() {
+        // CommonMark says only language is "first word"; metadata is left as-is
+        // (modulo surrounding-whitespace trimming) so callers can parse it.
+        let info = CodeFenceInfo(rawInfoString: "ts  Title=\"Foo Bar\"  {1,3}")
+        XCTAssertEqual(info.language, "ts")
+        XCTAssertEqual(info.metadata, "Title=\"Foo Bar\"  {1,3}")
+    }
+
+    // MARK: - Trimming and empty cases
+
+    func testLeadingAndTrailingWhitespaceIsTrimmedBeforeSplitting() {
+        let info = CodeFenceInfo(rawInfoString: "   mermaid   some-name   ")
+        XCTAssertEqual(info.language, "mermaid")
+        XCTAssertEqual(info.metadata, "some-name")
+    }
+
+    func testNilInfoStringYieldsEmptyValues() {
+        let info = CodeFenceInfo(rawInfoString: nil)
+        XCTAssertEqual(info.language, "")
+        XCTAssertEqual(info.metadata, "")
+    }
+
+    func testEmptyInfoStringYieldsEmptyValues() {
+        let info = CodeFenceInfo(rawInfoString: "")
+        XCTAssertEqual(info.language, "")
+        XCTAssertEqual(info.metadata, "")
+    }
+
+    func testWhitespaceOnlyInfoStringYieldsEmptyValues() {
+        let info = CodeFenceInfo(rawInfoString: "   \t  ")
+        XCTAssertEqual(info.language, "")
+        XCTAssertEqual(info.metadata, "")
+    }
+}

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import MarkdownHelpers
+
+// Info-string parsing is covered by CodeFenceInfoTests. This single test just
+// confirms the formatter wires that parser into the `language-` class so the
+// trailing metadata (e.g. ```mermaid some-name) does not leak into HTML.
+final class EscapingHTMLFormatterTests: XCTestCase {
+
+    func testFencedCodeBlockSetsLanguageClassFromFirstInfoWord() {
+        let html = EscapingHTMLFormatter.format("""
+        ```mermaid some-name
+        graph TD
+        ```
+        """)
+        XCTAssertTrue(
+            html.contains(#"<pre><code class="language-mermaid">"#),
+            "expected language-mermaid class (metadata after space ignored): \(html)"
+        )
+        XCTAssertFalse(
+            html.contains("some-name"),
+            "metadata after the language word must not leak into the class attribute: \(html)"
+        )
+    }
+}


### PR DESCRIPTION
CommonMark describes how the info string after a code fence may [include metadata](https://spec.commonmark.org/0.31.2/#example-143) as well as the language declaration.

Markdown Preview currently has the HTML formatter pass the whole info string into the `language-` class attribute, so `'''mermaid some-name` produces `class="language-mermaid some-name"`, both preventing the decorator and adding expected classes.

This PR adds a `CodeFenceInfo` helper which parses the info string into `language` + `metadata` (used by both the formatter and the math extractor) so metadata is ignored (but could also be used for things like showing a file name or line numbers in code blocks)