### PR TITLE
Add Obsidian to known Markdown editors

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -1,0 +1,19 @@
+name: Swift Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: swift test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Run tests
+        run: swift test --package-path tests/swift-tests

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -869,6 +869,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         "com.microsoft.VSCode",
         "com.todesktop.230313mzl4w4u92",
         "dev.zed.Zed",
+        "md.obsidian",
         "com.sublimetext.4",
         "com.sublimetext.3",
         "com.barebones.bbedit",
@@ -879,6 +880,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         "com.macromates.TextMate",
         "org.vim.MacVim"
     ]
+    private static let knownMarkdownEditorBundleIDs: Set<String> = Set(editorBundleIDPriority)
 
     private func makeOpenWithItem() -> NSToolbarItem {
         let item = NSMenuToolbarItem(itemIdentifier: .openWith)
@@ -938,14 +940,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
             }
         }
 
-        return NSWorkspace.shared.urlsForApplications(toOpen: fileURL).compactMap { appURL in
+        var appURLs = NSWorkspace.shared.urlsForApplications(toOpen: fileURL)
+        for bundleID in Self.knownMarkdownEditorBundleIDs {
+            guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID),
+                  !appURLs.contains(where: { sameApplication($0, appURL) }) else {
+                continue
+            }
+            appURLs.append(appURL)
+        }
+
+        return appURLs.compactMap { appURL in
             if selfURLs.contains(canonicalAppURL(appURL)) { return nil }
             let plist = infoPlist(at: appURL)
             let bundleID = (plist?["CFBundleIdentifier"] as? String)
                 ?? Bundle(url: appURL)?.bundleIdentifier
-            guard canEditMarkdown(plist: plist) else { return nil }
+            guard canEditMarkdown(plist: plist) || knownMarkdownEditor(bundleID: bundleID) else { return nil }
             return EditorCandidate(url: appURL, bundleID: bundleID)
         }
+    }
+
+    private func knownMarkdownEditor(bundleID: String?) -> Bool {
+        bundleID.map(Self.knownMarkdownEditorBundleIDs.contains) ?? false
     }
 
     private func resolveDefaultEditor(among candidates: [EditorCandidate]) -> EditorCandidate? {


### PR DESCRIPTION
## Summary

- Add `md.obsidian` to the editor bundle-ID priority list so Obsidian appears in the **Open With** menu.
- Look up known editors explicitly by bundle ID instead of relying solely on `NSWorkspace.urlsForApplications(toOpen:)`, which can omit installed editors that don't declare a matching document type.

## Test plan

- Install Obsidian, open a Markdown file in the app, confirm Obsidian appears in the **Open With** menu and launches correctly.
- Confirm other known editors (VS Code, Zed, etc.) still appear and that duplicates are not listed.