### PR TITLE
[codex] Add command line tools installer

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -32,6 +32,8 @@
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://release.md-preview.app/v1/apps/doc.md-preview/appcast.xml</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Markdown Preview uses Terminal to install the optional command line tools.</string>
 	<key>SUPublicEDKey</key>
 	<string>gIQjgqfjkIR+egQ4S1oBLxE/NCDxpXXGdZXSpn04VAY=</string>
 	<key>UTImportedTypeDeclarations</key>

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ Or grab the latest signed and notarized DMG from the [Releases](https://github.c
 - **Inspector panel** — toggleable side panel with file metadata.
 - **In-document search** — toolbar search field plus standard <kbd>⌘F</kbd> / <kbd>⌘G</kbd> / <kbd>⌘⇧G</kbd> for next/previous match.
 - **Open With** — switch to your real editor (VS Code, Cursor, Zed, Sublime, BBEdit, Nova, CotEditor, TextMate, MacVim, Xcode, TextEdit) without leaving the preview. The list filters to apps that actually declare an editor role for Markdown, and remembers your pick.
+- **Open in LLM** — send the current Markdown file to Codex, Claude, or ChatGPT from the toolbar. Supported apps open with file or folder context where possible, with a copy-and-open fallback for longer prompts.
 - **Text zoom** — bump preview text up or down with the toolbar's <kbd>A A</kbd> control or <kbd>⌘+</kbd> / <kbd>⌘−</kbd> / <kbd>⌘0</kbd>. Discrete Safari-style stops from 50% to 300%.
 - **Customizable toolbar** — drag in the items you actually use (Print, Copy, Zoom, Sidebar, Open With, Inspector, Share, Search) via *View → Customize Toolbar…* Standard AppKit affordance, your layout sticks across launches.
 - **Share = copy the source** — the share toolbar feeds the picker the Markdown text itself, so **Copy** writes the raw source to the clipboard (great for pasting into ChatGPT / Claude), and Mail, Messages, and Notes get the content in the body instead of a file URL.
 - **Quick Look extension** — system-wide `.md` previews from Finder spacebar, Spotlight, and Mail attachments without launching the app.
+- **Command line tools** — install `mdp`, `md-preview`, and `markdown-preview` from the app menu, then open files or folders from any shell with commands like `mdp README.md` or `mdp .`.
 - **Default handler** — offers to register itself as the default `.md` opener on first launch.
 
 ## Supported file types

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -7,8 +7,39 @@ import Cocoa
 import Sparkle
 import UniformTypeIdentifiers
 
+private enum CommandLineToolInstallError: LocalizedError {
+    case terminalAutomationFailed(String?)
+    case installerScriptWriteFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .terminalAutomationFailed(let message):
+            if let message, !message.isEmpty {
+                return "Terminal automation failed: \(message)"
+            }
+            return "Terminal automation failed."
+        case .installerScriptWriteFailed(let message):
+            return "Failed to write CLI installer script: \(message)"
+        }
+    }
+}
+
+private extension String {
+    var appleScriptQuotedString: String {
+        let escaped = replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    var shellQuotedString: String {
+        "'\(replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+
 @main
 final class AppDelegate: NSObject, NSApplicationDelegate {
+
+    @IBOutlet private weak var checkForUpdatesMenuItem: NSMenuItem?
 
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -28,6 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         installSidebarViewMenuItems()
         installGoMenu()
+        installAppMenuItemIcons()
         installZoomMenuItemIcons()
         scheduleDocumentPrompt(requiresNoDocuments: true)
     }
@@ -49,6 +81,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            if url.isExistingDirectory {
+                openFolder(url)
+                continue
+            }
+
+            NSDocumentController.shared.openDocument(withContentsOf: url,
+                                                     display: true) { _, _, error in
+                guard let error else { return }
+                NSAlert(error: error).runModal()
+            }
+        }
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
     }
@@ -59,6 +106,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBAction func checkForUpdates(_ sender: Any?) {
         updaterController.updater.checkForUpdates()
+    }
+
+    @objc private func installCommandLineTools(_ sender: Any?) {
+        do {
+            let installerScriptURL = try writeCommandLineToolInstallerScript()
+            let installCommand = makeCommandLineToolInstallCommand(scriptURL: installerScriptURL)
+            try runInstallCommandInTerminal(installCommand)
+        } catch {
+            NSLog("Failed to run Markdown Preview CLI installer in Terminal: \(error.localizedDescription)")
+        }
     }
 
     @IBAction func openDocument(_ sender: Any?) {
@@ -177,6 +234,236 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return panel
     }
 
+    private func makeCommandLineToolInstallerScript() -> String {
+        let launcherScript = """
+        #!/bin/sh
+        # Managed by Markdown Preview CLI
+        if [ "$#" -eq 0 ]; then
+          exec open -b "doc.md-preview" .
+        else
+          exec open -b "doc.md-preview" "$@"
+        fi
+        """
+
+        let installerScript = """
+        #!/bin/sh
+        set -eu
+        installer_path=$0
+        trap 'rm -f "$installer_path"' EXIT
+
+        path_contains() {
+          case ":$PATH:" in
+            *":$1:"*) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        can_install_without_sudo() {
+          dir="$1"
+          if [ -d "$dir" ]; then
+            [ -w "$dir" ] && [ -x "$dir" ]
+            return
+          fi
+
+          parent="${dir%/*}"
+          [ "$parent" != "$dir" ] || parent="."
+          [ -d "$parent" ] && [ -w "$parent" ] && [ -x "$parent" ]
+        }
+
+        is_safe_path_dir() {
+          case "$1" in
+            ""|.|/bin|/sbin|/usr/bin|/usr/sbin|/System/*) return 1 ;;
+            /*) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        choose_install_dir() {
+          for dir in "$HOME/.local/bin" "$HOME/bin"; do
+            if path_contains "$dir" && can_install_without_sudo "$dir"; then
+              printf '%s\t%s\n' "$dir" "false"
+              return 0
+            fi
+          done
+
+          old_ifs=$IFS
+          IFS=:
+          set -- $PATH
+          IFS=$old_ifs
+
+          for dir in /usr/local/bin /opt/homebrew/bin; do
+            if path_contains "$dir"; then
+              if can_install_without_sudo "$dir"; then
+                printf '%s\t%s\n' "$dir" "false"
+              else
+                printf '%s\t%s\n' "$dir" "true"
+              fi
+              return 0
+            fi
+          done
+
+          for dir do
+            if is_safe_path_dir "$dir" && can_install_without_sudo "$dir"; then
+              printf '%s\t%s\n' "$dir" "false"
+              return 0
+            fi
+          done
+
+          for dir do
+            if is_safe_path_dir "$dir"; then
+              printf '%s\t%s\n' "$dir" "true"
+              return 0
+            fi
+          done
+
+          return 1
+        }
+
+        choice=$(choose_install_dir) || {
+          echo "Could not find a usable PATH directory for Markdown Preview command line tools." >&2
+          exit 1
+        }
+
+        install_dir=${choice%	*}
+        needs_sudo=${choice#*	}
+        primary="$install_dir/md-preview"
+
+        is_markdown_preview_launcher() {
+          path="$1"
+          [ -f "$path" ] && [ ! -L "$path" ] || return 1
+          if grep -q '^# Managed by Markdown Preview CLI$' "$path"; then
+            return 0
+          fi
+          grep -q 'exec open -b "doc.md-preview"' "$path"
+        }
+
+        can_replace_primary() {
+          path="$1"
+          if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+            return 0
+          fi
+          is_markdown_preview_launcher "$path"
+        }
+
+        can_replace_alias() {
+          alias_path="$1"
+          if [ ! -e "$alias_path" ] && [ ! -L "$alias_path" ]; then
+            return 0
+          fi
+          [ -L "$alias_path" ] || return 1
+          alias_target=$(readlink "$alias_path" || true)
+          [ "$alias_target" = "md-preview" ] ||
+            [ "$alias_target" = "$primary" ] ||
+            [ "$alias_target" = "$install_dir/md-preview" ]
+        }
+
+        refuse_existing_command() {
+          echo "Refusing to replace existing command that was not installed by Markdown Preview: $1" >&2
+          exit 1
+        }
+
+        can_replace_primary "$primary" || refuse_existing_command "$primary"
+        for alias in mdp markdown-preview; do
+          can_replace_alias "$install_dir/$alias" || refuse_existing_command "$install_dir/$alias"
+        done
+
+        tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/md-preview-cli.XXXXXX")
+        trap 'rm -rf "$tmp_dir"; rm -f "$installer_path"' EXIT
+
+        cat > "$tmp_dir/md-preview" <<'MD_PREVIEW_CLI'
+        \(launcherScript)
+        MD_PREVIEW_CLI
+
+        chmod 755 "$tmp_dir/md-preview"
+
+        if [ "$needs_sudo" = "true" ]; then
+          echo "Installing Markdown Preview command line tools to $install_dir requires your password."
+          sudo mkdir -p "$install_dir"
+          sudo install -m 755 "$tmp_dir/md-preview" "$primary"
+        else
+          mkdir -p "$install_dir"
+          install -m 755 "$tmp_dir/md-preview" "$primary"
+        fi
+
+        for alias in mdp markdown-preview; do
+          alias_path="$install_dir/$alias"
+          if [ "$needs_sudo" = "true" ]; then
+            sudo ln -sfn "md-preview" "$alias_path"
+          else
+            ln -sfn "md-preview" "$alias_path"
+          fi
+        done
+
+        echo
+        echo "Markdown Preview CLI is ready."
+        echo
+        echo "Use any of these commands:"
+        echo "  mdp"
+        echo "  md-preview"
+        echo "  markdown-preview"
+        echo
+        echo "Examples:"
+        echo "  mdp README.md        Open a Markdown file"
+        echo "  mdp .                Open the current folder"
+        echo "  mdp docs             Browse a folder in Markdown Preview"
+        echo
+        echo "Tips:"
+        echo "  Use mdp for the shortest command."
+        echo "  Re-run Install CLI... after updating the app to refresh these commands."
+        echo "  Installed in: $install_dir"
+        echo
+
+        if command -v mdp >/dev/null 2>&1; then
+          echo "Try it now: mdp ."
+        else
+          echo "Open a new terminal window, then try: mdp ."
+        fi
+        """
+
+        return installerScript
+    }
+
+    private func writeCommandLineToolInstallerScript() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("install-markdown-preview-cli-\(UUID().uuidString).sh")
+
+        do {
+            try makeCommandLineToolInstallerScript().write(to: url,
+                                                           atomically: true,
+                                                           encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o700],
+                                                  ofItemAtPath: url.path)
+            return url
+        } catch {
+            throw CommandLineToolInstallError.installerScriptWriteFailed(error.localizedDescription)
+        }
+    }
+
+    private func makeCommandLineToolInstallCommand(scriptURL: URL) -> String {
+        "/bin/sh \(scriptURL.path.shellQuotedString)"
+    }
+
+    private func runInstallCommandInTerminal(_ command: String) throws {
+        let source = """
+        tell application "Terminal"
+            activate
+            do script \(command.appleScriptQuotedString)
+        end tell
+        """
+
+        var errorInfo: NSDictionary?
+        guard let script = NSAppleScript(source: source) else {
+            throw CommandLineToolInstallError.terminalAutomationFailed(nil)
+        }
+
+        script.executeAndReturnError(&errorInfo)
+        if let errorInfo {
+            let message = errorInfo[NSAppleScript.errorMessage] as? String
+                ?? errorInfo.description
+            throw CommandLineToolInstallError.terminalAutomationFailed(message)
+        }
+    }
+
     private func installGoMenu() {
         guard let mainMenu = NSApp.mainMenu,
               mainMenu.items.first(where: { $0.title == "Go" }) == nil else { return }
@@ -271,6 +558,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let item = viewMenu.items.first(where: { $0.title == title }),
                   let image = NSImage(systemSymbolName: symbol,
                                       accessibilityDescription: title)
+            else { continue }
+            image.isTemplate = true
+            item.image = image
+        }
+    }
+
+    private func installAppMenuItemIcons() {
+        checkForUpdatesMenuItem?.target = updaterController
+        checkForUpdatesMenuItem?.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
+
+        guard let updatesItem = checkForUpdatesMenuItem,
+              let appMenu = updatesItem.menu
+        else { return }
+
+        let cliItem = NSMenuItem(title: "Install CLI...",
+                                 action: #selector(installCommandLineTools(_:)),
+                                 keyEquivalent: "")
+        cliItem.target = self
+        appMenu.insertItem(.separator(), at: appMenu.index(of: updatesItem) + 1)
+        appMenu.insertItem(cliItem, at: appMenu.index(of: updatesItem) + 2)
+
+        let icons: [(NSMenuItem, String)] = [
+            (updatesItem, "arrow.triangle.2.circlepath"),
+            (cliItem, "terminal")
+        ]
+        for (item, symbol) in icons {
+            guard let image = NSImage(systemSymbolName: symbol,
+                                      accessibilityDescription: item.title)
             else { continue }
             image.isTemplate = true
             item.image = image

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -12,7 +12,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target">
+            <connections>
+                <outlet property="checkForUpdatesMenuItem" destination="spk-cu-itm" id="spk-cu-out"/>
+            </connections>
+        </customObject>
         <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
             <items>
                 <menuItem title="Markdown Preview" id="1Xt-HY-uBw">

--- a/md-preview/md-preview.entitlements
+++ b/md-preview/md-preview.entitlements
@@ -6,6 +6,12 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.temporary-exception.apple-events</key>
+    <array>
+        <string>com.apple.Terminal</string>
+    </array>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.print</key>


### PR DESCRIPTION
## Summary
- add an app-menu `Install CLI...` command below Sparkle's update item
- install `md-preview`, `mdp`, and `markdown-preview` launchers into a usable PATH directory
- route CLI-opened folders into the app's folder navigator while preserving file-open behavior

## Details
The installer opens Terminal and runs a short temporary `/bin/sh` script, avoiding app-side writes into user shell config and avoiding pasted or Base64-heavy commands in the visible prompt. The script chooses an existing PATH directory when possible, falls back to sudo for conventional PATH locations when needed, and prints a compact usage guide after installation.

Terminal automation uses the app's Apple Events entitlement with an `NSAppleEventsUsageDescription` so macOS can authorize the handoff explicitly.

## Validation
- `git diff --check`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`
