### PR TITLE
Fix printing executor isolation crash

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -451,5 +451,7 @@ final class ContentViewController: NSViewController {
 }
 
 private final class FlippedDocumentView: NSView {
-    override var isFlipped: Bool { true }
+    // AppKit may query view geometry from its background printing thread.
+    // This override is immutable and does not touch main-actor-owned state.
+    nonisolated override var isFlipped: Bool { true }
 }


### PR DESCRIPTION
## Summary

- mark `FlippedDocumentView.isFlipped` as `nonisolated`
- document why AppKit is allowed to query this immutable geometry override outside the main actor

## Root cause

The app target uses Swift 6 with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which caused the `isFlipped` override to enforce main-executor isolation. During WebKit printing, AppKit queries the ancestor view geometry from its background printing thread, triggering a libdispatch assertion in `_checkExpectedExecutor`.

The override always returns a constant and accesses no main-actor-owned state, so making only this getter nonisolated removes the invalid executor assertion without weakening isolation for the surrounding UI code.

Fixes Sentry issue `MARKDOWN-PREVIEW-2` (`7607619807`).

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-print-crash-fix CODE_SIGNING_ALLOWED=NO build`
- `swift test --package-path tests/swift-tests` (54 tests passed)
- launched the Debug app with Computer Use, opened a Markdown document, invoked Print with Command-P, confirmed the macOS print sheet rendered `Page 1 of 1`, then cancelled cleanly
- `git diff --check`
