### PR TITLE
[codex] Restore empty launch file picker

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -29,7 +29,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
-        return false
+        NSDocumentController.shared.documents.isEmpty
+    }
+
+    func applicationOpenUntitledFile(_ sender: NSApplication) -> Bool {
+        promptForDocument()
+        return true
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {


### PR DESCRIPTION
## Summary
- Routes the document-app empty-launch path through the existing Markdown file picker.
- Keeps normal document URL opens on the native NSDocumentController path.

## Root cause
After moving to native document windows, `applicationShouldOpenUntitledFile` returned `false`, which stopped AppKit from opening an untitled document on cold launch but did not replace that request with the previous file-selection flow.

## Validation
- `git diff --check`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`