### PR TITLE
[codex] Fix blockquote styling

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1654,6 +1654,7 @@ nonisolated enum MarkdownHTML {
         --link: #0066cc;
         --aside-bg: #f5f5f7;
         --aside-border: #696969;
+        --quote-border: #d2d2d7;
         --code-bg: #f5f5f7;
         --grid: #d2d2d7;
     }
@@ -1664,6 +1665,7 @@ nonisolated enum MarkdownHTML {
             --link: #2997ff;
             --aside-bg: #323232;
             --aside-border: #9a9a9e;
+            --quote-border: #6e6e73;
             --code-bg: #2A2828;
             --grid: #424245;
         }
@@ -2007,11 +2009,10 @@ nonisolated enum MarkdownHTML {
     .katex { direction: ltr !important; unicode-bidi: isolate; }
 
     blockquote {
-        margin: 1.6em 0 0;
-        padding: 14px 16px;
-        background: var(--aside-bg);
-        border-radius: 15px;
-        color: var(--text);
+        margin: 1.2em 0 0;
+        padding: 0 0 0 1em;
+        border-left: 4px solid var(--quote-border);
+        color: var(--secondary);
     }
     blockquote > *:first-child { margin-top: 0; }
 

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
@@ -83,6 +83,31 @@ final class EscapingHTMLFormatterTests: XCTestCase {
         XCTAssertFalse(html.contains("markdown-alert"), "no alert wrapper for unknown tag: \(html)")
     }
 
+    func testQuotedBlankLinesRenderAsPlainBlockquote() {
+        let html = EscapingHTMLFormatter.format("""
+        > All canon is stored as markdown files.
+        >
+        > Markdown files are the authoritative source of truth.
+        >
+        > Agent modifications must be applied through patches whenever possible.
+        >
+        > Generated content is disposable.
+        >
+        > Canon is permanent.
+        """)
+
+        XCTAssertTrue(html.contains("<blockquote>"), "expected plain blockquote wrapper: \(html)")
+        XCTAssertTrue(
+            html.contains("<p>All canon is stored as markdown files.</p>"),
+            "expected first quote paragraph: \(html)"
+        )
+        XCTAssertTrue(
+            html.contains("<p>Canon is permanent.</p>"),
+            "expected final quote paragraph: \(html)"
+        )
+        XCTAssertFalse(html.contains("<pre><code"), "blockquote must not render as a code block: \(html)")
+    }
+
     func testGitHubAlertEscapesPlainTextInCustomTitle() {
         // Ampersands and lone `<`/`>` in text should round-trip as entities.
         // Inline HTML (e.g. <script>) is parsed as InlineHTML and passed


### PR DESCRIPTION
## Summary
- Restyle regular blockquotes with a left rule instead of the same filled rounded treatment used by code blocks.
- Add a regression test for quoted blank lines using the sample from issue #145.

Fixes #145

## Testing
- `swift test --package-path tests/swift-tests`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`