### PR TITLE
Fix default sidebar toolbar spacing

### DIFF
--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -409,6 +409,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
+            .flexibleSpace,
             .sidebarMenu,
             .sidebarTrackingSeparator,
             .navigation,


### PR DESCRIPTION
## Summary

- add flexible space before the default Sidebar toolbar menu
- align the Sidebar control with the trailing edge of the sidebar
- preserve the native sidebar tracking separator and user-customized layouts

## Root cause

The Sidebar menu was the first item in the default toolbar layout, so AppKit anchored it beside the window controls instead of at the sidebar divider.

## Testing

- `swift test --package-path tests/swift-tests` (54 tests passed)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-toolbar-flex-4981 CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
