### PR TITLE
Preserve Markdown source line breaks

### DIFF
--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -323,7 +323,9 @@ nonisolated struct EscapingHTMLFormatter: MarkupWalker {
     }
 
     mutating func visitSoftBreak(_ softBreak: SoftBreak) {
-        result += "\n"
+        // Obsidian-style breaks: a single newline in the source is a real
+        // line break, not a CommonMark soft-wrap space.
+        result += "<br />\n"
     }
 
     mutating func visitLink(_ link: Link) {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
@@ -48,7 +48,18 @@ final class EscapingHTMLFormatterTests: XCTestCase {
         """)
         XCTAssertTrue(html.contains("markdown-alert-warning"), "expected warning kind: \(html)")
         XCTAssertTrue(html.contains("Something specific</p>"), "expected custom title text: \(html)")
-        XCTAssertTrue(html.contains("Multi\nline body."), "expected body across lines: \(html)")
+        XCTAssertTrue(
+            html.contains("Multi<br />\nline body."),
+            "expected body line break to remain visible: \(html)"
+        )
+    }
+
+    func testSoftBreakRendersAsVisibleLineBreak() {
+        let html = EscapingHTMLFormatter.format("First line\nSecond line")
+        XCTAssertTrue(
+            html.contains("First line<br />\nSecond line"),
+            "expected a source newline to remain visible: \(html)"
+        )
     }
 
     func testGitHubAlertTagIsCaseInsensitive() {


### PR DESCRIPTION
## Summary

- render Markdown soft breaks as visible HTML line breaks in read-only preview
- update alert coverage for the new output
- add a focused regression test for ordinary multiline paragraphs

## Why

Single source newlines were previously collapsed by HTML layout, causing lines intentionally separated in Markdown to appear joined in read-only mode.

## Validation

- `swift test --package-path tests/swift-tests` (41 tests passed)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/md-preview-line-break-pr build`
- `git diff --check`
