### PR TITLE
Fix delayed code block line-height shift

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -2030,6 +2030,10 @@ nonisolated enum MarkdownHTML {
         background-color: color-mix(in srgb, var(--text) 55%, transparent);
     }
     pre code {
+        /* highlight.js adds display:block with the .hljs class after its
+           deferred pass. Match that layout from first paint so syntax
+           coloring cannot change the code block's line boxes. */
+        display: block;
         padding: 0;
         background: transparent;
         font-size: 0.88em;

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -56,6 +56,25 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(rendered.articleHTML.contains("<code class=\"language-mermaid\""))
     }
 
+    func testCodeBlockLayoutMatchesDeferredHighlightingFromFirstPaint() throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```swift
+            let answer = 42
+            ```
+            """,
+            vendorLoading: .lazy
+        )
+
+        let codeRuleStart = try XCTUnwrap(rendered.html.range(of: "pre code {"))
+        let codeRuleEnd = try XCTUnwrap(
+            rendered.html.range(of: "}", range: codeRuleStart.upperBound..<rendered.html.endIndex)
+        )
+        let codeRule = rendered.html[codeRuleStart.lowerBound..<codeRuleEnd.upperBound]
+
+        XCTAssertTrue(codeRule.contains("display: block;"))
+    }
+
     func testBlockMathKeepsValidWrapperAndSourceLine() {
         let rendered = MarkdownHTML.render(
             markdown: """


### PR DESCRIPTION
## Summary

- keep fenced code elements block-level from the initial render
- prevent deferred highlight.js activation from recalculating code line boxes
- add a render regression test for the initial code-block layout

## Root cause

Code blocks initially rendered with an inline `<code>` element. The deferred highlight.js pass later added the `.hljs` class, whose stylesheet changed that element to `display: block`. Combined with the code font's `0.88em` size, that display change recalculated line boxes and caused a visible line-height jump a few seconds after opening a document.

## Validation

- `swift test --package-path tests/swift-tests` (50 tests)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-line-height-build build CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
