### PR TITLE
Add Markdown navigation history

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -48,6 +48,7 @@ final class ContentViewController: NSViewController {
 
     var activeHeadingDidChange: ((Int?) -> Void)?
     var taskCheckboxToggled: ((Int, Bool) -> Void)?
+    var localMarkdownLinkActivated: ((URL) -> Void)?
 
     override func loadView() {
         let scrollView = NSScrollView()
@@ -78,6 +79,9 @@ final class ContentViewController: NSViewController {
         }
         webView.fragmentLinkActivated = { [weak self] fragment in
             self?.scrollToElement(id: fragment)
+        }
+        webView.localMarkdownLinkActivated = { [weak self] url in
+            self?.localMarkdownLinkActivated?(url)
         }
         webView.taskCheckboxToggled = { [weak self] line, checked in
             self?.taskCheckboxToggled?(line, checked)

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -20,6 +20,7 @@ extension NSToolbarItem.Identifier {
     static let copyMarkdown = NSToolbarItem.Identifier("CopyMarkdown")
     static let zoom = NSToolbarItem.Identifier("Zoom")
     static let editDocument = NSToolbarItem.Identifier("EditDocument")
+    static let navigation = NSToolbarItem.Identifier("Navigation")
 }
 
 private extension Array where Element == NSToolbarItem.Identifier {
@@ -33,6 +34,12 @@ private extension Array where Element == NSToolbarItem.Identifier {
 }
 
 final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate, NSSearchFieldDelegate, NSMenuDelegate {
+
+    private enum NavigationIntent {
+        case normal
+        case back
+        case forward
+    }
 
     private enum DiskFileState {
         case unchanged
@@ -55,6 +62,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private var currentFileURL: URL?
     private var currentMarkdown: String?
+    private var backHistory: [URL] = []
+    private var forwardHistory: [URL] = []
+    private weak var navigationItem: NSToolbarItem?
+    private weak var navigationControl: NSSegmentedControl?
     private var fileWatcher: FileWatcher?
     private var isInspectorToggleSelected = false
     private weak var openActionsItem: NSMenuToolbarItem?
@@ -157,6 +168,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         split.onSelectFile = { [weak self] url in
             self?.present(url: url)
         }
+        split.onOpenMarkdownLink = { [weak self] url in
+            self?.present(url: url)
+        }
         split.onToggleTaskCheckbox = { [weak self] line, checked in
             self?.toggleTaskCheckbox(onLine: line, checked: checked)
         }
@@ -249,23 +263,31 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     }
 
     private func present(url: URL) {
+        present(url: url, intent: .normal)
+    }
+
+    private func present(url: URL, intent: NavigationIntent) {
+        let url = Self.fileURLWithoutFragment(url)
         let preserveEditMode = isEditing || pendingEditModeURL != nil
         if isEditing || hasPendingEditorChanges {
             requestEndEditing(keepAccessoryMounted: true) { [weak self] success in
                 guard success else { return }
-                self?.present(url: url, preservingEditMode: preserveEditMode)
+                self?.present(url: url, preservingEditMode: preserveEditMode, intent: intent)
             }
             return
         }
-        present(url: url, preservingEditMode: preserveEditMode)
+        present(url: url, preservingEditMode: preserveEditMode, intent: intent)
     }
 
-    private func present(url: URL, preservingEditMode: Bool) {
+    private func present(url: URL, preservingEditMode: Bool, intent: NavigationIntent) {
         if url.isExistingDirectory {
             pendingEditModeURL = nil
             openFolder(url)
             return
         }
+
+        guard currentFileURL?.standardizedFileURL != url.standardizedFileURL else { return }
+        commitNavigation(to: url, intent: intent)
 
         // Switching to a different file blanks the preview so the previous
         // doc doesn't linger on screen during sheet dismissal + load.
@@ -288,6 +310,37 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         loadFile(at: url)
         startWatching(url)
         offerToBecomeDefaultHandlerIfNeeded()
+    }
+
+    private func commitNavigation(to url: URL, intent: NavigationIntent) {
+        guard let currentFileURL else { return }
+        switch intent {
+        case .normal:
+            Self.appendHistory(currentFileURL, to: &backHistory)
+            forwardHistory.removeAll()
+        case .back:
+            guard backHistory.last?.standardizedFileURL == url.standardizedFileURL else { return }
+            backHistory.removeLast()
+            Self.appendHistory(currentFileURL, to: &forwardHistory)
+        case .forward:
+            guard forwardHistory.last?.standardizedFileURL == url.standardizedFileURL else { return }
+            forwardHistory.removeLast()
+            Self.appendHistory(currentFileURL, to: &backHistory)
+        }
+        updateNavigationControl()
+    }
+
+    private static func appendHistory(_ url: URL, to history: inout [URL]) {
+        if history.last?.standardizedFileURL != url.standardizedFileURL {
+            history.append(url.standardizedFileURL)
+        }
+    }
+
+    private static func fileURLWithoutFragment(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.fragment != nil else { return url }
+        components.fragment = nil
+        return components.url ?? url
     }
 
     private func startWatching(_ url: URL) {
@@ -355,9 +408,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
-            .flexibleSpace,
             .sidebarMenu,
             .sidebarTrackingSeparator,
+            .navigation,
+            .flexibleSpace,
             .openActions,
             .space,
             .zoom,
@@ -372,6 +426,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         var identifiers: [NSToolbarItem.Identifier] = [
             .sidebarMenu,
             .sidebarTrackingSeparator,
+            .navigation,
             .flexibleSpace,
             .space,
             .openActions,
@@ -395,6 +450,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                  willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         switch itemIdentifier {
         case .sidebarMenu: return makeSidebarMenuItem(willBeInsertedIntoToolbar: flag)
+        case .navigation: return makeNavigationItem()
         case .openActions: return makeOpenActionsItem()
         case .openWith: return makeOpenWithItem()
         case .openInLLM:
@@ -409,6 +465,53 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         case .zoom: return makeZoomItem()
         default: return nil
         }
+    }
+
+    private func makeNavigationItem() -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: .navigation)
+        item.label = "Navigation"
+        item.paletteLabel = "Back and Forward"
+        item.isNavigational = true
+        item.autovalidates = false
+
+        let control = NSSegmentedControl(labels: ["", ""],
+                                         trackingMode: .momentary,
+                                         target: self,
+                                         action: #selector(navigateHistory(_:)))
+        control.segmentStyle = .automatic
+        control.setImage(NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Back"),
+                         forSegment: 0)
+        control.setImage(NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Forward"),
+                         forSegment: 1)
+        control.setToolTip("Back", forSegment: 0)
+        control.setToolTip("Forward", forSegment: 1)
+        item.view = control
+        navigationItem = item
+        navigationControl = control
+        updateNavigationControl()
+        return item
+    }
+
+    @objc private func navigateHistory(_ sender: NSSegmentedControl) {
+        switch sender.selectedSegment {
+        case 0:
+            guard let url = backHistory.last else { return }
+            present(url: url, intent: .back)
+        case 1:
+            guard let url = forwardHistory.last else { return }
+            present(url: url, intent: .forward)
+        default:
+            break
+        }
+    }
+
+    private func updateNavigationControl() {
+        let hasHistory = !backHistory.isEmpty || !forwardHistory.isEmpty
+        navigationItem?.isHidden = !hasHistory
+        navigationItem?.isEnabled = hasHistory
+        navigationControl?.isEnabled = hasHistory
+        navigationControl?.setEnabled(!backHistory.isEmpty, forSegment: 0)
+        navigationControl?.setEnabled(!forwardHistory.isEmpty, forSegment: 1)
     }
 
     private func makeSidebarMenuItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -10,6 +10,7 @@ final class MainSplitViewController: NSSplitViewController {
     private static let didSeedKey = "MainSplitView.didSeedInitialState"
 
     var onSelectFile: ((URL) -> Void)?
+    var onOpenMarkdownLink: ((URL) -> Void)?
     var onToggleTaskCheckbox: ((Int, Bool) -> Void)?
 
     override func viewDidLoad() {
@@ -51,6 +52,9 @@ final class MainSplitViewController: NSSplitViewController {
         }
         contentViewController?.taskCheckboxToggled = { [weak self] line, checked in
             self?.onToggleTaskCheckbox?(line, checked)
+        }
+        contentViewController?.localMarkdownLinkActivated = { [weak self] url in
+            self?.onOpenMarkdownLink?(url)
         }
     }
 

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -76,6 +76,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     var heightDidChange: ((CGFloat) -> Void)?
     var zoomDidChange: ((CGFloat) -> Void)?
     var fragmentLinkActivated: ((String) -> Void)?
+    var localMarkdownLinkActivated: ((URL) -> Void)?
     var taskCheckboxToggled: ((Int, Bool) -> Void)?
     private let assetScheme = MarkdownAssetScheme()
     private var currentAssetBase: URL?
@@ -981,7 +982,11 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             } else if url.scheme == MarkdownAssetScheme.scheme,
                let base = currentAssetBase,
                let resolved = MarkdownAssetScheme.resolve(url, against: base) {
-                NSWorkspace.shared.open(resolved)
+                if Self.isMarkdownDocument(resolved) {
+                    localMarkdownLinkActivated?(resolved)
+                } else {
+                    NSWorkspace.shared.open(resolved)
+                }
             } else if url.scheme != MarkdownAssetScheme.scheme {
                 NSWorkspace.shared.open(url)
             }
@@ -989,6 +994,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             return
         }
         decisionHandler(.allow)
+    }
+
+    private static func isMarkdownDocument(_ url: URL) -> Bool {
+        ["md", "markdown", "mdown", "mkdn", "mkd"].contains(url.pathExtension.lowercased())
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/samples/navigation.md
+++ b/samples/navigation.md
@@ -1,0 +1,9 @@
+# Sample Navigation
+
+Use these standard Markdown links to test Back and Forward navigation between existing sample files.
+
+- [Full Markdown sample](full.md)
+- [Code blocks](codeblocks.md)
+- [Long footnotes](long-footnotes.md)
+- [Right-to-left text](rtl-test.md)
+- [TOML frontmatter](toml-frontmatter.md)


### PR DESCRIPTION
## Summary

- keep local Markdown links in the current document window
- maintain per-window Back and Forward history
- show a Finder-style navigational toolbar control only after navigation begins
- add a sample note linking the existing Markdown fixtures

## Why

Local Markdown links were previously handed to `NSWorkspace`, which opened linked notes in another window and left the current window without navigation history. This makes link-heavy Markdown folders cumbersome to browse.

The new path resolves local Markdown documents inside the app, switches the current document through the existing presentation flow, and records history without corrupting it when an unsaved-edit prompt is cancelled.

Closes #89.

## Validation

- `swift test --package-path tests/swift-tests` — 53 tests passed
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-issue89-pr-derived CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
