### PR TITLE
Make read-mode task checkboxes interactive

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -47,6 +47,7 @@ final class ContentViewController: NSViewController {
     private static let stickyReleaseFraction: CGFloat = 1.0 / 3.0
 
     var activeHeadingDidChange: ((Int?) -> Void)?
+    var taskCheckboxToggled: ((Int, Bool) -> Void)?
 
     override func loadView() {
         let scrollView = NSScrollView()
@@ -77,6 +78,9 @@ final class ContentViewController: NSViewController {
         }
         webView.fragmentLinkActivated = { [weak self] fragment in
             self?.scrollToElement(id: fragment)
+        }
+        webView.taskCheckboxToggled = { [weak self] line, checked in
+            self?.taskCheckboxToggled?(line, checked)
         }
         webView.zoomDidChange = { [weak self] zoom in
             self?.webViewPageWidthConstraint?.constant = MarkdownHTML.preferredPageWidth * zoom

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -157,6 +157,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         split.onSelectFile = { [weak self] url in
             self?.present(url: url)
         }
+        split.onToggleTaskCheckbox = { [weak self] line, checked in
+            self?.toggleTaskCheckbox(onLine: line, checked: checked)
+        }
         documentWindow.contentViewController = split
         documentWindow.setContentSize(NSSize(width: 1100, height: 720))
         documentWindow.center()
@@ -1283,6 +1286,44 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         }
     }
 
+    private func toggleTaskCheckbox(onLine sourceLine: Int, checked: Bool) {
+        guard !isEditing,
+              let baseline = currentMarkdown,
+              let updated = TaskCheckboxSource.settingChecked(
+                checked, onLine: sourceLine, in: baseline
+              ),
+              updated != baseline else {
+            rerenderCurrentPreview()
+            return
+        }
+
+        let diskState = diskFileState(for: currentFileURL, expectedMarkdown: baseline)
+        saveEditedMarkdown(updated, diskState: diskState) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .saved:
+                self.currentMarkdown = updated
+                if let url = self.currentFileURL {
+                    self.markdownDocument?.replaceContents(markdown: updated, fileURL: url)
+                    self.renderCurrentDocument(text: updated, fileURL: url)
+                }
+            case let .reloaded(externalMarkdown):
+                self.currentMarkdown = externalMarkdown
+                if let url = self.currentFileURL {
+                    self.markdownDocument?.replaceContents(markdown: externalMarkdown, fileURL: url)
+                    self.renderCurrentDocument(text: externalMarkdown, fileURL: url)
+                }
+            case .cancelled:
+                self.rerenderCurrentPreview()
+            }
+        }
+    }
+
+    private func rerenderCurrentPreview() {
+        guard let url = currentFileURL, let markdown = currentMarkdown else { return }
+        renderCurrentDocument(text: markdown, fileURL: url)
+    }
+
     private func presentExternalEditConflict(
         localMarkdown: String,
         externalMarkdown: String,
@@ -1292,7 +1333,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "This document changed on disk"
-        alert.informativeText = "Another app changed \(fileURL.lastPathComponent). Cancel keeps your editor changes unsaved. Choose which version to keep."
+        alert.informativeText = "Another app changed \(fileURL.lastPathComponent). Cancel keeps your changes unsaved. Choose which version to keep."
         alert.addButton(withTitle: "Keep My Changes")
         alert.addButton(withTitle: "Reload from Disk")
         alert.addButton(withTitle: "Cancel")
@@ -1329,7 +1370,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Unable to verify the document on disk"
-        alert.informativeText = "\(reason) Cancel keeps your editor changes unsaved."
+        alert.informativeText = "\(reason) Cancel keeps your changes unsaved."
         alert.addButton(withTitle: overwriteTitle)
         alert.addButton(withTitle: "Cancel")
         alert.beginSheetModal(for: documentWindow) { [weak self] response in

--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -6,6 +6,36 @@
 import Foundation
 import Markdown
 
+nonisolated enum TaskCheckboxSource {
+    private static let markerRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(
+            pattern: #"^(\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+\[)([ xX])(\])"#
+        )
+    }()
+
+    /// Returns a copy with the task marker on the 1-based source line set to
+    /// the requested state. The source line comes from swift-markdown's range,
+    /// so duplicate task labels and nested lists remain unambiguous.
+    static func settingChecked(_ checked: Bool,
+                               onLine sourceLine: Int,
+                               in markdown: String) -> String? {
+        guard sourceLine > 0 else { return nil }
+        var lines = markdown.components(separatedBy: "\n")
+        let index = sourceLine - 1
+        guard lines.indices.contains(index) else { return nil }
+
+        let line = lines[index]
+        let fullRange = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = markerRegex.firstMatch(in: line, range: fullRange),
+              let markerRange = Range(match.range(at: 2), in: line) else {
+            return nil
+        }
+        lines[index].replaceSubrange(markerRange, with: checked ? "x" : " ")
+        return lines.joined(separator: "\n")
+    }
+}
+
 // Mirrors swift-markdown's HTMLFormatter but HTML-escapes text, code, and
 // attribute values. Upstream HTMLFormatter emits unescaped content
 // (swift-markdown 0.7.x), so characters like `<`, `>`, and `&` either render

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -10,6 +10,7 @@ final class MainSplitViewController: NSSplitViewController {
     private static let didSeedKey = "MainSplitView.didSeedInitialState"
 
     var onSelectFile: ((URL) -> Void)?
+    var onToggleTaskCheckbox: ((Int, Bool) -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,6 +48,9 @@ final class MainSplitViewController: NSSplitViewController {
         // Wired after addSplitViewItem so the accessors are non-nil.
         contentViewController?.activeHeadingDidChange = { [weak self] headingID in
             self?.sidebarViewController?.setActiveHeading(headingID)
+        }
+        contentViewController?.taskCheckboxToggled = { [weak self] line, checked in
+            self?.onToggleTaskCheckbox?(line, checked)
         }
     }
 

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -844,11 +844,13 @@ nonisolated enum MarkdownHTML {
     private static let hostBridgeScript: String = """
     <script>
     (() => {
+        let hasHostBridge = false;
         const post = (() => {
             try {
                 const h = window.webkit && window.webkit.messageHandlers
                     && window.webkit.messageHandlers.mdPreviewHost;
                 if (!h) return () => false;
+                hasHostBridge = true;
                 return (msg) => {
                     h.postMessage(msg);
                     return true;
@@ -1015,6 +1017,29 @@ nonisolated enum MarkdownHTML {
             copyCodeBlock(button);
         });
 
+        function enableTaskCheckboxes() {
+            if (!hasHostBridge) return;
+            document.querySelectorAll('.task-list-item-checkbox').forEach((checkbox) => {
+                checkbox.disabled = false;
+            });
+        }
+
+        document.addEventListener('change', (event) => {
+            const checkbox = event.target.closest('.task-list-item-checkbox');
+            if (!checkbox || !hasHostBridge) return;
+            const item = checkbox.closest('[data-source-line]');
+            const sourceLine = item && Number(item.dataset.sourceLine);
+            if (!Number.isInteger(sourceLine) || sourceLine < 1) {
+                checkbox.checked = !checkbox.checked;
+                return;
+            }
+            checkbox.disabled = true;
+            if (!post({ kind: 'taskCheckbox', line: sourceLine, checked: checkbox.checked })) {
+                checkbox.checked = !checkbox.checked;
+                checkbox.disabled = false;
+            }
+        });
+
         document.addEventListener('copy', (event) => {
             const selection = window.getSelection();
             if (!selection || selection.rangeCount === 0 || !event.clipboardData) return;
@@ -1144,6 +1169,7 @@ nonisolated enum MarkdownHTML {
             }
             if (articleHTML) {
                 decorateCodeBlocks();
+                enableTaskCheckboxes();
                 for (const fn of reappliers) {
                     try { fn(); } catch (e) { /* one bad apple shouldn't block others */ }
                 }
@@ -2276,6 +2302,7 @@ nonisolated enum MarkdownHTML {
         border-color: #007aff;
         background: #007aff;
     }
+    .task-list-item-checkbox:not(:disabled) { cursor: pointer; }
     .task-list-item-checkbox:checked::after {
         content: "";
         position: absolute;

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -76,6 +76,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     var heightDidChange: ((CGFloat) -> Void)?
     var zoomDidChange: ((CGFloat) -> Void)?
     var fragmentLinkActivated: ((String) -> Void)?
+    var taskCheckboxToggled: ((Int, Bool) -> Void)?
     private let assetScheme = MarkdownAssetScheme()
     private var currentAssetBase: URL?
     private let messageBridge = HostBridge()
@@ -317,6 +318,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(text, forType: .string)
+        case "taskCheckbox":
+            guard let line = dict["line"] as? NSNumber,
+                  let checked = dict["checked"] as? NSNumber else { return }
+            taskCheckboxToggled?(line.intValue, checked.boolValue)
         case "scroll":
             guard let value = dict["value"] as? String else { return }
             switch value {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/EscapingHTMLFormatterTests.swift
@@ -6,6 +6,30 @@ import XCTest
 // trailing metadata (e.g. ```mermaid some-name) does not leak into HTML.
 final class EscapingHTMLFormatterTests: XCTestCase {
 
+    func testTaskCheckboxSourceTogglesExactSourceLine() {
+        let markdown = "- [ ] Same\n  - [x] Nested\n- [ ] Same\n"
+        XCTAssertEqual(
+            TaskCheckboxSource.settingChecked(true, onLine: 3, in: markdown),
+            "- [ ] Same\n  - [x] Nested\n- [x] Same\n"
+        )
+        XCTAssertEqual(
+            TaskCheckboxSource.settingChecked(false, onLine: 2, in: markdown),
+            "- [ ] Same\n  - [ ] Nested\n- [ ] Same\n"
+        )
+    }
+
+    func testTaskCheckboxSourceRejectsNonTaskLine() {
+        XCTAssertNil(TaskCheckboxSource.settingChecked(true, onLine: 1, in: "Plain text"))
+        XCTAssertNil(TaskCheckboxSource.settingChecked(true, onLine: 2, in: "- [ ] Task"))
+    }
+
+    func testTaskCheckboxSourceSupportsQuotedAndOrderedTasks() {
+        XCTAssertEqual(
+            TaskCheckboxSource.settingChecked(true, onLine: 1, in: "> 1. [ ] Quoted"),
+            "> 1. [x] Quoted"
+        )
+    }
+
     func testFencedCodeBlockSetsLanguageClassFromFirstInfoWord() {
         let html = EscapingHTMLFormatter.format("""
         ```mermaid some-name


### PR DESCRIPTION
## Summary

- make rendered task-list checkboxes clickable in the app preview
- update the exact source line and save immediately through the existing sandbox-aware document flow
- keep Quick Look checkboxes read-only and restore preview state when a save is cancelled
- preserve external-edit conflict handling and support nested, quoted, ordered, and duplicate-label tasks

## Why

Task checkboxes looked actionable in read mode but could only be changed by entering the editor. This lets users complete tasks directly from the preview while keeping the Markdown file as the source of truth.

## Validation

- `swift test --package-path tests/swift-tests` (52 tests passed)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/md-preview-checkbox-pr-build build`
- `git diff --check`