### PR TITLE
Strip TOML frontmatter

### DIFF
--- a/md-preview/InspectorView.swift
+++ b/md-preview/InspectorView.swift
@@ -25,7 +25,7 @@ extension DocumentMetadata {
 
         let split = MarkdownFrontmatter.split(markdown)
         if let raw = split.raw {
-            meta.frontmatter = MarkdownFrontmatter.parse(raw)
+            meta.frontmatter = MarkdownFrontmatter.parse(raw, format: split.format ?? .yaml)
         }
         let body = split.body
         let bodyLines = body.components(separatedBy: .newlines)
@@ -130,7 +130,7 @@ struct InspectorView: View {
     @ViewBuilder
     private var propertiesTab: some View {
         if metadata.frontmatter.isEmpty {
-            Text("No YAML frontmatter")
+            Text("No frontmatter")
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {

--- a/md-preview/MarkdownFrontmatter.swift
+++ b/md-preview/MarkdownFrontmatter.swift
@@ -16,28 +16,42 @@ struct FrontmatterEntry: Equatable, Identifiable {
 // before parsing and surface the parsed entries in the Inspector instead.
 nonisolated enum MarkdownFrontmatter {
 
-    static func split(_ markdown: String) -> (raw: String?, body: String) {
+    enum Format {
+        case yaml
+        case toml
+    }
+
+    static func split(_ markdown: String) -> (raw: String?, format: Format?, body: String) {
         let stripped = markdown.first == "\u{FEFF}" ? String(markdown.dropFirst()) : markdown
         var lines: [String] = []
         stripped.enumerateLines { line, _ in lines.append(line) }
 
         guard let first = lines.first,
               let delimiter = Delimiter(openingLine: first)
-        else { return (nil, markdown) }
+        else { return (nil, nil, markdown) }
 
         guard let close = lines.dropFirst().firstIndex(where: {
             delimiter.closes($0)
-        }) else { return (nil, markdown) }
+        }) else { return (nil, nil, markdown) }
 
         let raw = lines[1..<close].joined(separator: "\n")
         let body = lines[(close + 1)...].joined(separator: "\n")
-        return (raw, body)
+        return (raw, delimiter.format, body)
     }
 
     // Best-effort parse: each top-level `key: value` line becomes an entry;
     // indented continuation lines append to the previous value. We don't
     // interpret YAML types — values are shown verbatim in the Inspector.
-    static func parse(_ raw: String) -> [FrontmatterEntry] {
+    static func parse(_ raw: String, format: Format = .yaml) -> [FrontmatterEntry] {
+        switch format {
+        case .yaml:
+            parseYaml(raw)
+        case .toml:
+            parseToml(raw)
+        }
+    }
+
+    private static func parseYaml(_ raw: String) -> [FrontmatterEntry] {
         var entries: [FrontmatterEntry] = []
         for rawLine in raw.split(separator: "\n", omittingEmptySubsequences: false) {
             let line = String(rawLine)
@@ -60,9 +74,42 @@ nonisolated enum MarkdownFrontmatter {
         return entries
     }
 
+    private static func parseToml(_ raw: String) -> [FrontmatterEntry] {
+        var entries: [FrontmatterEntry] = []
+        for rawLine in raw.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") || trimmed.hasPrefix("[") { continue }
+
+            guard let equals = line.firstIndex(of: "=") else { continue }
+            let key = line[..<equals].trimmingCharacters(in: .whitespaces)
+            let value = line[line.index(after: equals)...].trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+            entries.append(FrontmatterEntry(id: entries.count, key: key, value: unquoteTomlValue(value)))
+        }
+        return entries
+    }
+
+    private static func unquoteTomlValue(_ value: String) -> String {
+        guard value.count >= 2,
+              let first = value.first,
+              first == value.last,
+              first == "\"" || first == "'"
+        else { return value }
+
+        return String(value.dropFirst().dropLast())
+    }
+
     private enum Delimiter {
         case yaml
         case toml
+
+        var format: Format {
+            switch self {
+            case .yaml: .yaml
+            case .toml: .toml
+            }
+        }
 
         init?(openingLine: String) {
             switch openingLine.trimmingCharacters(in: .whitespaces) {

--- a/md-preview/MarkdownFrontmatter.swift
+++ b/md-preview/MarkdownFrontmatter.swift
@@ -11,10 +11,9 @@ struct FrontmatterEntry: Equatable, Identifiable {
     let value: String
 }
 
-// Swift-markdown is CommonMark: it has no YAML frontmatter notion, so a closing
-// `---` would otherwise turn the preceding lines into a setext H2 in the
-// rendered output. We strip the block before parsing and surface the parsed
-// entries in the Inspector instead.
+// Swift-markdown is CommonMark: it has no frontmatter notion, so delimiter
+// blocks can be rendered as document content. We strip supported frontmatter
+// before parsing and surface the parsed entries in the Inspector instead.
 nonisolated enum MarkdownFrontmatter {
 
     static func split(_ markdown: String) -> (raw: String?, body: String) {
@@ -23,12 +22,11 @@ nonisolated enum MarkdownFrontmatter {
         stripped.enumerateLines { line, _ in lines.append(line) }
 
         guard let first = lines.first,
-              first.trimmingCharacters(in: .whitespaces) == "---"
+              let delimiter = Delimiter(openingLine: first)
         else { return (nil, markdown) }
 
         guard let close = lines.dropFirst().firstIndex(where: {
-            let trimmed = $0.trimmingCharacters(in: .whitespaces)
-            return trimmed == "---" || trimmed == "..."
+            delimiter.closes($0)
         }) else { return (nil, markdown) }
 
         let raw = lines[1..<close].joined(separator: "\n")
@@ -60,5 +58,31 @@ nonisolated enum MarkdownFrontmatter {
             entries.append(FrontmatterEntry(id: entries.count, key: key, value: value))
         }
         return entries
+    }
+
+    private enum Delimiter {
+        case yaml
+        case toml
+
+        init?(openingLine: String) {
+            switch openingLine.trimmingCharacters(in: .whitespaces) {
+            case "---":
+                self = .yaml
+            case "+++":
+                self = .toml
+            default:
+                return nil
+            }
+        }
+
+        func closes(_ line: String) -> Bool {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            switch self {
+            case .yaml:
+                return trimmed == "---" || trimmed == "..."
+            case .toml:
+                return trimmed == "+++"
+            }
+        }
     }
 }

--- a/samples/toml-frontmatter.md
+++ b/samples/toml-frontmatter.md
@@ -1,0 +1,11 @@
++++
+title = "TOML Frontmatter Test"
+date = "2026-05-21"
+tags = ["markdown", "frontmatter", "toml"]
++++
+
+# TOML Frontmatter Test
+
+The TOML frontmatter block above should not render in the preview.
+
+If the fix is working, this heading is the first visible content.

--- a/tests/swift-tests/Sources/MarkdownHelpers/MarkdownFrontmatter.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/MarkdownFrontmatter.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/MarkdownFrontmatter.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownFrontmatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownFrontmatterTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import MarkdownHelpers
+
+final class MarkdownFrontmatterTests: XCTestCase {
+
+    func testSplitsYamlFrontmatter() {
+        let markdown = """
+        ---
+        title: Draft
+        ---
+        # Body
+        """
+
+        let result = MarkdownFrontmatter.split(markdown)
+
+        XCTAssertEqual(result.raw, "title: Draft")
+        XCTAssertEqual(result.body, "# Body")
+    }
+
+    func testSplitsYamlFrontmatterWithEllipsisCloser() {
+        let markdown = """
+        ---
+        title: Draft
+        ...
+        # Body
+        """
+
+        let result = MarkdownFrontmatter.split(markdown)
+
+        XCTAssertEqual(result.raw, "title: Draft")
+        XCTAssertEqual(result.body, "# Body")
+    }
+
+    func testSplitsTomlFrontmatter() {
+        let markdown = """
+        +++
+        title = "Draft"
+        +++
+        # Body
+        """
+
+        let result = MarkdownFrontmatter.split(markdown)
+
+        XCTAssertEqual(result.raw, #"title = "Draft""#)
+        XCTAssertEqual(result.body, "# Body")
+    }
+
+    func testDoesNotSplitTomlFrontmatterWithYamlCloser() {
+        let markdown = """
+        +++
+        title = "Draft"
+        ---
+        # Body
+        """
+
+        let result = MarkdownFrontmatter.split(markdown)
+
+        XCTAssertNil(result.raw)
+        XCTAssertEqual(result.body, markdown)
+    }
+
+    func testDoesNotSplitPlusSignsAwayFromDocumentStart() {
+        let markdown = """
+        # Body
+
+        +++
+        title = "Draft"
+        +++
+        """
+
+        let result = MarkdownFrontmatter.split(markdown)
+
+        XCTAssertNil(result.raw)
+        XCTAssertEqual(result.body, markdown)
+    }
+}

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownFrontmatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownFrontmatterTests.swift
@@ -15,6 +15,7 @@ final class MarkdownFrontmatterTests: XCTestCase {
         let result = MarkdownFrontmatter.split(markdown)
 
         XCTAssertEqual(result.raw, "title: Draft")
+        XCTAssertEqual(result.format, .yaml)
         XCTAssertEqual(result.body, "# Body")
     }
 
@@ -29,6 +30,7 @@ final class MarkdownFrontmatterTests: XCTestCase {
         let result = MarkdownFrontmatter.split(markdown)
 
         XCTAssertEqual(result.raw, "title: Draft")
+        XCTAssertEqual(result.format, .yaml)
         XCTAssertEqual(result.body, "# Body")
     }
 
@@ -43,6 +45,7 @@ final class MarkdownFrontmatterTests: XCTestCase {
         let result = MarkdownFrontmatter.split(markdown)
 
         XCTAssertEqual(result.raw, #"title = "Draft""#)
+        XCTAssertEqual(result.format, .toml)
         XCTAssertEqual(result.body, "# Body")
     }
 
@@ -57,6 +60,7 @@ final class MarkdownFrontmatterTests: XCTestCase {
         let result = MarkdownFrontmatter.split(markdown)
 
         XCTAssertNil(result.raw)
+        XCTAssertNil(result.format)
         XCTAssertEqual(result.body, markdown)
     }
 
@@ -72,6 +76,36 @@ final class MarkdownFrontmatterTests: XCTestCase {
         let result = MarkdownFrontmatter.split(markdown)
 
         XCTAssertNil(result.raw)
+        XCTAssertNil(result.format)
         XCTAssertEqual(result.body, markdown)
+    }
+
+    func testParsesYamlEntries() {
+        let entries = MarkdownFrontmatter.parse("""
+        title: Draft
+        tags:
+          - markdown
+        """, format: .yaml)
+
+        XCTAssertEqual(entries, [
+            FrontmatterEntry(id: 0, key: "title", value: "Draft"),
+            FrontmatterEntry(id: 1, key: "tags", value: "- markdown")
+        ])
+    }
+
+    func testParsesTomlEntries() {
+        let entries = MarkdownFrontmatter.parse("""
+        title = "Draft"
+        date = "2026-05-21"
+        draft = false
+        tags = ["markdown", "frontmatter"]
+        """, format: .toml)
+
+        XCTAssertEqual(entries, [
+            FrontmatterEntry(id: 0, key: "title", value: "Draft"),
+            FrontmatterEntry(id: 1, key: "date", value: "2026-05-21"),
+            FrontmatterEntry(id: 2, key: "draft", value: "false"),
+            FrontmatterEntry(id: 3, key: "tags", value: #"["markdown", "frontmatter"]"#)
+        ])
     }
 }


### PR DESCRIPTION
## Summary
- strip TOML frontmatter delimited by matching +++ blocks before Markdown rendering
- keep existing YAML frontmatter behavior, including ... closers
- add helper tests covering YAML, TOML, and malformed delimiter cases

Fixes #118

## Tests
- swift test --package-path tests/swift-tests
- xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build