### PR TITLE
Fix explicit img width/height attributes being ignored

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -2099,9 +2099,13 @@ nonisolated enum MarkdownHTML {
     img {
         display: block;
         max-width: 100%;
-        height: auto;
         margin: 1.6em auto;
         border-radius: 10px;
+    }
+    /* Keep downscaled images proportional, but let explicit width/height
+       attributes (e.g. GitHub-style <img height="54">) take effect. */
+    img:not([width]):not([height]) {
+        height: auto;
     }
     p img {
         display: inline-block;


### PR DESCRIPTION
## Summary

Sponsor logos in the README (`<img height="54">` inside `<p align="center">`) rendered as two full-width stacked images in both the app preview and Quick Look, while GitHub shows them side by side at 54px.

Root cause: the stylesheet's unconditional `img { height: auto; }` overrides presentational `width`/`height` attributes (CSS rules beat HTML attributes), so such images fall back to natural size capped by `max-width: 100%`.

Fix: scope `height: auto` to images without explicit size attributes:

```css
img:not([width]):not([height]) { height: auto; }
```

Images with authored dimensions now render at the declared size (WebKit derives aspect-ratio from the attributes, so proportional downscaling still works); all other images keep the previous behavior. Quick Look shares the same renderer, so both surfaces are fixed.

## Test plan

- Built the app and opened the project README: sponsor logos render side by side at 54px, matching GitHub.
- Verified regular attribute-less images (screenshots elsewhere in the README) still scale to fit with correct aspect ratio.
- Manual smoke test per contributing guidelines (no UI test suite).