### PR TITLE
Add spacebar page scrolling

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -749,6 +749,47 @@ nonisolated enum MarkdownHTML {
 
         window.MdPreviewHost = { pushHeight, measureHeight };
 
+        function elementForEventTarget(target) {
+            if (target instanceof Element) return target;
+            if (target && target.parentElement instanceof Element) return target.parentElement;
+            return document.activeElement instanceof Element ? document.activeElement : null;
+        }
+
+        function spaceBelongsToFocusedControl(target) {
+            const el = elementForEventTarget(target);
+            if (!el) return false;
+            if (el.isContentEditable) return true;
+            return !!el.closest([
+                'button',
+                'input',
+                'select',
+                'textarea',
+                'summary',
+                'audio',
+                'video',
+                '[contenteditable]',
+                '[role="button"]',
+                '[role="checkbox"]',
+                '[role="switch"]',
+                '[role="textbox"]',
+                '[role="combobox"]',
+                '[role="listbox"]',
+                '[role="menuitem"]'
+            ].join(','));
+        }
+
+        document.addEventListener('keydown', (event) => {
+            const isSpace = event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space';
+            if (!isSpace || event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+            if (spaceBelongsToFocusedControl(event.target)) return;
+
+            const value = event.shiftKey ? 'pageUp' : 'pageDown';
+            if (post({ kind: 'scroll', value })) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+        }, true);
+
         function decorateCodeBlocks() {
             document.querySelectorAll('pre > code').forEach((code) => {
                 const pre = code.parentElement;

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -819,8 +819,8 @@ private final class NonScrollingWKWebView: WKWebView {
     override func scrollLineDown(_ sender: Any?)          { forwardScrollAction(.lineDown) }
     override func scrollPageUp(_ sender: Any?)            { forwardScrollAction(.pageUp) }
     override func scrollPageDown(_ sender: Any?)          { forwardScrollAction(.pageDown) }
-    override func moveUpAndModifySelection(_ sender: Any?) { forwardScrollAction(.lineUp) }
-    override func moveDownAndModifySelection(_ sender: Any?) { forwardScrollAction(.lineDown) }
+    override func moveUpAndModifySelection(_ sender: Any?) { forwardScrollAction(.pageUp) }
+    override func moveDownAndModifySelection(_ sender: Any?) { forwardScrollAction(.pageDown) }
     override func pageUp(_ sender: Any?)                  { forwardScrollAction(.pageUp) }
     override func pageDown(_ sender: Any?)                { forwardScrollAction(.pageDown) }
     override func scrollToBeginningOfDocument(_ sender: Any?) { forwardScrollAction(.top) }
@@ -856,9 +856,9 @@ private final class NonScrollingWKWebView: WKWebView {
 
         switch Int(scalar.value) {
         case NSUpArrowFunctionKey:
-            return forwardScrollAction(.lineUp)
+            return forwardScrollAction(.pageUp)
         case NSDownArrowFunctionKey:
-            return forwardScrollAction(.lineDown)
+            return forwardScrollAction(.pageDown)
         default:
             return false
         }
@@ -889,9 +889,9 @@ private final class NonScrollingWKWebView: WKWebView {
         case #selector(scrollLineDown(_:)):
             return forwardScrollAction(.lineDown)
         case #selector(moveUpAndModifySelection(_:)):
-            return forwardScrollAction(.lineUp)
+            return forwardScrollAction(.pageUp)
         case #selector(moveDownAndModifySelection(_:)):
-            return forwardScrollAction(.lineDown)
+            return forwardScrollAction(.pageDown)
         case #selector(scrollPageUp(_:)), #selector(pageUp(_:)):
             return forwardScrollAction(.pageUp)
         case #selector(scrollPageDown(_:)), #selector(pageDown(_:)):

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -248,6 +248,16 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(text, forType: .string)
+        case "scroll":
+            guard let value = dict["value"] as? String else { return }
+            switch value {
+            case "pageUp":
+                performScrollAction(.pageUp)
+            case "pageDown":
+                performScrollAction(.pageDown)
+            default:
+                break
+            }
         default:
             break
         }

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -787,7 +787,7 @@ private final class NonScrollingWKWebView: WKWebView {
 
     override func keyDown(with event: NSEvent) {
         if forwardHeadingKey(event) { return }
-        if forwardShiftSpaceKey(event) { return }
+        if forwardShiftArrowKey(event) { return }
         if isStandardScrollKey(event) {
             interpretKeyEvents([event])
             return
@@ -846,13 +846,20 @@ private final class NonScrollingWKWebView: WKWebView {
         }
     }
 
-    private func forwardShiftSpaceKey(_ event: NSEvent) -> Bool {
+    private func forwardShiftArrowKey(_ event: NSEvent) -> Bool {
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         guard modifiers.subtracting([.shift, .capsLock]).isEmpty,
               modifiers.contains(.shift),
-              event.charactersIgnoringModifiers == " " else { return false }
+              let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first else { return false }
 
-        return forwardScrollAction(.pageUp)
+        switch Int(scalar.value) {
+        case NSUpArrowFunctionKey:
+            return forwardScrollAction(.lineUp)
+        case NSDownArrowFunctionKey:
+            return forwardScrollAction(.lineDown)
+        default:
+            return false
+        }
     }
 
     private func isStandardScrollKey(_ event: NSEvent) -> Bool {

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -819,6 +819,8 @@ private final class NonScrollingWKWebView: WKWebView {
     override func scrollLineDown(_ sender: Any?)          { forwardScrollAction(.lineDown) }
     override func scrollPageUp(_ sender: Any?)            { forwardScrollAction(.pageUp) }
     override func scrollPageDown(_ sender: Any?)          { forwardScrollAction(.pageDown) }
+    override func moveUpAndModifySelection(_ sender: Any?) { forwardScrollAction(.lineUp) }
+    override func moveDownAndModifySelection(_ sender: Any?) { forwardScrollAction(.lineDown) }
     override func pageUp(_ sender: Any?)                  { forwardScrollAction(.pageUp) }
     override func pageDown(_ sender: Any?)                { forwardScrollAction(.pageDown) }
     override func scrollToBeginningOfDocument(_ sender: Any?) { forwardScrollAction(.top) }
@@ -885,6 +887,10 @@ private final class NonScrollingWKWebView: WKWebView {
         case #selector(scrollLineUp(_:)):
             return forwardScrollAction(.lineUp)
         case #selector(scrollLineDown(_:)):
+            return forwardScrollAction(.lineDown)
+        case #selector(moveUpAndModifySelection(_:)):
+            return forwardScrollAction(.lineUp)
+        case #selector(moveDownAndModifySelection(_:)):
             return forwardScrollAction(.lineDown)
         case #selector(scrollPageUp(_:)), #selector(pageUp(_:)):
             return forwardScrollAction(.pageUp)

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -787,6 +787,7 @@ private final class NonScrollingWKWebView: WKWebView {
 
     override func keyDown(with event: NSEvent) {
         if forwardHeadingKey(event) { return }
+        if forwardShiftSpaceKey(event) { return }
         if isStandardScrollKey(event) {
             interpretKeyEvents([event])
             return
@@ -843,6 +844,15 @@ private final class NonScrollingWKWebView: WKWebView {
         default:
             return false
         }
+    }
+
+    private func forwardShiftSpaceKey(_ event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard modifiers.subtracting([.shift, .capsLock]).isEmpty,
+              modifiers.contains(.shift),
+              event.charactersIgnoringModifiers == " " else { return false }
+
+        return forwardScrollAction(.pageUp)
     }
 
     private func isStandardScrollKey(_ event: NSEvent) -> Bool {


### PR DESCRIPTION
## Summary
- Add a rendered-page keydown bridge for Space and Shift+Space.
- Route those events to the existing outer NSScrollView page up/down actions while leaving focused controls alone.
- Forward Shift+Up Arrow and Shift+Down Arrow through both the native key path and AppKit modify-selection command path so they page-scroll the preview instead of falling through to WebKit.

## Validation
- git diff --check
- swift test --package-path tests/swift-tests
- xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build

Fixes #129