### PR TITLE
Fix window growing on zoom and blocked min-width resize in centered mode

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -107,7 +107,10 @@ final class ContentViewController: NSViewController {
         // column keeps its 820 CSS-px measure at every zoom level.
         let pageWidth = webView.widthAnchor.constraint(
             equalToConstant: MarkdownHTML.preferredPageWidth * webView.pageZoom)
-        pageWidth.priority = .init(999) // yields to the clip-width cap below
+        // Must stay below windowSizeStayPut (500): anything stronger drives
+        // the window frame through the clip-width chain — zooming would
+        // grow the window and block resizing below the page width.
+        pageWidth.priority = .init(499)
         webViewPageWidthConstraint = pageWidth
         webViewCenteredConstraints = [
             webView.centerXAnchor.constraint(equalTo: documentView.centerXAnchor),


### PR DESCRIPTION
## Summary
- Drop the centered-mode page-width constraint priority from 999 to 499, below `NSLayoutConstraint.Priority.windowSizeStayPut` (500)

## Root cause
#163 introduced `webView.width = preferredPageWidth × pageZoom` at priority 999. In AppKit the window frame participates in Auto Layout at priority 500, and the web view's width chains up to the window (webView.width ≤ documentView.width = clip view width = window content width). At 999 the constraint was strong enough to:

1. **Grow the window on zoom** — every ⌘+/pinch bumped the constant and pushed the window frame outward to satisfy it
2. **Block shrinking** — resize drags couldn't beat 999, so the window behaved as if its min width were 820 × zoom

The constraint was always meant to yield to the clip width (per its original comment), but that only works below 500. At 499 the column still holds its 820 CSS-px measure (× zoom) on wide windows, the required `≤ documentView.width` cap still shrinks it on narrow ones, and the window frame is free again.

## Validation
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` passes

## Test plan
- [ ] ⌘+/⌘−/pinch zoom no longer resizes the window
- [ ] Window resizes below the column width normally
- [ ] Centered column and the #162 jitter fix (sidebar toggle) behave as before
- [ ] Full Width mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)