### PR TITLE
[codex] Fix README repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   A fast, native macOS app for reading Markdown files.
 </p>
 
-<p align="center"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" />&nbsp;<img alt="Swift" src="https://img.shields.io/badge/swift-6.0-orange" />&nbsp;<img alt="License" src="https://img.shields.io/github/license/pluk-inc/md-preview.app" />&nbsp;<img alt="Latest release" src="https://img.shields.io/github/v/release/pluk-inc/md-preview.app" /></p>
+<p align="center"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" />&nbsp;<img alt="Swift" src="https://img.shields.io/badge/swift-6.0-orange" />&nbsp;<img alt="License" src="https://img.shields.io/github/license/pluk-inc/markdown-preview" />&nbsp;<img alt="Latest release" src="https://img.shields.io/github/v/release/pluk-inc/markdown-preview" /></p>
 
 ---
 
@@ -20,7 +20,7 @@
 brew install --cask pluk-inc/tap/markdown-preview
 ```
 
-Or grab the latest signed and notarized DMG from the [Releases](https://github.com/pluk-inc/md-preview.app/releases) page.
+Or grab the latest signed and notarized DMG from the [Releases](https://github.com/pluk-inc/markdown-preview/releases) page.
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary
- Update README badge URLs to use the canonical pluk-inc/markdown-preview repository
- Update the Releases link to avoid the redirected md-preview.app slug

## Verification
- Confirmed the canonical Shields license badge returns MIT
- Confirmed the canonical Shields release badge returns v0.0.24