### PR TITLE
Simplify LLM handoff prompt

### DIFF
--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -754,9 +754,6 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func llmPrompt(for fileURL: URL) -> String {
         """
         Open this Markdown file and use it as the working context:
-        \(fileURL.absoluteString)
-
-        The file is on this Mac at:
         \(fileURL.path)
         """
     }


### PR DESCRIPTION
## Summary
- Remove the redundant file URL from the LLM handoff prompt
- Keep the local Markdown path as the single working-context value

## Why
The handoff prompt already targets local desktop apps, and the plain path is the actionable value for opening the Markdown file. Keeping both the file URL and local path made the prompt noisier without adding useful context.

## Validation
- git diff --check
- xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build