### PR TITLE
Release 0.0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.0.35] – 2026-07-14
+
+Markdown Preview now lets you edit Markdown tables directly in the rendered document, with native controls for managing rows and columns.
+
+### Added
+
+- **Direct table editing.** Edit cells in place, drag to select rectangular ranges, and use native context-menu actions to insert, duplicate, select, or delete rows and columns, with undo support ([#191](https://github.com/pluk-inc/markdown-preview/pull/191)).
+
+### Fixed
+
+- **Printing no longer crashes.** The macOS print sheet now opens reliably without triggering a Swift concurrency executor failure ([#189](https://github.com/pluk-inc/markdown-preview/pull/189)).
+- **The default Sidebar control is aligned with the sidebar edge.** New toolbar layouts place the native Sidebar menu beside the sidebar divider while preserving customized toolbars ([#190](https://github.com/pluk-inc/markdown-preview/pull/190)).
+
 ## [0.0.34] – 2026-07-13
 
 Markdown Preview now makes linked documents easier to navigate and keeps selections and toolbar customizations consistent across sessions.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.34
-CURRENT_PROJECT_VERSION = 38
+MARKETING_VERSION = 0.0.35
+CURRENT_PROJECT_VERSION = 39


### PR DESCRIPTION
## Summary

- bump Markdown Preview to 0.0.35 build 39
- add user-facing release notes for direct table editing
- document the printing crash and default Sidebar toolbar placement fixes

## Impact

This prepares the next Amore release with the version and changelog metadata required by `scripts/release.sh`.

## Validation

- `git diff --check -- CHANGELOG.md Version.xcconfig`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -showBuildSettings` resolves `MARKETING_VERSION = 0.0.35` and `CURRENT_PROJECT_VERSION = 39`
- confirmed the `0.0.35` changelog entry is present for 2026-07-14