### PR TITLE
Add trackpad pinch zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Or grab the latest signed and notarized DMG from the [Releases](https://github.c
 - **In-document search** — toolbar search field plus standard <kbd>⌘F</kbd> / <kbd>⌘G</kbd> / <kbd>⌘⇧G</kbd> for next/previous match.
 - **Open With** — switch to your real editor (VS Code, Cursor, Zed, Sublime, BBEdit, Nova, CotEditor, TextMate, MacVim, Xcode, TextEdit) without leaving the preview. The list filters to apps that actually declare an editor role for Markdown, and remembers your pick.
 - **Open in LLM** — send the current Markdown file to Codex, Claude, or ChatGPT from the toolbar. Supported apps open with file or folder context where possible, with a copy-and-open fallback for longer prompts.
-- **Text zoom** — bump preview text up or down with the toolbar's <kbd>A A</kbd> control or <kbd>⌘+</kbd> / <kbd>⌘−</kbd> / <kbd>⌘0</kbd>. Discrete Safari-style stops from 50% to 300%.
+- **Text zoom** — bump preview text up or down with trackpad pinch, the toolbar's <kbd>A A</kbd> control, or <kbd>⌘+</kbd> / <kbd>⌘−</kbd> / <kbd>⌘0</kbd>. Discrete Safari-style stops from 50% to 300%.
 - **Customizable toolbar** — drag in the items you actually use (Print, Copy, Zoom, Sidebar, Open With, Inspector, Share, Search) via *View → Customize Toolbar…* Standard AppKit affordance, your layout sticks across launches.
 - **Share = copy the source** — the share toolbar feeds the picker the Markdown text itself, so **Copy** writes the raw source to the clipboard (great for pasting into ChatGPT / Claude), and Mail, Messages, and Notes get the content in the body instead of a file URL.
 - **Quick Look extension** — system-wide `.md` previews from Finder spacebar, Spotlight, and Mail attachments without launching the app.

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1458,6 +1458,8 @@ nonisolated enum MarkdownHTML {
                 states.set(figure, state);
                 cacheRect(figure);
 
+                figure.addEventListener('pointerenter', () => postMermaidHover(true));
+                figure.addEventListener('pointerleave', () => postMermaidHover(false));
                 figure.addEventListener('wheel', onWheel, { passive: false });
                 figure.addEventListener('pointerdown', onPointerDown);
                 figure.addEventListener('dblclick', onDoubleClick);
@@ -1468,6 +1470,15 @@ nonisolated enum MarkdownHTML {
             function cacheRect(figure) {
                 const s = states.get(figure);
                 if (s) s.rect = figure.getBoundingClientRect();
+            }
+
+            function postMermaidHover(value) {
+                try {
+                    window.webkit?.messageHandlers?.mdPreviewHost?.postMessage({
+                        kind: 'mermaidHover',
+                        value
+                    });
+                } catch (_) {}
             }
 
             function apply(figure, s) {

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -59,6 +59,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     // is invariant under pageZoom).
     private var lastReportedDocumentHeight: CGFloat = 1
     private var zoomDefaultsKey: String?
+    private var magnificationStartZoom: CGFloat?
+    private var accumulatedMagnification: CGFloat = 0
+    private var didMagnifyDuringCurrentGesture = false
+    private var isPointerOverMermaidFigure = false
     private var currentMarkdown: String?
 
     override init(frame frameRect: NSRect) {
@@ -161,6 +165,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     func display(markdown: String, assetBaseURL: URL? = nil) {
         currentMarkdown = markdown
+        isPointerOverMermaidFigure = false
         assetScheme.setBaseURL(assetBaseURL)
         currentAssetBase = assetBaseURL
         let baseHref = "\(MarkdownAssetScheme.scheme):///"
@@ -250,6 +255,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             // --predicate 'subsystem == "doc.md-preview"'` surfaces them.
             guard let message = dict["message"] as? String else { return }
             Logger.perf.debug("\(message, privacy: .public)")
+        case "mermaidHover":
+            guard let value = dict["value"] as? NSNumber else { return }
+            isPointerOverMermaidFigure = value.boolValue
         case "copyCode":
             guard let text = dict["value"] as? String else { return }
             let pasteboard = NSPasteboard.general
@@ -322,6 +330,39 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     func zoomIn() { setPageZoom(nextZoomStep(from: webView.pageZoom, increasing: true)) }
     func zoomOut() { setPageZoom(nextZoomStep(from: webView.pageZoom, increasing: false)) }
     func resetZoom() { setPageZoom(1.0) }
+
+    fileprivate func beginMagnificationZoom() {
+        magnificationStartZoom = webView.pageZoom
+        accumulatedMagnification = 0
+        didMagnifyDuringCurrentGesture = false
+    }
+
+    fileprivate var shouldForwardMagnificationToContent: Bool {
+        isPointerOverMermaidFigure && magnificationStartZoom == nil
+    }
+
+    fileprivate func magnifyPreview(by delta: CGFloat) {
+        guard delta.isFinite else { return }
+        if magnificationStartZoom == nil {
+            beginMagnificationZoom()
+        }
+
+        didMagnifyDuringCurrentGesture = true
+        accumulatedMagnification += delta
+        let scale = max(0.1, 1 + accumulatedMagnification)
+        setPageZoom((magnificationStartZoom ?? webView.pageZoom) * scale, persist: false)
+    }
+
+    fileprivate func endMagnificationZoom() {
+        guard magnificationStartZoom != nil else { return }
+        let shouldPersistZoom = didMagnifyDuringCurrentGesture
+        magnificationStartZoom = nil
+        accumulatedMagnification = 0
+        didMagnifyDuringCurrentGesture = false
+        if shouldPersistZoom {
+            persistPageZoom(webView.pageZoom)
+        }
+    }
 
     func enablePersistentZoom(defaultsKey: String) {
         zoomDefaultsKey = defaultsKey
@@ -824,6 +865,34 @@ private final class NonScrollingWKWebView: WKWebView {
 
     override func reload(_ sender: Any?) {
         (superview as? MarkdownWebView)?.reloadPreview()
+    }
+
+    override func beginGesture(with event: NSEvent) {
+        guard let owner = superview as? MarkdownWebView else {
+            super.beginGesture(with: event)
+            return
+        }
+        if !owner.shouldForwardMagnificationToContent {
+            owner.beginMagnificationZoom()
+        }
+        super.beginGesture(with: event)
+    }
+
+    override func magnify(with event: NSEvent) {
+        guard let owner = superview as? MarkdownWebView else {
+            super.magnify(with: event)
+            return
+        }
+        if owner.shouldForwardMagnificationToContent {
+            super.magnify(with: event)
+            return
+        }
+        owner.magnifyPreview(by: event.magnification)
+    }
+
+    override func endGesture(with event: NSEvent) {
+        (superview as? MarkdownWebView)?.endMagnificationZoom()
+        super.endGesture(with: event)
     }
 
     override func scrollLineUp(_ sender: Any?)            { forwardScrollAction(.lineUp) }


### PR DESCRIPTION
Summary
- Add native trackpad pinch gestures for preview zoom by routing AppKit magnification events into the existing WKWebView.pageZoom path.
- Harden the gesture state machine so only actual finite magnification events persist zoom, while unrelated begin/end gesture traffic cannot dirty the stored zoom preference.
- Preserve existing Mermaid diagram pinch zoom by forwarding magnification back to WebKit while the pointer is over a Mermaid figure.
- Preserve the current toolbar/menu zoom behavior, 50%-300% clamp, document-height updates, and persisted zoom preference.
- Document trackpad pinch in the README text-zoom feature line.

Verification
- git diff --check
- swift test --package-path tests/swift-tests
- xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug CODE_SIGNING_ALLOWED=NO build
- GitHub Actions: swift test passed on run 28933771709 / job 85838974937
- Codex Security diff preflight: status ready
- Codex Security diff audit: changed files are README.md, MarkdownHTML.swift, and MarkdownWebView.swift only; no new network, file, process, URL-opening, secret-handling, sandbox entitlement, dependency, or external resource surface. Added host-bridge message is boolean-only Mermaid hover state used to avoid stealing the existing Mermaid zoom path.

Risk / Notes
- Public-facing README.md changed to advertise trackpad pinch zoom.
- No GitHub repository settings were changed.
- UI gesture behavior still needs maintainer/manual smoke on a trackpad build because the existing test suite does not cover AppKit gesture delivery.