### PR TITLE
[codex] Add vim-style preview scrolling

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -755,7 +755,7 @@ nonisolated enum MarkdownHTML {
             return document.activeElement instanceof Element ? document.activeElement : null;
         }
 
-        function spaceBelongsToFocusedControl(target) {
+        function keyBelongsToFocusedControl(target) {
             const el = elementForEventTarget(target);
             if (!el) return false;
             if (el.isContentEditable) return true;
@@ -778,13 +778,24 @@ nonisolated enum MarkdownHTML {
             ].join(','));
         }
 
-        document.addEventListener('keydown', (event) => {
-            const isSpace = event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space';
-            if (!isSpace || event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
-            if (spaceBelongsToFocusedControl(event.target)) return;
+        function handlePreviewScrollKey(event) {
+            if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.isComposing) return false;
+            if (keyBelongsToFocusedControl(event.target)) return false;
 
-            const value = event.shiftKey ? 'pageUp' : 'pageDown';
-            if (post({ kind: 'scroll', value })) {
+            const isSpace = event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space';
+            if (isSpace) {
+                return post({ kind: 'scroll', value: event.shiftKey ? 'pageUp' : 'pageDown' });
+            }
+
+            if (event.shiftKey) return false;
+            const key = (event.key || '').toLowerCase();
+            if (key === 'j') return post({ kind: 'scroll', value: 'lineDown' });
+            if (key === 'k') return post({ kind: 'scroll', value: 'lineUp' });
+            return false;
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (handlePreviewScrollKey(event)) {
                 event.preventDefault();
                 event.stopPropagation();
             }

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -251,6 +251,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         case "scroll":
             guard let value = dict["value"] as? String else { return }
             switch value {
+            case "lineUp":
+                performScrollAction(.lineUp)
+            case "lineDown":
+                performScrollAction(.lineDown)
             case "pageUp":
                 performScrollAction(.pageUp)
             case "pageDown":


### PR DESCRIPTION
## Summary
- Add read-mode `j`/`k` key handling in the rendered preview for line down/up scrolling.
- Reuse the existing host scroll bridge and outer AppKit scroll actions.
- Preserve Space / Shift-Space page scrolling and keep shortcuts out of focused controls, editable content, and composed text input.

Closes #142

## Validation
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`
- `swift test --package-path tests/swift-tests`