### PR TITLE
Add Content Width setting (centered / full width)

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -91,6 +91,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private weak var automaticAppearanceMenuItem: NSMenuItem?
     private weak var lightAppearanceMenuItem: NSMenuItem?
     private weak var darkAppearanceMenuItem: NSMenuItem?
+    private weak var normalContentWidthMenuItem: NSMenuItem?
+    private weak var fullContentWidthMenuItem: NSMenuItem?
     private var isOpeningDocumentFromPrompt = false
     private var isPromptingForDocument = false
     private var isDocumentPromptScheduled = false
@@ -100,6 +102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         applyAppearanceMode(AppAppearanceMode.current, reloadPreviews: false)
         installAppearanceMenuItems()
+        installContentWidthMenuItems()
         installSidebarViewMenuItems()
         installGoMenu()
         installAppMenuItemIcons()
@@ -197,9 +200,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         applyAppearanceMode(mode, reloadPreviews: true)
     }
 
+    @objc private func selectContentWidthSetting(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let setting = ContentWidthSetting(rawValue: rawValue),
+              setting != ContentWidthSetting.current else { return }
+
+        ContentWidthSetting.current = setting
+        syncContentWidthMenuState()
+        reloadDocumentPreviewsForSettingChange()
+    }
+
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         syncSidebarViewMenuState()
         syncAppearanceMenuState()
+        syncContentWidthMenuState()
         switch menuItem.action {
         case #selector(hideSidebarFromMenu(_:)),
              #selector(selectOutlineMode(_:)),
@@ -207,7 +221,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
              #selector(performFindPanelAction(_:)),
              #selector(performTextFinderAction(_:)):
             return activeDocumentWindowController != nil
-        case #selector(selectAppearanceMode(_:)):
+        case #selector(selectAppearanceMode(_:)),
+             #selector(selectContentWidthSetting(_:)):
             return true
         default:
             return true
@@ -655,6 +670,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         syncAppearanceMenuState()
     }
 
+    private func installContentWidthMenuItems() {
+        guard let viewMenu = NSApp.mainMenu?.items
+            .first(where: { $0.title == "View" })?.submenu,
+              viewMenu.items.first(where: { $0.title == "Content Width" }) == nil else { return }
+
+        let widthItem = NSMenuItem(title: "Content Width", action: nil, keyEquivalent: "")
+        if let image = NSImage(systemSymbolName: "arrow.left.and.right.text.vertical",
+                               accessibilityDescription: "Content Width") {
+            image.isTemplate = true
+            widthItem.image = image
+        }
+
+        let submenu = NSMenu(title: "Content Width")
+        for setting in ContentWidthSetting.allCases {
+            let item = NSMenuItem(title: setting.title,
+                                  action: #selector(selectContentWidthSetting(_:)),
+                                  keyEquivalent: "")
+            item.target = self
+            item.representedObject = setting.rawValue
+            submenu.addItem(item)
+
+            switch setting {
+            case .normal:
+                normalContentWidthMenuItem = item
+            case .fullWidth:
+                fullContentWidthMenuItem = item
+            }
+        }
+        widthItem.submenu = submenu
+        let insertIndex = viewMenu.items
+            .firstIndex(where: { $0.title == "Appearance" })
+            .map { $0 + 1 } ?? 0
+        viewMenu.insertItem(widthItem, at: insertIndex)
+        syncContentWidthMenuState()
+    }
+
     private func applyAppearanceMode(_ mode: AppAppearanceMode, reloadPreviews: Bool) {
         let appearance = mode.appearance
         NSApp.appearance = appearance
@@ -663,7 +714,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         syncAppearanceMenuState()
         if reloadPreviews {
-            reloadDocumentPreviewsForAppearanceChange()
+            reloadDocumentPreviewsForSettingChange()
         }
     }
 
@@ -674,11 +725,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         darkAppearanceMenuItem?.state = mode == .dark ? .on : .off
     }
 
-    private func reloadDocumentPreviewsForAppearanceChange() {
+    private func syncContentWidthMenuState() {
+        let setting = ContentWidthSetting.current
+        normalContentWidthMenuItem?.state = setting == .normal ? .on : .off
+        fullContentWidthMenuItem?.state = setting == .fullWidth ? .on : .off
+    }
+
+    private func reloadDocumentPreviewsForSettingChange() {
         NSDocumentController.shared.documents
             .flatMap(\.windowControllers)
             .compactMap { $0 as? DocumentWindowController }
-            .forEach { $0.reloadPreviewForAppearanceChange() }
+            .forEach { $0.reloadPreviewForSettingChange() }
     }
 
     private func installAppMenuItemIcons() {

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -12,6 +12,11 @@ final class ContentViewController: NSViewController {
     private var webView: MarkdownWebView!
     private var documentHeightConstraint: NSLayoutConstraint!
     private var webViewHeightConstraint: NSLayoutConstraint!
+    // Two mutually-exclusive horizontal layouts for the web view, swapped
+    // when the Content Width setting changes. Full width pins both edges;
+    // centered locks a fixed page width and centers it.
+    private var fullWidthConstraints: [NSLayoutConstraint] = []
+    private var centeredConstraints: [NSLayoutConstraint] = []
     private var measuredDocumentHeight: CGFloat = 1
     private var lastLaidOutSize: NSSize = .zero
     private var pendingFlashWork: DispatchWorkItem?
@@ -90,6 +95,8 @@ final class ContentViewController: NSViewController {
         documentHeightConstraint = documentView.heightAnchor.constraint(equalToConstant: 1)
         webViewHeightConstraint = webView.heightAnchor.constraint(equalToConstant: 1)
 
+        // Shared: document view tracks the clip width, web view pinned to
+        // the top and sized to the measured content height.
         NSLayoutConstraint.activate([
             documentView.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
             documentView.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
@@ -97,10 +104,39 @@ final class ContentViewController: NSViewController {
             documentHeightConstraint,
 
             webView.topAnchor.constraint(equalTo: documentView.topAnchor),
-            webView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
             webViewHeightConstraint
         ])
+
+        // Full Width: the web view spans the whole document view.
+        fullWidthConstraints = [
+            webView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
+        ]
+
+        // Normal (centered): lock the web view to a fixed page width and
+        // center it, shrinking below the cap on narrow windows. A sidebar
+        // reveal then only slides the web view instead of re-flowing its
+        // content every frame — which is what made the centered column
+        // jitter. The web view / scroll view stack is transparent, so the
+        // area beside the page is the same window background, no seam.
+        let pageWidth = webView.widthAnchor.constraint(
+            equalToConstant: MarkdownHTML.preferredPageWidth)
+        pageWidth.priority = .init(999)
+        centeredConstraints = [
+            webView.centerXAnchor.constraint(equalTo: documentView.centerXAnchor),
+            webView.widthAnchor.constraint(lessThanOrEqualTo: documentView.widthAnchor),
+            pageWidth,
+        ]
+
+        applyContentWidthConstraints()
+    }
+
+    /// Activates the constraint set matching the current Content Width
+    /// setting. Safe to call repeatedly — it deactivates the other set first.
+    private func applyContentWidthConstraints() {
+        let centered = ContentWidthSetting.current == .normal
+        NSLayoutConstraint.deactivate(centered ? fullWidthConstraints : centeredConstraints)
+        NSLayoutConstraint.activate(centered ? centeredConstraints : fullWidthConstraints)
     }
 
     override func viewDidLayout() {
@@ -188,6 +224,7 @@ final class ContentViewController: NSViewController {
     var pageZoom: CGFloat { webView.pageZoom }
 
     func reloadPreviewForSettingChange() {
+        applyContentWidthConstraints()
         webView.reloadPreviewForSettingChange()
     }
 

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -187,8 +187,8 @@ final class ContentViewController: NSViewController {
     func resetZoom() { webView.resetZoom() }
     var pageZoom: CGFloat { webView.pageZoom }
 
-    func reloadPreviewForAppearanceChange() {
-        webView.reloadPreviewForAppearanceChange()
+    func reloadPreviewForSettingChange() {
+        webView.reloadPreviewForSettingChange()
     }
 
     func scrollToHeading(index: Int) {

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -12,11 +12,6 @@ final class ContentViewController: NSViewController {
     private var webView: MarkdownWebView!
     private var documentHeightConstraint: NSLayoutConstraint!
     private var webViewHeightConstraint: NSLayoutConstraint!
-    // Two mutually-exclusive horizontal layouts for the web view, swapped
-    // when the Content Width setting changes. Full width pins both edges;
-    // centered locks a fixed page width and centers it.
-    private var fullWidthConstraints: [NSLayoutConstraint] = []
-    private var centeredConstraints: [NSLayoutConstraint] = []
     private var measuredDocumentHeight: CGFloat = 1
     private var lastLaidOutSize: NSSize = .zero
     private var pendingFlashWork: DispatchWorkItem?
@@ -104,39 +99,10 @@ final class ContentViewController: NSViewController {
             documentHeightConstraint,
 
             webView.topAnchor.constraint(equalTo: documentView.topAnchor),
-            webViewHeightConstraint
-        ])
-
-        // Full Width: the web view spans the whole document view.
-        fullWidthConstraints = [
             webView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
-        ]
-
-        // Normal (centered): lock the web view to a fixed page width and
-        // center it, shrinking below the cap on narrow windows. A sidebar
-        // reveal then only slides the web view instead of re-flowing its
-        // content every frame — which is what made the centered column
-        // jitter. The web view / scroll view stack is transparent, so the
-        // area beside the page is the same window background, no seam.
-        let pageWidth = webView.widthAnchor.constraint(
-            equalToConstant: MarkdownHTML.preferredPageWidth)
-        pageWidth.priority = .init(999)
-        centeredConstraints = [
-            webView.centerXAnchor.constraint(equalTo: documentView.centerXAnchor),
-            webView.widthAnchor.constraint(lessThanOrEqualTo: documentView.widthAnchor),
-            pageWidth,
-        ]
-
-        applyContentWidthConstraints()
-    }
-
-    /// Activates the constraint set matching the current Content Width
-    /// setting. Safe to call repeatedly — it deactivates the other set first.
-    private func applyContentWidthConstraints() {
-        let centered = ContentWidthSetting.current == .normal
-        NSLayoutConstraint.deactivate(centered ? fullWidthConstraints : centeredConstraints)
-        NSLayoutConstraint.activate(centered ? centeredConstraints : fullWidthConstraints)
+            webViewHeightConstraint
+        ])
     }
 
     override func viewDidLayout() {
@@ -224,7 +190,6 @@ final class ContentViewController: NSViewController {
     var pageZoom: CGFloat { webView.pageZoom }
 
     func reloadPreviewForSettingChange() {
-        applyContentWidthConstraints()
         webView.reloadPreviewForSettingChange()
     }
 

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -361,9 +361,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         currentSidebarMenuState()
     }
 
-    func reloadPreviewForAppearanceChange() {
+    func reloadPreviewForSettingChange() {
         (documentWindow.contentViewController as? MainSplitViewController)?
-            .reloadPreviewForAppearanceChange()
+            .reloadPreviewForSettingChange()
     }
 
     private func currentSidebarMenuState() -> (sidebarVisible: Bool, mode: SidebarViewController.Mode) {

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -144,8 +144,8 @@ final class MainSplitViewController: NSSplitViewController {
         sidebarViewController?.setMode(mode)
     }
 
-    func reloadPreviewForAppearanceChange() {
-        contentViewController?.reloadPreviewForAppearanceChange()
+    func reloadPreviewForSettingChange() {
+        contentViewController?.reloadPreviewForSettingChange()
     }
 
     private var sidebarViewController: SidebarViewController? {

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -22,6 +22,24 @@ nonisolated enum MarkdownHTML {
         case lazy
     }
 
+    /// Layout of the rendered article column.
+    /// - centered: capped at `contentColumnWidth` and centered, so wide
+    ///   windows read like a paged document. Matches Quick Look, whose
+    ///   `preferredPageWidth` panel minus the body gutters is exactly one
+    ///   column.
+    /// - full: span the whole window.
+    enum ContentWidth {
+        case centered
+        case full
+    }
+
+    /// Width the Quick Look panel requests for its preview window.
+    static let preferredPageWidth: CGFloat = 900
+    /// The centered article measure: `preferredPageWidth` minus the 40px
+    /// body gutter on either side, so the app's centered column and the
+    /// Quick Look panel wrap lines identically.
+    static let contentColumnWidth = Int(preferredPageWidth) - 80
+
     struct RenderedHTML: Sendable {
         let html: String
         let articleHTML: String
@@ -44,6 +62,7 @@ nonisolated enum MarkdownHTML {
                        allowsScroll: Bool = false,
                        assetBaseHref: String? = nil,
                        vendorLoading: VendorLoading = .inline,
+                       contentWidth: ContentWidth = .centered,
                        warmup: Bool = false) -> RenderedHTML {
         let body = MarkdownFrontmatter.split(markdown).body
         let footnotes = extractFootnotes(from: body)
@@ -61,6 +80,11 @@ nonisolated enum MarkdownHTML {
         let scrollOverride = allowsScroll ? """
         <style>
         html, body { overflow: auto !important; }
+        </style>
+        """ : ""
+        let contentWidthOverride = contentWidth == .full ? """
+        <style>
+        article.markdown-body { max-width: none; }
         </style>
         """ : ""
         let baseTag = assetBaseHref.map { "<base href=\"\($0)\">" } ?? ""
@@ -92,6 +116,7 @@ nonisolated enum MarkdownHTML {
         \(baseTag)
         <style>\(stylesheet)</style>
         \(scrollOverride)
+        \(contentWidthOverride)
         \(sanitizerBlock)
         \(hostBridgeScript)
         \(mathBlock)
@@ -1743,6 +1768,11 @@ nonisolated enum MarkdownHTML {
         -webkit-font-smoothing: antialiased;
     }
 
+    article.markdown-body {
+        max-width: \(contentColumnWidth)px;
+        margin-left: auto;
+        margin-right: auto;
+    }
     article.markdown-body > *:first-child { margin-top: 0 !important; }
 
     p {

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -3,6 +3,7 @@
 //  md-preview
 //
 
+import CoreGraphics
 import Foundation
 import Markdown
 

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -17,6 +17,45 @@ enum SearchMode {
     case beginsWith
 }
 
+/// User-selectable article layout, persisted across launches. Quick Look
+/// always renders the centered column; this setting only drives the app.
+/// Lives here (not AppDelegate.swift) because this file is compiled into
+/// both targets and the setting is read at render time below.
+enum ContentWidthSetting: String, CaseIterable {
+    case normal
+    case fullWidth
+
+    private static let defaultsKey = "MarkdownPreview.contentWidth"
+
+    static var current: ContentWidthSetting {
+        get {
+            UserDefaults.standard.string(forKey: defaultsKey)
+                .flatMap(ContentWidthSetting.init(rawValue:)) ?? .normal
+        }
+        set {
+            if newValue == .normal {
+                UserDefaults.standard.removeObject(forKey: defaultsKey)
+            } else {
+                UserDefaults.standard.set(newValue.rawValue, forKey: defaultsKey)
+            }
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .normal: return "Normal"
+        case .fullWidth: return "Full Width"
+        }
+    }
+
+    var renderWidth: MarkdownHTML.ContentWidth {
+        switch self {
+        case .normal: return .centered
+        case .fullWidth: return .full
+        }
+    }
+}
+
 struct FindResult {
     let top: CGFloat?
     let bottom: CGFloat?
@@ -119,10 +158,12 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         guard !isPageReady, loadedFingerprint == nil else { return }
         let baseHref = "\(MarkdownAssetScheme.scheme):///"
         let markdown = Self.warmupMarkdown
+        let contentWidth = ContentWidthSetting.current.renderWidth
         Task { @concurrent [weak self] in
             let rendered = Self.timedRender(label: "warmup",
                                             markdown: markdown,
                                             assetBaseHref: baseHref,
+                                            contentWidth: contentWidth,
                                             warmup: true)
             await self?.applyWarmup(rendered)
         }
@@ -166,10 +207,12 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let baseHref = "\(MarkdownAssetScheme.scheme):///"
         renderGeneration &+= 1
         let generation = renderGeneration
+        let contentWidth = ContentWidthSetting.current.renderWidth
         Task { @concurrent [weak self] in
             let rendered = Self.timedRender(label: "display",
                                             markdown: markdown,
-                                            assetBaseHref: baseHref)
+                                            assetBaseHref: baseHref,
+                                            contentWidth: contentWidth)
             await self?.applyDisplay(rendered, generation: generation)
         }
     }
@@ -180,11 +223,13 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     private nonisolated static func timedRender(label: String,
                                                 markdown: String,
                                                 assetBaseHref: String,
+                                                contentWidth: MarkdownHTML.ContentWidth,
                                                 warmup: Bool = false) -> MarkdownHTML.RenderedHTML {
         let t0 = DispatchTime.now()
         let rendered = MarkdownHTML.render(markdown: markdown,
                                            assetBaseHref: assetBaseHref,
                                            vendorLoading: .lazy,
+                                           contentWidth: contentWidth,
                                            warmup: warmup)
         let elapsedMs = Int(
             (Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds)
@@ -228,8 +273,11 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         display(markdown: currentMarkdown, assetBaseURL: currentAssetBase)
     }
 
-    func reloadPreviewForAppearanceChange() {
-        guard currentMarkdown != nil else { return }
+    /// Full reload (no fast-path) so render-time settings — appearance,
+    /// content width — are re-evaluated. The fingerprint reset is
+    /// unconditional so a warmup-only page rendered under the old settings
+    /// can't be fast-pathed into later.
+    func reloadPreviewForSettingChange() {
         loadedFingerprint = nil
         isPageReady = false
         reloadPreview()

--- a/quick-look/PreviewProvider.swift
+++ b/quick-look/PreviewProvider.swift
@@ -33,7 +33,8 @@ class PreviewProvider: QLPreviewProvider, QLPreviewingController {
 
         return QLPreviewReply(
             dataOfContentType: .html,
-            contentSize: CGSize(width: 900, height: 900)
+            contentSize: CGSize(width: MarkdownHTML.preferredPageWidth,
+                                height: MarkdownHTML.preferredPageWidth)
         ) { replyToUpdate in
             replyToUpdate.stringEncoding = .utf8
             replyToUpdate.attachments = replyAttachments


### PR DESCRIPTION
## Summary

Adds a **Content Width** setting so wide displays can read Markdown like a paged document instead of stretching content edge-to-edge.

- **Normal** (default): centers the article in a fixed page width. The page width is `preferredPageWidth` (900pt); minus the 40pt body gutters this is an **820px column** — the exact measure the Quick Look panel already uses, so the app and the QL preview wrap lines identically.
- **Full Width**: the previous behavior — the article spans the whole window.

The choice lives under **View → Content Width**, persists across launches (`MarkdownPreview.contentWidth`; absent = Normal), and all open previews reload when it changes.

## What's included

**1. Content Width setting (`5459a49`)**
- New `MarkdownHTML.ContentWidth` render option plus shared `preferredPageWidth` / `contentColumnWidth` constants, used by both the app and the Quick Look extension so they stay in lock-step.
- `View → Content Width` submenu (Normal / Full Width) with persistence and live reload across every open window.
- Quick Look requests `preferredPageWidth` for its preview panel, keeping the app's centered column pixel-consistent with QL.

**2. Center via AppKit to stop resize jitter (`dd317be`)**
- In centered mode the web view previously spanned the full document width and the article was centered with CSS margins. Revealing the sidebar animates the content width, so the web view re-flowed and re-centered every frame — and WebKit's async layout lags the AppKit frame, making the centered column stutter left-right during the animation.
- The web view is now locked to a fixed page width and centered with Auto Layout, shrinking below the cap on narrow windows. A sidebar reveal only *slides* the web view; its width is constant so the content never re-flows and the jitter is gone.
- The web view / scroll view stack is transparent, so the area beside the page is the same window background — no seam, no color to keep in sync. Full Width is unchanged.

## Test plan

- Toggle **View → Content Width** between Normal and Full Width: open previews update immediately, and the choice survives relaunch.
- On a wide window: Normal centers the column at 820px; Full Width spans the window.
- Reveal / hide the sidebar (and outline) in Normal mode: content slides smoothly, no horizontal jitter.
- Zoom in / out in Normal mode: text stays within the page and re-wraps; no overflow or horizontal scrolling. Zoom-out and 100% are unchanged from before.
- The Quick Look preview column matches the app's Normal column.

---

Happy to add a `CHANGELOG.md` entry or adjust the menu wording / default to match your preferences.
