### PR TITLE
Release 0.0.32 (36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.0.32] – 2026-07-12
+
+Markdown Preview now includes a live Markdown editor, so you can write and preview documents without switching apps.
+
+### Added
+
+- **Live Markdown edit mode.** Press ⌘E to switch between the rendered preview and an in-place editor with live preview updates, synchronized scrolling, native formatting controls, and ⌘S saving ([#169](https://github.com/pluk-inc/markdown-preview/pull/169)).
+- **Bold and italic Markdown editing.** Bold and italic formatting now preserve Markdown syntax cleanly while editing, including selections and existing formatted text ([#171](https://github.com/pluk-inc/markdown-preview/pull/171)).
+
+### Fixed
+
+- **Sidebar resizing is steadier.** The sidebar now keeps its intended width priority during window resizing instead of collapsing unexpectedly ([#177](https://github.com/pluk-inc/markdown-preview/pull/177), [#179](https://github.com/pluk-inc/markdown-preview/pull/179)).
+
 ## [0.0.31] – 2026-07-08
 
 Opening files now respects the macOS window tabbing preference instead of always gathering documents into tabs.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.31
-CURRENT_PROJECT_VERSION = 35
+MARKETING_VERSION = 0.0.32
+CURRENT_PROJECT_VERSION = 36


### PR DESCRIPTION
## Summary
- Bump Markdown Preview to 0.0.32 build 36
- Add release notes for live Markdown edit mode
- Include bold/italic editing support and sidebar resize fixes

## Verification
- git diff --check
- xcodebuild -showBuildSettings confirmed MARKETING_VERSION=0.0.32 and CURRENT_PROJECT_VERSION=36