### PR TITLE
[codex] Allow opening folders from the picker

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -114,6 +114,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func promptForDocument() {
         let panel = makeOpenPanel()
         guard panel.runModal() == .OK, let url = panel.url else { return }
+        if url.isExistingDirectory {
+            openFolder(url)
+            return
+        }
+
         isOpeningDocumentFromPrompt = true
         NSDocumentController.shared.openDocument(withContentsOf: url,
                                                  display: true) { [weak self] _, _, error in
@@ -123,12 +128,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func openFolder(_ url: URL) {
+        if let controller = activeDocumentWindowController {
+            controller.openFolder(url)
+            return
+        }
+
+        let document = MarkdownDocument()
+        NSDocumentController.shared.addDocument(document)
+        document.makeWindowControllers()
+        document.showWindows()
+        guard let controller = document.windowControllers.first as? DocumentWindowController else {
+            return
+        }
+        controller.openFolder(url)
+    }
+
     private func makeOpenPanel() -> NSOpenPanel {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
+        panel.canChooseDirectories = true
         panel.canChooseFiles = true
-        panel.message = "Choose a Markdown file"
+        panel.message = "Choose a Markdown file or folder"
         panel.allowedContentTypes = Self.markdownFileExtensions
             .compactMap { UTType(filenameExtension: $0) }
         return panel

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -124,6 +124,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     }
 
     private func present(url: URL) {
+        if url.isExistingDirectory {
+            openFolder(url)
+            return
+        }
+
         // Switching to a different file blanks the preview so the previous
         // doc doesn't linger on screen during sheet dismissal + load.
         let isFileSwitch = currentFileURL != nil && currentFileURL != url
@@ -1252,6 +1257,18 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         }
     }
 
+    func openFolder(_ folderURL: URL) {
+        let folderURL = folderURL.standardizedFileURL
+        if currentFileURL == nil {
+            documentWindow.title = folderURL.lastPathComponent
+        }
+        (documentWindow.contentViewController as? MainSplitViewController)?
+            .openFolder(folderURL, selectedFileURL: currentFileURL)
+        documentWindow.makeKeyAndOrderFront(nil)
+        NSApp.activate()
+        syncSidebarMenuState()
+    }
+
     func contextMenuEditorItems(for fileURL: URL) -> [NSMenuItem] {
         let candidates = editorCandidates(for: fileURL)
         let defaultEditor = resolveDefaultEditor(among: candidates)
@@ -1311,6 +1328,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let panel = makeOpenPanel()
         panel.beginSheetModal(for: documentWindow) { [weak self] response in
             guard let self, response == .OK, let url = panel.url else { return }
+            if url.isExistingDirectory {
+                self.openFolder(url)
+                return
+            }
             self.openInNewWindow(url)
         }
     }
@@ -1318,9 +1339,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func makeOpenPanel() -> NSOpenPanel {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
+        panel.canChooseDirectories = true
         panel.canChooseFiles = true
-        panel.message = "Choose a Markdown file"
+        panel.message = "Choose a Markdown file or folder"
         panel.allowedContentTypes = Self.markdownFileExtensions
             .compactMap { UTType(filenameExtension: $0) }
         return panel

--- a/md-preview/FileURLHelpers.swift
+++ b/md-preview/FileURLHelpers.swift
@@ -1,0 +1,18 @@
+//
+//  FileURLHelpers.swift
+//  md-preview
+//
+
+import Foundation
+
+extension URL {
+    nonisolated var isExistingDirectory: Bool {
+        (try? resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    nonisolated func isDescendantOrSame(of other: URL) -> Bool {
+        let mine = standardizedFileURL.path
+        let root = other.standardizedFileURL.path
+        return mine == root || mine.hasPrefix(root + "/")
+    }
+}

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -64,6 +64,12 @@ final class MainSplitViewController: NSSplitViewController {
         inspectorViewController?.display(metadata: DocumentMetadata.make(url: newURL, markdown: markdown))
     }
 
+    func openFolder(_ folderURL: URL, selectedFileURL: URL?) {
+        sidebarViewController?.openFolder(folderURL, selectedFileURL: selectedFileURL)
+        setSidebarMode(.files)
+        showSidebar()
+    }
+
     func clearContent() {
         contentViewController?.clearContent()
     }

--- a/md-preview/MarkdownDocument.swift
+++ b/md-preview/MarkdownDocument.swift
@@ -9,9 +9,14 @@ import Synchronization
 final class MarkdownDocument: NSDocument {
 
     private nonisolated let markdownStorage = Mutex("")
+    private nonisolated let folderStorage = Mutex<URL?>(nil)
 
     var markdown: String {
         markdownStorage.withLock { $0 }
+    }
+
+    private var folderURL: URL? {
+        folderStorage.withLock { $0 }
     }
 
     override init() {
@@ -30,13 +35,30 @@ final class MarkdownDocument: NSDocument {
     override func makeWindowControllers() {
         let controller = DocumentWindowController()
         addWindowController(controller)
+        if let folderURL {
+            controller.display(markdown: "", fileURL: nil)
+            controller.openFolder(folderURL)
+            return
+        }
         controller.display(markdown: markdown, fileURL: fileURL)
+    }
+
+    override nonisolated func read(from url: URL, ofType typeName: String) throws {
+        if url.isExistingDirectory {
+            folderStorage.withLock { $0 = url.standardizedFileURL }
+            markdownStorage.withLock { $0 = "" }
+            return
+        }
+
+        let data = try Data(contentsOf: url)
+        try read(from: data, ofType: typeName)
     }
 
     override nonisolated func read(from data: Data, ofType typeName: String) throws {
         guard let text = String(data: data, encoding: .utf8) else {
             throw CocoaError(.fileReadCorruptFile)
         }
+        folderStorage.withLock { $0 = nil }
         markdownStorage.withLock { $0 = text }
     }
 

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -157,18 +157,34 @@ final class SidebarViewController: NSViewController {
         setOpenFileURL(newURL)
     }
 
+    /// Mounts an explicitly chosen folder as the Project Navigator root.
+    /// If the current document is inside that folder, keep it selected.
+    func openFolder(_ folderURL: URL, selectedFileURL: URL?) {
+        loadViewIfNeeded()
+        let root = folderURL.standardizedFileURL
+        pendingFolderURL = root
+        if let selectedFileURL, selectedFileURL.isDescendantOrSame(of: root) {
+            pendingFileURL = selectedFileURL.standardizedFileURL
+        } else {
+            pendingFileURL = nil
+        }
+        if currentMode == .files {
+            refreshNavigatorIfNeeded()
+        }
+    }
+
     /// Defers folder enumeration until the user is actually in the
     /// navigator (saves disk walks on every TOC-mode open). Keeps the
     /// existing root if the new file is a descendant; otherwise resets
     /// so an unrelated File → Open updates the tree.
     private func setOpenFileURL(_ fileURL: URL?) {
-        let parent = fileURL?.deletingLastPathComponent()
+        let parent = fileURL?.deletingLastPathComponent().standardizedFileURL
         if let parent, let current = loadedFolderURL, parent.isDescendantOrSame(of: current) {
             pendingFolderURL = current
         } else {
             pendingFolderURL = parent
         }
-        pendingFileURL = fileURL
+        pendingFileURL = fileURL?.standardizedFileURL
         if currentMode == .files {
             refreshNavigatorIfNeeded()
         }
@@ -452,7 +468,7 @@ final class ProjectNavigatorView: NSView {
 
     func setRoot(_ url: URL?) {
         cancelAllWatchers()
-        rootNode = url.map { FileNode(url: $0, isDirectory: true) }
+        rootNode = url.map { FileNode(url: $0.standardizedFileURL, isDirectory: true) }
         outlineView.reloadData()
         if let rootNode {
             outlineView.expandItem(rootNode)
@@ -765,14 +781,6 @@ extension ProjectNavigatorView: NSOutlineViewDelegate {
     func outlineViewItemDidExpand(_ notification: Notification) {
         // Newly-loaded subtree needs its own watcher.
         syncWatchers()
-    }
-}
-
-private extension URL {
-    func isDescendantOrSame(of other: URL) -> Bool {
-        let mine = standardizedFileURL.path
-        let root = other.standardizedFileURL.path
-        return mine == root || mine.hasPrefix(root + "/")
     }
 }
 


### PR DESCRIPTION
## Summary
- Allows the app open panel to choose either a Markdown file or a folder.
- Mounts a chosen folder as the Project Navigator root and switches the sidebar into Project Navigator mode.
- Keeps the currently open document selected when it lives inside the chosen folder.

## Context
A user asked whether the app intentionally only opens Markdown files. Their desired workflow is closer to Obsidian: open a root folder and browse all Markdown files from that folder, rather than first opening one file and only seeing that file's parent folder.

## Notes
This keeps the existing lazy Project Navigator behavior, so the app does not eagerly render or load every Markdown file in the tree.

## Validation
- `git diff --check`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`