### PR TITLE
Add Github-style 'Alert' blockquotes

### DIFF
--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -33,6 +33,9 @@ nonisolated struct EscapingHTMLFormatter: MarkupWalker {
     // MARK: Block elements
 
     mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
+        if renderAlertIfPresent(blockQuote) {
+            return
+        }
         if options.contains(.parseAsides),
            let aside = Aside(blockQuote, tagRequirement: .requireSingleWordTag) {
             result += "<aside data-kind=\"\(escapeAttribute(aside.kind.rawValue))\">\n"
@@ -45,6 +48,122 @@ nonisolated struct EscapingHTMLFormatter: MarkupWalker {
             descendInto(blockQuote)
             result += "</blockquote>\n"
         }
+    }
+
+    // GitHub-style alerts: `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`,
+    // `> [!WARNING]`, `> [!CAUTION]`. Tag matching is case-insensitive. Any
+    // text on the tag line after the closing `]` is used as a custom title;
+    // otherwise the alert's default title is used.
+    private mutating func renderAlertIfPresent(_ blockQuote: BlockQuote) -> Bool {
+        let blocks = Array(blockQuote.children)
+        guard let firstPara = blocks.first as? Paragraph else { return false }
+        let inlines = Array(firstPara.children)
+        guard let firstText = inlines.first as? Text,
+              let (kind, prefixLen) = Self.matchAlertTag(firstText.string) else {
+            return false
+        }
+
+        var firstTextRest = String(firstText.string.dropFirst(prefixLen))
+        if firstTextRest.hasPrefix(" ") {
+            firstTextRest.removeFirst()
+        }
+
+        var titleInlinesAfter: [Markup] = []
+        var firstParaBody: [Markup] = []
+        var pastTitle = false
+        for inline in inlines.dropFirst() {
+            if !pastTitle {
+                if inline is SoftBreak || inline is LineBreak {
+                    pastTitle = true
+                    continue
+                }
+                titleInlinesAfter.append(inline)
+            } else {
+                firstParaBody.append(inline)
+            }
+        }
+
+        let hasCustomTitle = !firstTextRest.trimmingCharacters(in: .whitespaces).isEmpty
+            || !titleInlinesAfter.isEmpty
+
+        result += "<div class=\"markdown-alert markdown-alert-\(kind.rawValue)\">\n"
+        result += "<p class=\"markdown-alert-title\">"
+        result += kind.iconSVG
+        result += " "
+        if hasCustomTitle {
+            if !firstTextRest.isEmpty {
+                result += escapeText(firstTextRest)
+            }
+            for inline in titleInlinesAfter {
+                visit(inline)
+            }
+        } else {
+            result += escapeText(kind.defaultTitle)
+        }
+        result += "</p>\n"
+
+        if !firstParaBody.isEmpty {
+            result += "<p>"
+            for inline in firstParaBody {
+                visit(inline)
+            }
+            result += "</p>\n"
+        }
+        for block in blocks.dropFirst() {
+            visit(block)
+        }
+        result += "</div>\n"
+        return true
+    }
+
+    private enum AlertKind: String {
+        case note, tip, important, warning, caution
+
+        // GitHub Octicons (info, light-bulb, report, alert, stop).
+        // Stripped to the path data only — the wrapper is built by `iconSVG`.
+        private var iconPath: String {
+            switch self {
+            case .note:
+                return "M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
+            case .tip:
+                return "M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"
+            case .important:
+                return "M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+            case .warning:
+                return "M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+            case .caution:
+                return "M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
+            }
+        }
+
+        var iconSVG: String {
+            "<svg class=\"markdown-alert-icon\" viewBox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path d=\"\(iconPath)\"></path></svg>"
+        }
+
+        var defaultTitle: String {
+            switch self {
+            case .note: return "Note"
+            case .tip: return "Tip"
+            case .important: return "Important"
+            case .warning: return "Warning"
+            case .caution: return "Caution"
+            }
+        }
+    }
+
+    private static func matchAlertTag(_ text: String) -> (AlertKind, Int)? {
+        let tags: [(String, AlertKind)] = [
+            ("[!note]", .note),
+            ("[!tip]", .tip),
+            ("[!important]", .important),
+            ("[!warning]", .warning),
+            ("[!caution]", .caution),
+        ]
+        let lower = text.lowercased()
+        for (tag, kind) in tags where lower.hasPrefix(tag) {
+            return (kind, tag.count)
+        }
+        return nil
     }
 
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) {

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1936,6 +1936,40 @@ nonisolated enum MarkdownHTML {
     }
     blockquote > *:first-child { margin-top: 0; }
 
+    .markdown-alert {
+        margin: 1.6em 0 0;
+        padding: 12px 16px;
+        background: var(--aside-bg);
+        border-left: 4px solid var(--aside-border);
+        border-radius: 6px;
+        color: var(--text);
+    }
+    .markdown-alert > *:first-child { margin-top: 0; }
+    .markdown-alert-title {
+        font-weight: 600;
+        margin: 0;
+        display: flex;
+        align-items: center;
+        line-height: 1;
+    }
+    .markdown-alert-icon {
+        width: 1em;
+        height: 1em;
+        margin-right: 0.5em;
+        flex: 0 0 auto;
+        fill: currentColor;
+    }
+    .markdown-alert-note { border-left-color: #0969da; }
+    .markdown-alert-note .markdown-alert-title { color: #0969da; }
+    .markdown-alert-tip { border-left-color: #1a7f37; }
+    .markdown-alert-tip .markdown-alert-title { color: #1a7f37; }
+    .markdown-alert-important { border-left-color: #8250df; }
+    .markdown-alert-important .markdown-alert-title { color: #8250df; }
+    .markdown-alert-warning { border-left-color: #9a6700; }
+    .markdown-alert-warning .markdown-alert-title { color: #9a6700; }
+    .markdown-alert-caution { border-left-color: #d1242f; }
+    .markdown-alert-caution .markdown-alert-title { color: #d1242f; }
+
     ul, ol { margin: 0.8em 0 0; padding-left: 1.6em; }
     li { margin-top: 0.4em; }
     li:first-child { margin-top: 0.8em; }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
@@ -21,4 +21,76 @@ final class EscapingHTMLFormatterTests: XCTestCase {
             "metadata after the language word must not leak into the class attribute: \(html)"
         )
     }
+
+    func testGitHubAlertWithDefaultTitle() {
+        let html = EscapingHTMLFormatter.format("""
+        > [!IMPORTANT]
+        > Body text.
+        """)
+        XCTAssertTrue(
+            html.contains(#"<div class="markdown-alert markdown-alert-important">"#),
+            "expected alert wrapper: \(html)"
+        )
+        XCTAssertTrue(
+            html.contains(#"<p class="markdown-alert-title"><svg class="markdown-alert-icon""#),
+            "expected title with leading icon SVG: \(html)"
+        )
+        XCTAssertTrue(html.contains("Important</p>"), "expected default title text: \(html)")
+        XCTAssertTrue(html.contains("<p>Body text.</p>"), "expected body paragraph: \(html)")
+        XCTAssertFalse(html.contains("<blockquote"), "alert should replace blockquote: \(html)")
+    }
+
+    func testGitHubAlertWithCustomTitle() {
+        let html = EscapingHTMLFormatter.format("""
+        > [!WARNING] Something specific
+        > Multi
+        > line body.
+        """)
+        XCTAssertTrue(html.contains("markdown-alert-warning"), "expected warning kind: \(html)")
+        XCTAssertTrue(html.contains("Something specific</p>"), "expected custom title text: \(html)")
+        XCTAssertTrue(html.contains("Multi\nline body."), "expected body across lines: \(html)")
+    }
+
+    func testGitHubAlertTagIsCaseInsensitive() {
+        let html = EscapingHTMLFormatter.format("> [!tIp] Pro move")
+        XCTAssertTrue(
+            html.contains(#"<div class="markdown-alert markdown-alert-tip">"#),
+            "case-insensitive tag should match: \(html)"
+        )
+        XCTAssertTrue(html.contains("Pro move</p>"), "expected custom title text: \(html)")
+    }
+
+    func testGitHubAlertSupportsInlineFormattingInCustomTitle() {
+        let html = EscapingHTMLFormatter.format("> [!NOTE] With **bold** title")
+        XCTAssertTrue(
+            html.contains("With <strong>bold</strong> title</p>"),
+            "inline formatting in title should be rendered: \(html)"
+        )
+    }
+
+    func testGitHubAlertIncludesOcticonSVG() {
+        let html = EscapingHTMLFormatter.format("> [!NOTE]")
+        XCTAssertTrue(
+            html.contains(#"<svg class="markdown-alert-icon" viewBox="0 0 16 16""#),
+            "expected Octicon SVG markup: \(html)"
+        )
+        XCTAssertTrue(html.contains("<path d=\""), "expected path data: \(html)")
+    }
+
+    func testUnknownAlertTagFallsBackToBlockquote() {
+        let html = EscapingHTMLFormatter.format("> [!FOO] Nope")
+        XCTAssertTrue(html.contains("<blockquote>"), "unknown tag should be a plain blockquote: \(html)")
+        XCTAssertFalse(html.contains("markdown-alert"), "no alert wrapper for unknown tag: \(html)")
+    }
+
+    func testGitHubAlertEscapesPlainTextInCustomTitle() {
+        // Ampersands and lone `<`/`>` in text should round-trip as entities.
+        // Inline HTML (e.g. <script>) is parsed as InlineHTML and passed
+        // through by design — DOMPurify handles that at render time.
+        let html = EscapingHTMLFormatter.format("> [!CAUTION] R&D < 5")
+        XCTAssertTrue(
+            html.contains("R&amp;D &lt; 5"),
+            "custom title plain text must be HTML-escaped: \(html)"
+        )
+    }
 }


### PR DESCRIPTION
Adds a coloured icon & title to blockquotes with [!Note], [!Tip], [!Important], [!Warning], or [!Caution] on the first line, just [like Github](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

> [!Tip]
> Like this!

On top of Github's structure this also supports [Tangled](https://tangled.org)-style custom titles, so the following:

```
> [!Important] Don't cross the streams
> Try to imagine all life as you know it stopping instantaneously and every molecule in your body exploding at the speed of light. Total protonic reversal.
```

Renders with the Title "Don't cross the streams" instead of the default "Important"