### PR TITLE
Center the preview column via AppKit to stop sidebar jitter

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -12,6 +12,15 @@ final class ContentViewController: NSViewController {
     private var webView: MarkdownWebView!
     private var documentHeightConstraint: NSLayoutConstraint!
     private var webViewHeightConstraint: NSLayoutConstraint!
+
+    // Two mutually-exclusive horizontal layouts for the web view, swapped
+    // when the Content Width setting changes. Full Width pins both edges so
+    // the web view spans the window; Normal locks a fixed page width and
+    // centers it. Centering in AppKit (not CSS) keeps the web view's width
+    // constant while the sidebar animates, so the column never re-flows and
+    // never jitters.
+    private var fullWidthConstraints: [NSLayoutConstraint] = []
+    private var centeredConstraints: [NSLayoutConstraint] = []
     private var measuredDocumentHeight: CGFloat = 1
     private var lastLaidOutSize: NSSize = .zero
     private var pendingFlashWork: DispatchWorkItem?
@@ -91,7 +100,8 @@ final class ContentViewController: NSViewController {
         webViewHeightConstraint = webView.heightAnchor.constraint(equalToConstant: 1)
 
         // Shared: document view tracks the clip width, web view pinned to
-        // the top and sized to the measured content height.
+        // the top and sized to the measured content height. Its horizontal
+        // layout is set separately by the Content Width constraint sets.
         NSLayoutConstraint.activate([
             documentView.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
             documentView.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
@@ -99,10 +109,34 @@ final class ContentViewController: NSViewController {
             documentHeightConstraint,
 
             webView.topAnchor.constraint(equalTo: documentView.topAnchor),
-            webView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
             webViewHeightConstraint
         ])
+
+        // Full Width: the web view spans the whole document view.
+        fullWidthConstraints = [
+            webView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
+        ]
+        // Normal (centered): lock the web view to a fixed page width and
+        // center it, shrinking below the cap on narrow windows. The width is
+        // constant across a sidebar reveal, so the web content never re-flows.
+        let pageWidth = webView.widthAnchor.constraint(
+            equalToConstant: MarkdownHTML.preferredPageWidth)
+        pageWidth.priority = .init(999)
+        centeredConstraints = [
+            webView.centerXAnchor.constraint(equalTo: documentView.centerXAnchor),
+            webView.widthAnchor.constraint(lessThanOrEqualTo: documentView.widthAnchor),
+            pageWidth,
+        ]
+        applyContentWidthConstraints()
+    }
+
+    /// Activates the constraint set matching the current Content Width
+    /// setting. Safe to call repeatedly — it deactivates the other set first.
+    private func applyContentWidthConstraints() {
+        let centered = ContentWidthSetting.current == .normal
+        NSLayoutConstraint.deactivate(centered ? fullWidthConstraints : centeredConstraints)
+        NSLayoutConstraint.activate(centered ? centeredConstraints : fullWidthConstraints)
     }
 
     override func viewDidLayout() {
@@ -190,6 +224,7 @@ final class ContentViewController: NSViewController {
     var pageZoom: CGFloat { webView.pageZoom }
 
     func reloadPreviewForSettingChange() {
+        applyContentWidthConstraints()
         webView.reloadPreviewForSettingChange()
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #157. In Normal (centered) mode the preview column jitters left and right while the sidebar or outline animates open/closed. This restores the AppKit-based centering that removes it.

## The problem

The merged Content Width feature centers the Normal column with a **full-width web view** and CSS margins (`article.markdown-body { max-width; margin: auto }`). Revealing the sidebar animates the content view's width, so every animation frame the web view re-flows and CSS re-centers the column. WebKit lays out asynchronously across processes and lags the AppKit frame, so the centered column visibly stutters left-right for the duration of the animation. Full Width mode is left-anchored and never showed this.

## The fix

Center the column in **AppKit** instead of CSS: lock the web view to a fixed page width (`preferredPageWidth`) and center it with Auto Layout, shrinking below the cap on narrow windows. A sidebar reveal now only *slides* the web view; its width is constant, so the web content never re-flows and the jitter is gone.

- Two mutually-exclusive constraint sets (`centeredConstraints` / `fullWidthConstraints`) swap when the Content Width setting changes, alongside the existing reload.
- The web view / scroll view stack is transparent, so the area beside the page is the same window background as before. No seam, no color to keep in sync.
- The centered column still measures the same `contentColumnWidth`, so it stays pixel-consistent with Quick Look.
- **Full Width mode is unchanged** (pins both edges).

One file touched: `md-preview/ContentViewController.swift`.

## Test plan

- Normal mode, wide window: reveal / hide the sidebar and the outline. The column slides smoothly with no horizontal jitter.
- Toggle **View → Content Width** between Normal and Full Width: layout switches correctly and the choice still survives relaunch.
- Narrow window: the column shrinks below the page-width cap instead of clipping.
- Full Width: still spans the window.
- Zoom in / out in Normal mode: text stays within the page and re-wraps; no overflow.
