### PR TITLE
Fix native sidebar resize priority

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -120,10 +120,10 @@ final class ContentViewController: NSViewController {
         // column keeps its 820 CSS-px measure at every zoom level.
         let pageWidth = webView.widthAnchor.constraint(
             equalToConstant: MarkdownHTML.preferredPageWidth * webView.pageZoom)
-        // Must stay below windowSizeStayPut (500): anything stronger drives
-        // the window frame through the clip-width chain — zooming would
-        // grow the window and block resizing below the page width.
-        pageWidth.priority = .init(499)
+        // Stay below the split items' holding priorities (content 250,
+        // sidebar 260) so window resizing breaks this page-width preference
+        // before AppKit changes the user's chosen sidebar width.
+        pageWidth.priority = .init(249)
         webViewPageWidthConstraint = pageWidth
         webViewCenteredConstraints = [
             webView.centerXAnchor.constraint(equalTo: documentView.centerXAnchor),

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -219,22 +219,6 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         return false
     }
 
-    func windowWillStartLiveResize(_ notification: Notification) {
-        (documentWindow.contentViewController as? MainSplitViewController)?
-            .windowWillStartLiveResize()
-    }
-
-    func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
-        (documentWindow.contentViewController as? MainSplitViewController)?
-            .windowWillResize(by: frameSize.width - sender.frame.width)
-        return frameSize
-    }
-
-    func windowDidEndLiveResize(_ notification: Notification) {
-        (documentWindow.contentViewController as? MainSplitViewController)?
-            .windowDidEndLiveResize()
-    }
-
     func windowWillClose(_ notification: Notification) {
         fileWatcher?.cancel()
         fileWatcher = nil

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -219,6 +219,22 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         return false
     }
 
+    func windowWillStartLiveResize(_ notification: Notification) {
+        (documentWindow.contentViewController as? MainSplitViewController)?
+            .windowWillStartLiveResize()
+    }
+
+    func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
+        (documentWindow.contentViewController as? MainSplitViewController)?
+            .windowWillResize(by: frameSize.width - sender.frame.width)
+        return frameSize
+    }
+
+    func windowDidEndLiveResize(_ notification: Notification) {
+        (documentWindow.contentViewController as? MainSplitViewController)?
+            .windowDidEndLiveResize()
+    }
+
     func windowWillClose(_ notification: Notification) {
         fileWatcher?.cancel()
         fileWatcher = nil

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -29,6 +29,7 @@ final class MainSplitViewController: NSSplitViewController {
         sidebar.maximumThickness = 400
         sidebar.canCollapse = true
         sidebar.canCollapseFromWindowResize = false
+        sidebar.holdingPriority = .defaultHigh
 
         let content = NSSplitViewItem(viewController: LayeredContentViewController())
 

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -28,12 +28,9 @@ final class MainSplitViewController: NSSplitViewController {
         sidebar.minimumThickness = 180
         sidebar.maximumThickness = 400
         sidebar.canCollapse = true
-        // When the window becomes too narrow to satisfy both panes, collapse
-        // the sidebar instead of leaving it pinned at its minimum thickness.
-        sidebar.canCollapseFromWindowResize = true
+        sidebar.canCollapseFromWindowResize = false
 
         let content = NSSplitViewItem(viewController: LayeredContentViewController())
-        content.minimumThickness = 420
 
         let inspector = NSSplitViewItem(inspectorWithViewController: InspectorViewController())
         inspector.minimumThickness = 270

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -8,7 +8,6 @@ import Cocoa
 final class MainSplitViewController: NSSplitViewController {
 
     private static let didSeedKey = "MainSplitView.didSeedInitialState"
-    private var sidebarHoldingPriorityBeforeLiveResize: NSLayoutConstraint.Priority?
 
     var onSelectFile: ((URL) -> Void)?
     var onToggleTaskCheckbox: ((Int, Bool) -> Void)?
@@ -59,30 +58,6 @@ final class MainSplitViewController: NSSplitViewController {
         contentViewController?.display(markdown: markdown, assetBaseURL: assetBaseURL)
         sidebarViewController?.display(markdown: markdown, fileName: fileName, fileURL: url)
         inspectorViewController?.display(metadata: DocumentMetadata.make(url: url, markdown: markdown))
-    }
-
-    func windowWillStartLiveResize() {
-        guard sidebarHoldingPriorityBeforeLiveResize == nil,
-              let sidebar = splitViewItems.first else { return }
-        sidebarHoldingPriorityBeforeLiveResize = sidebar.holdingPriority
-        sidebar.holdingPriority = .defaultHigh
-    }
-
-    func windowWillResize(by widthDelta: CGFloat) {
-        guard let originalPriority = sidebarHoldingPriorityBeforeLiveResize,
-              splitViewItems.count > 1 else { return }
-        let content = splitViewItems[1]
-        let proposedContentWidth = content.viewController.view.frame.width + widthDelta
-        splitViewItems[0].holdingPriority = proposedContentWidth >= content.minimumThickness
-            ? .defaultHigh
-            : originalPriority
-    }
-
-    func windowDidEndLiveResize() {
-        guard let priority = sidebarHoldingPriorityBeforeLiveResize,
-              let sidebar = splitViewItems.first else { return }
-        sidebar.holdingPriority = priority
-        sidebarHoldingPriorityBeforeLiveResize = nil
     }
 
     /// URL-only refresh after a rename. Skips the content re-render so

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -8,6 +8,7 @@ import Cocoa
 final class MainSplitViewController: NSSplitViewController {
 
     private static let didSeedKey = "MainSplitView.didSeedInitialState"
+    private var sidebarHoldingPriorityBeforeLiveResize: NSLayoutConstraint.Priority?
 
     var onSelectFile: ((URL) -> Void)?
     var onToggleTaskCheckbox: ((Int, Bool) -> Void)?
@@ -29,9 +30,9 @@ final class MainSplitViewController: NSSplitViewController {
         sidebar.maximumThickness = 400
         sidebar.canCollapse = true
         sidebar.canCollapseFromWindowResize = false
-        sidebar.holdingPriority = .defaultHigh
 
         let content = NSSplitViewItem(viewController: LayeredContentViewController())
+        content.minimumThickness = 420
 
         let inspector = NSSplitViewItem(inspectorWithViewController: InspectorViewController())
         inspector.minimumThickness = 270
@@ -58,6 +59,30 @@ final class MainSplitViewController: NSSplitViewController {
         contentViewController?.display(markdown: markdown, assetBaseURL: assetBaseURL)
         sidebarViewController?.display(markdown: markdown, fileName: fileName, fileURL: url)
         inspectorViewController?.display(metadata: DocumentMetadata.make(url: url, markdown: markdown))
+    }
+
+    func windowWillStartLiveResize() {
+        guard sidebarHoldingPriorityBeforeLiveResize == nil,
+              let sidebar = splitViewItems.first else { return }
+        sidebarHoldingPriorityBeforeLiveResize = sidebar.holdingPriority
+        sidebar.holdingPriority = .defaultHigh
+    }
+
+    func windowWillResize(by widthDelta: CGFloat) {
+        guard let originalPriority = sidebarHoldingPriorityBeforeLiveResize,
+              splitViewItems.count > 1 else { return }
+        let content = splitViewItems[1]
+        let proposedContentWidth = content.viewController.view.frame.width + widthDelta
+        splitViewItems[0].holdingPriority = proposedContentWidth >= content.minimumThickness
+            ? .defaultHigh
+            : originalPriority
+    }
+
+    func windowDidEndLiveResize() {
+        guard let priority = sidebarHoldingPriorityBeforeLiveResize,
+              let sidebar = splitViewItems.first else { return }
+        sidebar.holdingPriority = priority
+        sidebarHoldingPriorityBeforeLiveResize = nil
     }
 
     /// URL-only refresh after a rename. Skips the content re-render so


### PR DESCRIPTION
## Summary

- prevent the sidebar from automatically collapsing during window resizing
- lower the centered page-width preference below the split items holding priorities
- let AppKit shrink content first and shrink the sidebar only after content reaches its 420-point minimum
- preserve native manual sidebar-divider resizing

## Root cause

The preview web view had an 820-point preferred width constraint at priority 499. That was stronger than the native split-item holding priorities (content 250, sidebar 260), so AppKit protected the preview width by shrinking the sidebar first.

The page-width constraint is now priority 249. It remains a visual preference at roomy sizes but yields before either split item, allowing NSSplitViewController to perform the resize automatically.

## Computer Use validation

- manually resized sidebar from 188 to 301 points
- resized window from 1046 to 853 points; sidebar remained 301 points
- resized window from 853 to 653 points; content reached 420-point minimum and sidebar then reduced to 233 points
- repeated with an active document filter: sidebar remained 300 points at 853-point window width and reduced to 233 points at 653-point width
- direct sidebar resizing remained functional with the filter active

## Other checks

- Debug Xcode build passed
- 53 Swift tests passed
- git diff check passed