### PR TITLE
Release 0.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.0.34] – 2026-07-13
+
+Markdown Preview now makes linked documents easier to navigate and keeps selections and toolbar customizations consistent across sessions.
+
+### Added
+
+- **Back and forward navigation for Markdown links.** Local Markdown links now open in the same window, with native navigation controls for returning to previously viewed documents ([#184](https://github.com/pluk-inc/markdown-preview/pull/184), [#89](https://github.com/pluk-inc/markdown-preview/issues/89)).
+
+### Fixed
+
+- **Text selection is more reliable and visually consistent.** Full-document selections remain visible while scrolling long files, Shift-selection works correctly in read mode, and edit mode now uses the same macOS blue selection color as the rendered preview ([#185](https://github.com/pluk-inc/markdown-preview/pull/185)).
+- **Toolbar customizations persist after relaunch.** Added, removed, and reordered toolbar items are restored the next time Markdown Preview opens ([#187](https://github.com/pluk-inc/markdown-preview/pull/187), [#186](https://github.com/pluk-inc/markdown-preview/issues/186)).
+
+### Contributors
+
+Thanks to the external contributors and reporters who helped improve this release:
+
+- [@jjoanna2-debug](https://github.com/jjoanna2-debug) — improved selection behavior in long documents and read mode ([#185](https://github.com/pluk-inc/markdown-preview/pull/185))
+- [@Cuzeth](https://github.com/Cuzeth) — fixed and reported toolbar customization persistence ([#187](https://github.com/pluk-inc/markdown-preview/pull/187), [#186](https://github.com/pluk-inc/markdown-preview/issues/186))
+- [@mollydoo](https://github.com/mollydoo) — requested back navigation for linked Markdown documents ([#89](https://github.com/pluk-inc/markdown-preview/issues/89))
+
 ## [0.0.33] – 2026-07-12
 
 Markdown Preview now includes a live Markdown editor, so you can write and preview documents without switching apps.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.33
-CURRENT_PROJECT_VERSION = 37
+MARKETING_VERSION = 0.0.34
+CURRENT_PROJECT_VERSION = 38

--- a/md-preview/EditorViewController.swift
+++ b/md-preview/EditorViewController.swift
@@ -275,6 +275,11 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         }
         #editor .cm-line[dir="rtl"] { text-align: right; }
         #editor .cm-line[dir="ltr"] { text-align: left; }
+        #editor .cm-selectionBackground,
+        #editor .cm-focused .cm-selectionBackground {
+            /* Match WebKit's native selection tint in read-only mode. */
+            background: Highlight !important;
+        }
 
         /* Headings — preview's scale, padding instead of margin so
            CodeMirror's per-line height measurement stays exact.


### PR DESCRIPTION
## Summary

- match edit-mode text selection to the native blue read-mode highlight
- document Markdown navigation history, reliable long-document selection, and persisted toolbar customization
- bump Markdown Preview to 0.0.34 (38) with contributor credits

## Release

This PR prepares the `v0.0.34` release tag. After merge, `./scripts/release.sh` will publish through Amore and create/push the tag only after the release pipeline succeeds.

## Validation

- `swift test --package-path tests/swift-tests` — 54 tests passed
- Debug app build succeeded
- visually verified selection color in read and edit modes
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -showBuildSettings` resolves 0.0.34 (38)
- `git diff --check`