### PR TITLE
Keep preview on original file after atomic saves

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -1307,7 +1307,8 @@ private final class FileWatcher {
             // differs from the watcher's URL — surface that to the host.
             if !event.intersection([.delete, .rename, .revoke]).isEmpty {
                 if let newURL = self.currentPath(),
-                   newURL.standardizedFileURL != self.url.standardizedFileURL {
+                   newURL.standardizedFileURL != self.url.standardizedFileURL,
+                   !FileManager.default.fileExists(atPath: self.url.path) {
                     self.onRename?(newURL)
                 }
                 self.reopen()


### PR DESCRIPTION
## Summary
- keep the current document URL when an editor atomic-save moves the watched inode to a backup path
- continue reloading the original markdown path once it has been replaced

Fixes #119

## Tests
- xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build