### PR TITLE
Run Swift tests on pull requests

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -1,0 +1,19 @@
+name: Swift Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: swift test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Run tests
+        run: swift test --package-path tests/swift-tests


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that runs the `QuickLookHelpers` test package on every pull request and on pushes to `main`.
- Runs `swift test --package-path tests/swift-tests` on a `macos-15` runner.

## Test plan

- Confirm the **Swift Tests** check appears and passes on this PR.