### PR TITLE
Add native window tabs for opening multiple files in one window

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -104,6 +104,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         installAppearanceMenuItems()
         installContentWidthMenuItems()
         installSidebarViewMenuItems()
+        installNewTabMenuItem()
         installGoMenu()
         installAppMenuItemIcons()
         installZoomMenuItemIcons()
@@ -532,6 +533,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 ?? errorInfo.description
             throw CommandLineToolInstallError.terminalAutomationFailed(message)
         }
+    }
+
+    private func installNewTabMenuItem() {
+        guard let fileMenu = NSApp.mainMenu?.items
+            .first(where: { $0.title == "File" })?.submenu,
+              fileMenu.items.first(where: {
+                  $0.action == #selector(NSResponder.newWindowForTab(_:))
+              }) == nil else { return }
+
+        // nil target: resolves through the responder chain to the key
+        // document window's controller, and disables itself when no
+        // document window is open.
+        let item = NSMenuItem(title: "New Tab",
+                              action: #selector(NSResponder.newWindowForTab(_:)),
+                              keyEquivalent: "t")
+        let insertIndex = fileMenu.items
+            .firstIndex { $0.action == #selector(openDocument(_:)) } ?? 0
+        fileMenu.insertItem(item, at: insertIndex)
     }
 
     private func installGoMenu() {

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17150" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17150"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -11,8 +10,8 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target">
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Markdown_Preview" customModuleProvider="target">
             <connections>
                 <outlet property="checkForUpdatesMenuItem" destination="spk-cu-itm" id="spk-cu-out"/>
             </connections>
@@ -370,19 +369,16 @@
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
                             <menuItem title="Actual Size" keyEquivalent="0" id="mdp-zr-itm">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 <connections>
                                     <action selector="resetDocumentZoom:" target="-1" id="mdp-zr-act"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Zoom In" keyEquivalent="+" id="mdp-zi-itm">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 <connections>
                                     <action selector="zoomInDocument:" target="-1" id="mdp-zi-act"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Zoom Out" keyEquivalent="-" id="mdp-zo-itm">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 <connections>
                                     <action selector="zoomOutDocument:" target="-1" id="mdp-zo-act"/>
                                 </connections>

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -82,9 +82,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// One-shot override consumed by the next window's setup: "Open in
+    /// New Window" needs that window to skip the native tab group during
+    /// its first order-front (when AppKit decides tab placement).
+    private static var nextWindowDeclinesTabbing = false
+
+    static func markNextWindowAsSeparate() {
+        nextWindowDeclinesTabbing = true
+    }
+
     private func setupWindow() {
         documentWindow.styleMask.insert(.fullSizeContentView)
         documentWindow.delegate = self
+        documentWindow.tabbingIdentifier = "MarkdownDocumentWindow"
+        // .preferred groups every new document window into the frontmost
+        // window's native tab bar regardless of the system "prefer tabs"
+        // setting; the one-shot override opts a window out for its first show.
+        documentWindow.tabbingMode = Self.nextWindowDeclinesTabbing ? .disallowed : .preferred
+        Self.nextWindowDeclinesTabbing = false
         let split = MainSplitViewController()
         split.onSelectFile = { [weak self] url in
             self?.present(url: url)
@@ -104,6 +119,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         installFindBar()
     }
 
+    /// AppKit's automatic tab placement runs when NSDocument shows its
+    /// windows — but this controller orders the window front itself (from
+    /// makeWindowControllers, before showWindows), so the window is already
+    /// visible and placement never happens on its own. Join the frontmost
+    /// document window's tab group explicitly on first show instead.
+    private func attachToExistingTabGroupIfNeeded() {
+        guard !documentWindow.isVisible,
+              documentWindow.tabbingMode == .preferred else { return }
+        let host = ([NSApp.mainWindow] + NSApp.orderedWindows)
+            .compactMap { $0 }
+            .first {
+                $0 !== documentWindow
+                    && $0.isVisible
+                    && $0.tabbingIdentifier == documentWindow.tabbingIdentifier
+            }
+        host?.addTabbedWindow(documentWindow, ordered: .above)
+    }
+
     func windowWillClose(_ notification: Notification) {
         fileWatcher?.cancel()
         fileWatcher = nil
@@ -113,7 +146,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         currentFileURL = fileURL
         currentMarkdown = markdown
         documentWindow.title = fileURL?.lastPathComponent ?? "Untitled"
+        attachToExistingTabGroupIfNeeded()
         documentWindow.makeKeyAndOrderFront(nil)
+        // Tab placement is settled once the window is shown; a window opened
+        // via "Open in New Window" goes back to accepting tabs afterwards.
+        documentWindow.tabbingMode = .preferred
         NSApp.activate()
         refreshOpenWithItem()
         refreshOpenInLLMItem()
@@ -1524,12 +1561,33 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let appURL: URL
     }
 
+    func openInNewTab(_ fileURL: URL) {
+        openDocumentWindow(for: fileURL)
+    }
+
     func openInNewWindow(_ fileURL: URL) {
+        Self.markNextWindowAsSeparate()
+        openDocumentWindow(for: fileURL) {
+            // If the document was already open, no window was created and
+            // the override wasn't consumed — don't let it leak to the next one.
+            Self.nextWindowDeclinesTabbing = false
+        }
+    }
+
+    private func openDocumentWindow(for fileURL: URL, completion: (() -> Void)? = nil) {
         NSDocumentController.shared.openDocument(withContentsOf: fileURL,
                                                  display: true) { [weak self] _, _, error in
+            completion?()
             guard let self, let error else { return }
             NSAlert(error: error).beginSheetModal(for: self.documentWindow)
         }
+    }
+
+    /// Backs the "+" button in the native tab bar and File > New Tab.
+    /// There is no untitled-document concept here, so prompt for a file
+    /// and open it — it joins the tab group via .preferred tabbing.
+    override func newWindowForTab(_ sender: Any?) {
+        openDocument(sender)
     }
 
     func openFolder(_ folderURL: URL) {
@@ -1607,7 +1665,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                 self.openFolder(url)
                 return
             }
-            self.openInNewWindow(url)
+            self.openInNewTab(url)
         }
     }
 

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -629,6 +629,12 @@ final class ProjectNavigatorView: NSView {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    @objc private func openInNewTab(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL,
+              let controller = documentWindowController else { return }
+        controller.openInNewTab(url)
+    }
+
     @objc private func openInNewWindow(_ sender: NSMenuItem) {
         guard let url = sender.representedObject as? URL,
               let controller = documentWindowController else { return }
@@ -670,6 +676,10 @@ extension ProjectNavigatorView: NSMenuDelegate {
 
         if !node.isDirectory {
             menu.addItem(.separator())
+            menu.addItem(makeMenuItem(title: "Open in New Tab",
+                                      symbol: "macwindow",
+                                      action: #selector(openInNewTab(_:)),
+                                      url: url))
             menu.addItem(makeMenuItem(title: "Open in New Window",
                                       symbol: "macwindow.badge.plus",
                                       action: #selector(openInNewWindow(_:)),


### PR DESCRIPTION
## Summary
- Document windows now opt into native macOS tabbing (`tabbingMode = .preferred` with a shared `tabbingIdentifier`), so files opened from Finder, the open panel, or the sidebar group as tabs in the frontmost window
- New windows join the existing tab group explicitly on first show — this controller orders its window front itself (inside `makeWindowControllers`, before `NSDocument.showWindows` where AppKit's automatic tab placement hooks in), so automatic placement never fires on its own
- The tab bar's "+" button and a new File > New Tab (⌘T) menu item prompt with the open panel and open the chosen file as a new tab (the app has no untitled-document concept)
- The Project Navigator context menu gains "Open in New Tab"; "Open in New Window" still opens a genuinely separate window via a one-shot tabbing override that resets after the window's first show
- AppKit contributes Close Tab / Close Other Tabs and the Window-menu tab commands (Show Next/Previous Tab, Merge All Windows) automatically

Known behavior: since document windows now prefer tabs, documents reopened at launch gather into one tabbed window.

## Test plan
- [x] Build succeeds (`xcodebuild -scheme md-preview -configuration Debug`)
- [x] Opening two files from Finder produces one window with two native tabs and a "+" button
- [x] File menu shows New Tab (⌘T) plus AppKit's Close Tab / Close Other Tabs
- [x] Sidebar context menu shows both Open in New Tab and Open in New Window
- [ ] Open in New Window produces a separate window that can still merge via Window > Merge All Windows
- [ ] Tabs work in full screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)