### PR TITLE
Prepare 0.0.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.23] – 2026-05-18
+
+Fenced code blocks that carry extra metadata after the language now render the way they should.
+
+### Fixed
+
+- **Fenced code blocks with info-string metadata render correctly.** Only the first word of a fenced code block's info string is treated as the language, so blocks like ` ```mermaid {theme=dark} ` or ` ```swift title="example.swift" ` are recognized properly and Mermaid diagrams and math decorators are no longer broken by trailing metadata ([#109](https://github.com/pluk-inc/markdown-preview/pull/109)).
+
+### Contributors
+
+Thanks to the external contributors who shipped in this release:
+
+- [@jphastings](https://github.com/jphastings) — fenced code block info-string language handling ([#109](https://github.com/pluk-inc/markdown-preview/pull/109))
+
 ## [0.0.22] – 2026-05-14
 
 Markdown Preview now sanitizes rendered HTML before it reaches the preview WebView, and Sparkle update checks point at the Amore-published appcast.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.22
-CURRENT_PROJECT_VERSION = 26
+MARKETING_VERSION = 0.0.23
+CURRENT_PROJECT_VERSION = 27


### PR DESCRIPTION
## Summary
- Bump Markdown Preview to 0.0.23 build 27
- Add the 0.0.23 changelog entry for fenced code block info-string metadata handling
- Credit @jphastings for #109

## Verification
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -showBuildSettings | rg 'MARKETING_VERSION|CURRENT_PROJECT_VERSION'`\n