### PR TITLE
Fix toolbar customization resetting on relaunch

### DIFF
--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -169,6 +169,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
         toolbar.allowsUserCustomization = true
+        toolbar.autosavesConfiguration = true
         documentWindow.toolbar = toolbar
         documentWindow.toolbarStyle = .automatic
 


### PR DESCRIPTION
First off — I really appreciate and love this app, it's become my go-to for reading Markdown on the Mac. Thanks for building it! Hope this small fix helps.

## Summary

Enables `autosavesConfiguration` on the main window toolbar so user customizations (added, removed, or rearranged items) survive an app relaunch.

`NSToolbar` only writes the customized layout to user defaults — and restores it on the next launch — when `autosavesConfiguration` is `true`. The toolbar in `DocumentWindowController.setupWindow()` already allows customization but never opted into autosaving, so every launch fell back to `toolbarDefaultItemIdentifiers(_:)`.

The property is set before the toolbar is attached to the window, so AppKit restores any saved configuration at attach time; the `displayMode` assignment above it remains the fresh-install default and is overridden by the saved configuration when one exists.

Fixes #186

## Test plan

1. Build and launch, open a Markdown file.
2. Right-click the toolbar → Customize Toolbar…, add **Print**, remove **Share**, reorder something, close the palette.
3. Quit and relaunch, open a file → the customized layout is preserved.
4. Delete the app's defaults (`defaults delete doc.md-preview "NSToolbar Configuration MainToolbar"`) and relaunch → default layout returns, confirming fresh installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)