### PR TITLE
Add full-width toggle for Mermaid diagrams

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1886,6 +1886,7 @@ nonisolated enum MarkdownHTML {
             <button type="button" class="mermaid-hud-btn" data-mm-act="out" tabindex="-1" aria-label="Zoom out">−</button>
             <button type="button" class="mermaid-hud-btn mermaid-hud-level" data-mm-act="reset" tabindex="-1" aria-label="Reset zoom">100%</button>
             <button type="button" class="mermaid-hud-btn" data-mm-act="in" tabindex="-1" aria-label="Zoom in">+</button>
+            <button type="button" class="mermaid-hud-btn mermaid-hud-width" data-mm-act="width" tabindex="-1" aria-label="Fill width" aria-pressed="false" title="Fill width">⤢</button>
             </div>
             </figure>
             """
@@ -2045,6 +2046,23 @@ nonisolated enum MarkdownHTML {
                 apply(figure, s);
             }
 
+            function toggleWidth(figure) {
+                const expanded = figure.classList.toggle('mermaid-width-expanded');
+                const btn = figure.querySelector('[data-mm-act="width"]');
+                if (btn) {
+                    const label = expanded ? 'Fit diagram' : 'Fill width';
+                    btn.textContent = expanded ? '⤡' : '⤢';
+                    btn.setAttribute('aria-label', label);
+                    btn.setAttribute('aria-pressed', String(expanded));
+                    btn.setAttribute('title', label);
+                }
+                reset(figure);
+                requestAnimationFrame(() => {
+                    cacheRect(figure);
+                    window.dispatchEvent(new Event('md-preview-mermaid-rendered'));
+                });
+            }
+
             function step(figure, factor) {
                 const s = states.get(figure);
                 if (!s) return;
@@ -2128,6 +2146,7 @@ nonisolated enum MarkdownHTML {
                     case 'in':    step(figure, 1.25); break;
                     case 'out':   step(figure, 0.8);  break;
                     case 'reset': reset(figure);      break;
+                    case 'width': toggleWidth(figure); break;
                 }
             }
 
@@ -2471,7 +2490,7 @@ nonisolated enum MarkdownHTML {
     }
     .mermaid-figure {
         position: relative;
-        margin: 1.6em 0 0;
+        margin: 1.6em auto 0;
         background: var(--code-bg);
         border-radius: 15px;
         overflow: hidden;
@@ -2479,6 +2498,10 @@ nonisolated enum MarkdownHTML {
         aspect-ratio: var(--mm-aspect, 4 / 3);
         max-height: min(70vh, 720px);
         contain: layout paint;
+    }
+    .mermaid-figure.mermaid-width-expanded {
+        width: 100%;
+        max-height: none;
     }
     .mermaid-figure:focus-visible {
         box-shadow: 0 0 0 3px color-mix(in srgb, AccentColor 60%, transparent);
@@ -2503,6 +2526,7 @@ nonisolated enum MarkdownHTML {
     .mermaid svg {
         display: block;
         width: 100%;
+        max-width: none !important;
         height: 100%;
     }
     .mermaid-hud {
@@ -2552,6 +2576,10 @@ nonisolated enum MarkdownHTML {
     .mermaid-hud-level {
         min-width: 46px;
         font-variant-numeric: tabular-nums;
+    }
+    .mermaid-hud-width {
+        margin-left: 2px;
+        font-size: 14px;
     }
     @media (prefers-reduced-motion: reduce) {
         .mermaid-hud { transition: none; }

--- a/scripts/check-mermaid-html.py
+++ b/scripts/check-mermaid-html.py
@@ -15,6 +15,11 @@ checks = {
         and "svg.setAttribute('preserveAspectRatio', 'xMidYMid meet')" in source
         and "s.surface.style.transform" in source
     ),
+    "toggles full-width diagrams": (
+        'data-mm-act="width"' in source
+        and "classList.toggle('mermaid-width-expanded')" in source
+        and ".mermaid-figure.mermaid-width-expanded" in source
+    ),
 }
 failed = [name for name, ok in checks.items() if not ok]
 if failed:

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -131,6 +131,115 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(rendered.articleHTML.contains("<code class=\"language-mermaid\""))
     }
 
+    @MainActor
+    func testMermaidWidthToggleExpandsAndRestoresDiagram() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```mermaid
+            flowchart LR
+                A --> B
+            ```
+            """,
+            vendorLoading: .lazy
+        )
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"data-mm-act="width" tabindex="-1" aria-label="Fill width" aria-pressed="false""#
+        ))
+
+        let stylesheet = try XCTUnwrap(
+            rendered.html
+                .components(separatedBy: "<style>")
+                .dropFirst()
+                .first?
+                .components(separatedBy: "</style>")
+                .first
+        )
+        let html = """
+        <!DOCTYPE html>
+        <html><head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>\(stylesheet)</style>
+        </head><body><article class="markdown-body">\(rendered.articleHTML)</article>
+        <script>
+        const figure = document.querySelector('.mermaid-figure');
+        figure.style.setProperty('--mm-aspect', '1 / 4');
+        figure.querySelector('.mermaid').innerHTML = '<svg viewBox="0 0 200 800"></svg>';
+        document.querySelector('.mermaid-hud').addEventListener('click', (event) => {
+            const button = event.target.closest('[data-mm-act="width"]');
+            if (!button) return;
+            const figure = button.closest('.mermaid-figure');
+            const expanded = figure.classList.toggle('mermaid-width-expanded');
+            button.setAttribute('aria-pressed', String(expanded));
+        });
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let metricsScript = """
+        (() => {
+            const host = document.querySelector('.mermaid');
+            const figure = document.querySelector('.mermaid-figure');
+            const article = document.querySelector('.markdown-body');
+            const svg = host.querySelector('svg');
+            const button = figure.querySelector('[data-mm-act="width"]');
+            const style = getComputedStyle(host);
+            return JSON.stringify({
+                articleWidth: article.clientWidth,
+                articleLeft: article.getBoundingClientRect().left,
+                figureWidth: figure.getBoundingClientRect().width,
+                figureLeft: figure.getBoundingClientRect().left,
+                availableWidth: host.clientWidth
+                    - parseFloat(style.paddingLeft)
+                    - parseFloat(style.paddingRight),
+                svgWidth: svg.getBoundingClientRect().width,
+                expanded: figure.classList.contains('mermaid-width-expanded'),
+                buttonPressed: button?.getAttribute('aria-pressed') || '',
+            });
+        })()
+        """
+        let initialResult = try await webView.evaluateJavaScript(metricsScript)
+        let initialJSON = try XCTUnwrap(initialResult as? String)
+        let initial = try JSONDecoder().decode(MermaidLayoutMetrics.self, from: Data(initialJSON.utf8))
+
+        XCTAssertFalse(initial.expanded)
+        XCTAssertEqual(initial.buttonPressed, "false")
+        XCTAssertLessThan(initial.figureWidth, initial.articleWidth)
+        XCTAssertEqual(
+            initial.figureLeft - initial.articleLeft,
+            (initial.articleWidth - initial.figureWidth) / 2,
+            accuracy: 1
+        )
+
+        try await webView.evaluateJavaScript(
+            "document.querySelector('[data-mm-act=\"width\"]').click()"
+        )
+        let expandedResult = try await webView.evaluateJavaScript(metricsScript)
+        let expandedJSON = try XCTUnwrap(expandedResult as? String)
+        let expanded = try JSONDecoder().decode(MermaidLayoutMetrics.self, from: Data(expandedJSON.utf8))
+
+        XCTAssertTrue(expanded.expanded)
+        XCTAssertEqual(expanded.buttonPressed, "true")
+        XCTAssertEqual(expanded.figureWidth, expanded.articleWidth, accuracy: 1)
+        XCTAssertEqual(expanded.svgWidth, expanded.availableWidth, accuracy: 1)
+
+        try await webView.evaluateJavaScript(
+            "document.querySelector('[data-mm-act=\"width\"]').click()"
+        )
+        let restoredResult = try await webView.evaluateJavaScript(metricsScript)
+        let restoredJSON = try XCTUnwrap(restoredResult as? String)
+        let restored = try JSONDecoder().decode(MermaidLayoutMetrics.self, from: Data(restoredJSON.utf8))
+
+        XCTAssertFalse(restored.expanded)
+        XCTAssertEqual(restored.buttonPressed, "false")
+        XCTAssertEqual(restored.figureWidth, initial.figureWidth, accuracy: 1)
+    }
+
     func testCodeBlockLayoutMatchesDeferredHighlightingFromFirstPaint() throws {
         let rendered = MarkdownHTML.render(
             markdown: """
@@ -362,4 +471,15 @@ private struct HeadingLayoutMetrics: Decodable {
     let codeRight: CGFloat
     let viewportRight: CGFloat
     let boxDecorationBreak: String
+}
+
+private struct MermaidLayoutMetrics: Decodable {
+    let articleWidth: CGFloat
+    let articleLeft: CGFloat
+    let figureWidth: CGFloat
+    let figureLeft: CGFloat
+    let availableWidth: CGFloat
+    let svgWidth: CGFloat
+    let expanded: Bool
+    let buttonPressed: String
 }


### PR DESCRIPTION
## Summary

- keep tall Mermaid diagrams compact and centered by default
- add a one-click control alongside the zoom HUD to fill the article width and restore the fitted layout
- reset pan and zoom when switching modes and notify the host about the layout change
- cover the toggle markup and layout states with WebKit and static smoke checks

## Testing

- swift test --package-path tests/swift-tests
- python3 scripts/check-mermaid-html.py
- manually verified both expand and restore states in the Debug app with a tall sequence diagram