### PR TITLE
Fix sidebar collapse during window resize

### DIFF
--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -27,7 +27,9 @@ final class MainSplitViewController: NSSplitViewController {
         sidebar.minimumThickness = 180
         sidebar.maximumThickness = 400
         sidebar.canCollapse = true
-        sidebar.canCollapseFromWindowResize = false
+        // When the window becomes too narrow to satisfy both panes, collapse
+        // the sidebar instead of leaving it pinned at its minimum thickness.
+        sidebar.canCollapseFromWindowResize = true
 
         let content = NSSplitViewItem(viewController: LayeredContentViewController())
         content.minimumThickness = 420


### PR DESCRIPTION
## Summary

- allow the sidebar split item to collapse automatically when the window becomes too narrow
- prevent the sidebar from remaining stuck at its minimum width

## Root cause

The sidebar was collapsible, but automatic collapse during window resizing was explicitly disabled. AppKit therefore kept it pinned at its minimum thickness when the content pane also reached its minimum.

## Validation

- verified with Computer Use that narrowing the window fully collapses the sidebar
- verified resizing still works with an active document filter and the sidebar collapses fully
- `xcodebuild` Debug build passed
- 49 Swift tests passed
- `git diff --check` passed