### PR TITLE
Add privacy-filtered Sentry crash reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.33] – 2026-07-12
+
+Markdown Preview now includes a live Markdown editor, so you can write and preview documents without switching apps.
+
+### Added
+
+- **Live Markdown edit mode.** Press ⌘E to switch between the rendered preview and an in-place editor with live preview updates, synchronized scrolling, native formatting controls, and ⌘S saving ([#169](https://github.com/pluk-inc/markdown-preview/pull/169)).
+- **Bold and italic Markdown editing.** Bold and italic formatting now preserve Markdown syntax cleanly while editing, including selections and existing formatted text ([#171](https://github.com/pluk-inc/markdown-preview/pull/171)).
+- **Privacy-filtered crash reporting.** Native Sentry crash reports now help diagnose release failures without collecting document contents, file paths, user information, breadcrumbs, performance traces, or session data.
+
+### Fixed
+
+- **Sidebar resizing is steadier.** The sidebar now keeps its intended width priority during window resizing instead of collapsing unexpectedly ([#177](https://github.com/pluk-inc/markdown-preview/pull/177), [#179](https://github.com/pluk-inc/markdown-preview/pull/179)).
+
 ## [0.0.32] – 2026-07-12
 
 Markdown Preview now includes a live Markdown editor, so you can write and preview documents without switching apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Markdown Preview now includes a live Markdown editor, so you can write and previ
 
 - **Live Markdown edit mode.** Press ⌘E to switch between the rendered preview and an in-place editor with live preview updates, synchronized scrolling, native formatting controls, and ⌘S saving ([#169](https://github.com/pluk-inc/markdown-preview/pull/169)).
 - **Bold and italic Markdown editing.** Bold and italic formatting now preserve Markdown syntax cleanly while editing, including selections and existing formatted text ([#171](https://github.com/pluk-inc/markdown-preview/pull/171)).
-- **Privacy-filtered crash reporting.** Native Sentry crash reports now help diagnose release failures without collecting document contents, file paths, user information, breadcrumbs, performance traces, or session data.
+- **Privacy-filtered crash reporting.** Native Sentry crash reports now help diagnose release failures without collecting document contents, file paths, user information, breadcrumbs, performance traces, or session data, and can be disabled completely from Preferences.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Markdown Preview now includes a live Markdown editor, so you can write and previ
 
 - **Live Markdown edit mode.** Press ⌘E to switch between the rendered preview and an in-place editor with live preview updates, synchronized scrolling, native formatting controls, and ⌘S saving ([#169](https://github.com/pluk-inc/markdown-preview/pull/169)).
 - **Bold and italic Markdown editing.** Bold and italic formatting now preserve Markdown syntax cleanly while editing, including selections and existing formatted text ([#171](https://github.com/pluk-inc/markdown-preview/pull/171)).
-- **Privacy-filtered crash reporting.** Native Sentry crash reports now help diagnose release failures without collecting document contents, file paths, user information, breadcrumbs, performance traces, or session data, and can be disabled completely from Preferences.
+- **Privacy-filtered crash reporting.** Native Sentry crash reports now help diagnose release failures without collecting document contents, file paths, user information, breadcrumbs, performance traces, or session data, and can be disabled completely from the app menu.
 
 ### Fixed
 

--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SentryDSN</key>
+	<string>https://ff4b789ea2ae9b16dd0874590ee7bcd5@o4509530813890560.ingest.us.sentry.io/4511720750120960</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ cd markdown-preview
 open markdown-preview.xcodeproj
 ```
 
-Build and run the `markdown-preview` scheme. Swift Package Manager will resolve [Sparkle](https://github.com/sparkle-project/Sparkle) and [swift-markdown](https://github.com/swiftlang/swift-markdown) on first build.
+Build and run the `markdown-preview` scheme. Swift Package Manager will resolve [Sparkle](https://github.com/sparkle-project/Sparkle), [Sentry](https://github.com/getsentry/sentry-cocoa), and [swift-markdown](https://github.com/swiftlang/swift-markdown) on first build.
+
+### Crash reporting
+
+Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths.
+
+The committed DSN is a public client key. Release archives upload the app dSYM with `sentry-cli`; authenticate locally with `sentry-cli login` and keep that authentication token outside the repository.
 
 ## Project layout
 
@@ -141,6 +147,7 @@ Pull requests are welcome. For larger changes, please open an issue first to dis
 - [Mermaid](https://mermaid.js.org/) — Bundled diagram renderer for `mermaid` fenced code blocks
 - [KaTeX](https://katex.org/) — Bundled math typesetter for inline `$…$`, display `$$…$$`, and ` ```math ` blocks
 - [Sparkle](https://sparkle-project.org) — Auto-update framework
+- [Sentry](https://sentry.io) — Privacy-filtered native crash reporting
 - [LottieFiles](https://lottiefiles.com/) — Animated README logo
 
 ## License

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Build and run the `markdown-preview` scheme. Swift Package Manager will resolve 
 
 ### Crash reporting
 
-Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths. Users can turn reporting off from Markdown Preview > Preferences; on later launches, the Sentry SDK will not initialize at all.
+Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths. Users can turn reporting off directly from Markdown Preview > Send Anonymous Crash Reports; on later launches, the Sentry SDK will not initialize at all.
 
 The committed DSN is a public client key. Release archives upload the app dSYM with `sentry-cli`; authenticate locally with `sentry-cli login` and keep that authentication token outside the repository.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Build and run the `markdown-preview` scheme. Swift Package Manager will resolve 
 
 ### Crash reporting
 
-Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths.
+Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths. Users can turn reporting off from Markdown Preview > Preferences; on later launches, the Sentry SDK will not initialize at all.
 
 The committed DSN is a public client key. Release archives upload the app dSYM with `sentry-cli`; authenticate locally with `sentry-cli login` and keep that authentication token outside the repository.
 

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.32
-CURRENT_PROJECT_VERSION = 36
+MARKETING_VERSION = 0.0.33
+CURRENT_PROJECT_VERSION = 37

--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9A0209302FA10D4C00092060 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A02092F2FA10D4C00092060 /* Quartz.framework */; };
 		9A02093C2FA10D4C00092060 /* quick-look.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9A02092D2FA10D4C00092060 /* quick-look.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9A0209C12FA1100200092060 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9A0209C22FA1100200092060 /* Sparkle */; };
+		9A7B10012FB0000100010001 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 9A7B10032FB0000100010001 /* Sentry */; };
 		9A33940A2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3394092FA5AF500015D9A4 /* Markdown */; };
 		9A33940C2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A33940B2FA5AF500015D9A4 /* Markdown */; };
 		9AF000000000000000000003 /* mermaid.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 9AF000000000000000000101 /* mermaid.min.js */; };
@@ -114,6 +115,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A0209C12FA1100200092060 /* Sparkle in Frameworks */,
+				9A7B10012FB0000100010001 /* Sentry in Frameworks */,
 				9A33940A2FA5AF500015D9A4 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -180,6 +182,7 @@
 				9A0207BE2FA0ED7C00092060 /* Frameworks */,
 				9A0207BF2FA0ED7C00092060 /* Resources */,
 				9A02093D2FA10D4C00092060 /* Embed Foundation Extensions */,
+				9A7B10042FB0000100010001 /* Upload dSYMs to Sentry */,
 			);
 			buildRules = (
 			);
@@ -192,6 +195,7 @@
 			name = "md-preview";
 			packageProductDependencies = (
 				9A0209C22FA1100200092060 /* Sparkle */,
+				9A7B10032FB0000100010001 /* Sentry */,
 				9A3394092FA5AF500015D9A4 /* Markdown */,
 			);
 			productName = "md-preview";
@@ -223,6 +227,29 @@
 		};
 /* End PBXNativeTarget section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		9A7B10042FB0000100010001 /* Upload dSYMs to Sentry */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Upload dSYMs to Sentry";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nSENTRY_CLI=\"$(command -v sentry-cli || true)\"\nif [ -z \"$SENTRY_CLI\" ] && [ -x /opt/homebrew/bin/sentry-cli ]; then\n    SENTRY_CLI=/opt/homebrew/bin/sentry-cli\nfi\nif [ -z \"$SENTRY_CLI\" ]; then\n    echo \"error: sentry-cli is required to upload release dSYMs\" >&2\n    exit 1\nfi\n\n\"$SENTRY_CLI\" debug-files upload \\\n    --org pluk-inc \\\n    --project markdown-preview \\\n    --type dsym \\\n    \"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXProject section */
 		9A0207B92FA0ED7C00092060 /* Project object */ = {
 			isa = PBXProject;
@@ -250,6 +277,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				9A0209C32FA1100200092060 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				9A7B10022FB0000100010001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				9A3394082FA5AF500015D9A4 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -424,7 +452,7 @@
 				DEVELOPMENT_TEAM = 5P3TSMNV42;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -614,6 +642,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		9A7B10022FB0000100010001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 		9A0209C32FA1100200092060 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -633,6 +669,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		9A7B10032FB0000100010001 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9A7B10022FB0000100010001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
 		9A0209C22FA1100200092060 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9A0209C32FA1100200092060 /* XCRemoteSwiftPackageReference "Sparkle" */;

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -192,20 +192,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         updaterController.updater.checkForUpdates()
     }
 
-    @IBAction func showPreferences(_ sender: Any?) {
-        let checkbox = NSButton(checkboxWithTitle: "Send Anonymous Crash Reports",
-                                target: nil,
-                                action: nil)
-        checkbox.state = CrashReporter.isEnabled ? .on : .off
-
-        let alert = NSAlert()
-        alert.messageText = "Preferences"
-        alert.informativeText = "Crash reports help diagnose failures. They never include document contents, file paths, user information, or activity tracking."
-        alert.accessoryView = checkbox
-        alert.addButton(withTitle: "Done")
-        alert.runModal()
-
-        CrashReporter.isEnabled = checkbox.state == .on
+    @IBAction func toggleCrashReporting(_ sender: NSMenuItem) {
+        CrashReporter.isEnabled.toggle()
+        sender.state = CrashReporter.isEnabled ? .on : .off
     }
 
     @objc private func installCommandLineTools(_ sender: Any?) {
@@ -277,6 +266,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return activeDocumentWindowController != nil
         case #selector(selectAppearanceMode(_:)),
              #selector(selectContentWidthSetting(_:)):
+            return true
+        case #selector(toggleCrashReporting(_:)):
+            menuItem.state = CrashReporter.isEnabled ? .on : .off
             return true
         case #selector(toggleEditModeFromMenu(_:)):
             return activeDocumentWindowController?.canToggleEditMode ?? false

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -103,6 +103,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let markdownFileExtensions = ["md", "markdown", "mdown", "txt"]
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        CrashReporter.start()
         applyAppearanceMode(AppAppearanceMode.current, reloadPreviews: false)
         installAppearanceMenuItems()
         installContentWidthMenuItems()

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -192,6 +192,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         updaterController.updater.checkForUpdates()
     }
 
+    @IBAction func showPreferences(_ sender: Any?) {
+        let checkbox = NSButton(checkboxWithTitle: "Send Anonymous Crash Reports",
+                                target: nil,
+                                action: nil)
+        checkbox.state = CrashReporter.isEnabled ? .on : .off
+
+        let alert = NSAlert()
+        alert.messageText = "Preferences"
+        alert.informativeText = "Crash reports help diagnose failures. They never include document contents, file paths, user information, or activity tracking."
+        alert.accessoryView = checkbox
+        alert.addButton(withTitle: "Done")
+        alert.runModal()
+
+        CrashReporter.isEnabled = checkbox.state == .on
+    }
+
     @objc private func installCommandLineTools(_ sender: Any?) {
         do {
             let installerScriptURL = try writeCommandLineToolInstallerScript()

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -36,9 +36,10 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
+                            <menuItem title="Send Anonymous Crash Reports" id="BOF-NM-1cW">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="showPreferences:" target="Voe-Tx-rLC" id="sentry-pref-act"/>
+                                    <action selector="toggleCrashReporting:" target="Voe-Tx-rLC" id="sentry-pref-act"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -36,7 +36,11 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
+                                <connections>
+                                    <action selector="showPreferences:" target="Voe-Tx-rLC" id="sentry-pref-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
                             <menuItem title="Services" id="NMo-om-nkz">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/md-preview/CrashReporter.swift
+++ b/md-preview/CrashReporter.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Sentry
+
+enum CrashReporter {
+    static func start(bundle: Bundle = .main) {
+        guard let dsn = bundle.object(forInfoDictionaryKey: "SentryDSN") as? String,
+              !dsn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.sendDefaultPii = false
+            options.enableAutoSessionTracking = false
+            options.tracesSampleRate = 0
+            options.profilesSampleRate = 0
+            options.enableAppHangTracking = false
+            options.enableNetworkTracking = false
+            options.enableFileIOTracing = false
+            options.enableCoreDataTracing = false
+            options.enableSwizzling = false
+            options.environment = "production"
+
+            options.beforeSend = { event in
+                // Markdown documents and their paths may be sensitive. Keep only
+                // the native crash data needed to diagnose the failure.
+                event.breadcrumbs = nil
+                event.request = nil
+                event.user = nil
+                return event
+            }
+        }
+    }
+}

--- a/md-preview/CrashReporter.swift
+++ b/md-preview/CrashReporter.swift
@@ -2,8 +2,29 @@ import Foundation
 import Sentry
 
 enum CrashReporter {
+    private static let enabledDefaultsKey = "MarkdownPreview.sendAnonymousCrashReports"
+
+    static var isEnabled: Bool {
+        get {
+            guard let stored = UserDefaults.standard.object(forKey: enabledDefaultsKey) as? NSNumber else {
+                return true
+            }
+            return stored.boolValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: enabledDefaultsKey)
+            if newValue {
+                start()
+            } else if SentrySDK.isEnabled {
+                SentrySDK.close()
+            }
+        }
+    }
+
     static func start(bundle: Bundle = .main) {
-        guard let dsn = bundle.object(forInfoDictionaryKey: "SentryDSN") as? String,
+        guard isEnabled,
+              !SentrySDK.isEnabled,
+              let dsn = bundle.object(forInfoDictionaryKey: "SentryDSN") as? String,
               !dsn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return
         }


### PR DESCRIPTION
## Summary

- add the native Sentry Cocoa SDK for crash-only reporting
- strip breadcrumbs, requests, user data, document paths, and optional telemetry from submitted events
- add a native Preferences opt-out that shuts down Sentry and prevents initialization on later launches
- upload the main app dSYM during local release archives using the maintainer's existing `sentry-cli` authentication
- prepare version 0.0.33 build 37 by carrying forward the 0.0.32 notes and adding the Sentry entry

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Release -derivedDataPath /tmp/md-preview-sentry-release -clonedSourcePackagesDirPath /tmp/md-preview-sentry-packages build`
- `sentry-cli debug-files upload --org pluk-inc --project markdown-preview --type dsym --no-upload "/tmp/md-preview-sentry-release/Build/Products/Release/Markdown Preview.app.dSYM"`
- `plutil -lint Info.plist`
- `git diff --check`
