### PR TITLE
Release 0.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.0.24] – 2026-05-19
+
+GitHub-style alert blockquotes now render with their intended labels, and the Open With menu finds more Markdown editors.
+
+### Added
+
+- **GitHub-style alert blockquotes render with labels and colors.** Blockquotes that start with `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, or `[!CAUTION]` now render as alert callouts, including custom titles after the marker ([#113](https://github.com/pluk-inc/markdown-preview/pull/113)).
+
+### Fixed
+
+- **More Markdown editors appear in Open With.** Trusted Markdown-first editors such as iA Writer, Typora, MacDown, and Obsidian are now included even when Launch Services exposes them through custom Markdown UTIs, while noisy non-editors are filtered out ([#116](https://github.com/pluk-inc/markdown-preview/pull/116), [#114](https://github.com/pluk-inc/markdown-preview/issues/114)).
+
+### Contributors
+
+Thanks to the external contributor who shipped in this release:
+
+- [@jphastings](https://github.com/jphastings) — GitHub-style alert blockquotes ([#113](https://github.com/pluk-inc/markdown-preview/pull/113))
+
 ## [0.0.23] – 2026-05-18
 
 Fenced code blocks that carry extra metadata after the language now render the way they should.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.23
-CURRENT_PROJECT_VERSION = 27
+MARKETING_VERSION = 0.0.24
+CURRENT_PROJECT_VERSION = 28


### PR DESCRIPTION
## Summary

- Bump Markdown Preview to 0.0.24 (build 28)
- Add the 0.0.24 changelog entry for GitHub-style alert blockquotes and Open With editor discovery
- Credit @jphastings for the alert blockquote contribution

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -showBuildSettings | rg "MARKETING_VERSION|CURRENT_PROJECT_VERSION|PRODUCT_BUNDLE_IDENTIFIER"`