### PR TITLE
Allow-list known Markdown editors in "Open With" (#114)

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -879,6 +879,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
         "com.macromates.TextMate",
         "org.vim.MacVim"
     ]
+    /// Editors we trust to open Markdown even when their Info.plist doesn't pass
+    /// `canEditMarkdown`. Markdown-first apps like iA Writer declare a custom
+    /// imported UTI (which only *conforms to* `net.daringfireball.markdown`) and
+    /// omit `CFBundleTypeExtensions`, so the heuristic can't see them. See #114.
+    private static let editorBundleIDAllowlist: Set<String> = [
+        "pro.writer.mac",           // iA Writer (Mac App Store / direct)
+        "pro.writer.mac-setapp",    // iA Writer (Setapp)
+        "abnerworks.Typora",        // Typora
+        "com.uranusjr.macdown",     // MacDown
+        "md.obsidian"               // Obsidian
+    ]
+    /// Apps that claim a Markdown/plain-text document type but aren't useful as a
+    /// text editor — they pass `canEditMarkdown` only as noise. See #114.
+    private static let editorBundleIDDenylist: Set<String> = [
+        "com.microsoft.Word",
+        "com.ideasoncanvas.mindnode.macos",
+        "com.somac.subtitleburner"
+    ]
 
     private func makeOpenWithItem() -> NSToolbarItem {
         let item = NSMenuToolbarItem(itemIdentifier: .openWith)
@@ -943,7 +961,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSToolbarDelegate, NSSharing
             let plist = infoPlist(at: appURL)
             let bundleID = (plist?["CFBundleIdentifier"] as? String)
                 ?? Bundle(url: appURL)?.bundleIdentifier
-            guard canEditMarkdown(plist: plist) else { return nil }
+            if let bundleID, Self.editorBundleIDDenylist.contains(bundleID) { return nil }
+            let isAllowlisted = bundleID.map(Self.editorBundleIDAllowlist.contains) ?? false
+            guard isAllowlisted || canEditMarkdown(plist: plist) else { return nil }
             return EditorCandidate(url: appURL, bundleID: bundleID)
         }
     }


### PR DESCRIPTION
## Summary

Fixes the "Open With" toolbar/context menu missing Markdown-first editors like iA Writer (#114).

The editor list is discovered via Launch Services and filtered by `canEditMarkdown`, which inspects each app's `CFBundleDocumentTypes`. It only accepts an entry whose UTI exactly equals `net.daringfireball.markdown`, or that lists `md`/`markdown`/`mdown` in `CFBundleTypeExtensions`. Modern Markdown editors (iA Writer et al.) declare a *custom imported UTI* that only **conforms to** `net.daringfireball.markdown` and omit the legacy extensions key, so the heuristic never sees them.

## What's in this change

- **`editorBundleIDAllowlist`** — trusted editor bundle IDs that bypass the `canEditMarkdown` heuristic: iA Writer (`pro.writer.mac`, `pro.writer.mac-setapp`), Typora, MacDown, Obsidian.
- **`editorBundleIDDenylist`** — apps that claim a Markdown/plain-text type but are only noise, hidden outright: Word, MindNode, SubtitleBurner (per the issue thread).
- `editorCandidates(for:)` now drops denylisted apps, lets allowlisted apps through unconditionally, and otherwise falls back to the existing heuristic.

The allowlist is additive — apps not on it still appear if they pass the heuristic, so nothing that worked before is removed.

## Test plan

- [ ] With iA Writer installed, open a `.md` file — iA Writer appears in the "Open With" menu and context menu.
- [ ] Word / MindNode no longer appear in the list.
- [ ] Editors discovered by the heuristic before (VS Code, Sublime, etc.) still appear.