### PR TITLE
Fix Quick Look asset containment for rewritten images

### DIFF
--- a/quick-look/InlineLocalAssets.swift
+++ b/quick-look/InlineLocalAssets.swift
@@ -93,7 +93,14 @@ enum InlineLocalAssets {
         // CommonMark renderers percent-encode spaces in image targets;
         // FileManager wants real paths.
         let decoded = src.removingPercentEncoding ?? src
-        return URL(fileURLWithPath: decoded, relativeTo: baseDirectory).standardizedFileURL
+        guard !decoded.isEmpty else { return nil }
+        if decoded.hasPrefix("#") || decoded.hasPrefix("/") { return nil }
+        if hasURLScheme(decoded) { return nil }
+
+        let base = baseDirectory.standardizedFileURL
+        let candidate = URL(fileURLWithPath: decoded, relativeTo: base).standardizedFileURL
+        guard isDescendantOrSame(candidate, of: base) else { return nil }
+        return candidate
     }
 
     private static func hasURLScheme(_ value: String) -> Bool {
@@ -106,5 +113,11 @@ enum InlineLocalAssets {
         return scheme.allSatisfy { c in
             c.isLetter || c.isNumber || c == "+" || c == "." || c == "-"
         }
+    }
+
+    private static func isDescendantOrSame(_ candidate: URL, of baseDirectory: URL) -> Bool {
+        let candidatePath = candidate.standardizedFileURL.path
+        let basePath = baseDirectory.standardizedFileURL.path
+        return candidatePath == basePath || candidatePath.hasPrefix(basePath + "/")
     }
 }

--- a/tests/swift-tests/Tests/QuickLookHelperTests/InlineLocalAssetsTests.swift
+++ b/tests/swift-tests/Tests/QuickLookHelperTests/InlineLocalAssetsTests.swift
@@ -104,6 +104,39 @@ final class InlineLocalAssetsTests: XCTestCase {
         XCTAssertEqual(result.html, html)
     }
 
+    func testParentDirectoryTraversalIsLeftAlone() {
+        let html = #"<img src="../secret.png">"#
+        let result = InlineLocalAssets.rewriteRelativeImages(
+            html: html,
+            baseDirectory: baseDir,
+            reader: { _ in XCTFail("reader must not be called for parent traversal"); return Data() }
+        )
+        XCTAssertEqual(result.html, html)
+        XCTAssertTrue(result.attachments.isEmpty)
+    }
+
+    func testPercentEncodedAbsolutePathIsLeftAlone() {
+        let html = #"<img src="%2Fetc%2Fpasswd">"#
+        let result = InlineLocalAssets.rewriteRelativeImages(
+            html: html,
+            baseDirectory: baseDir,
+            reader: { _ in XCTFail("reader must not be called for encoded absolute path"); return Data() }
+        )
+        XCTAssertEqual(result.html, html)
+        XCTAssertTrue(result.attachments.isEmpty)
+    }
+
+    func testPercentEncodedSchemeIsLeftAlone() {
+        let html = #"<img src="file%3A%2F%2F%2Fetc%2Fpasswd">"#
+        let result = InlineLocalAssets.rewriteRelativeImages(
+            html: html,
+            baseDirectory: baseDir,
+            reader: { _ in XCTFail("reader must not be called for encoded URL scheme"); return Data() }
+        )
+        XCTAssertEqual(result.html, html)
+        XCTAssertTrue(result.attachments.isEmpty)
+    }
+
     func testSingleQuotedRawHTMLImageLeftAlone() {
         let html = #"<img src='images/local.png'>"#
         let result = InlineLocalAssets.rewriteRelativeImages(


### PR DESCRIPTION
## Summary
- keep Quick Look `cid:` image attachments scoped to the Markdown file directory after percent decoding
- reject parent-directory traversal, encoded absolute paths, and encoded URL schemes before reading local assets
- add regression coverage proving those sources leave HTML untouched and never call the asset reader

## Why
The app-side `md-asset` scheme already enforces base-folder containment. Quick Look had the same relative-image feature, but its helper decoded the image target and then resolved it against the base directory without proving the standardized result stayed inside that directory. That let `../...` style targets reach the reader, and encoded absolute or scheme values were not reclassified after decoding.

This patch makes the Quick Look path match the app path: decode first, reject absolute/scheme/fragment forms after decoding, standardize, then require the candidate to remain the base directory or a descendant before `Data(contentsOf:)` can run.

## Verification
- `git diff --check`
- `swift test --package-path tests/swift-tests`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`