### PR TITLE
Switch to official homebrew/cask install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   A fast, native macOS app for reading Markdown files.
 </p>
 
-<p align="center"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" />&nbsp;<img alt="Swift" src="https://img.shields.io/badge/swift-6.0-orange" />&nbsp;<img alt="License" src="https://img.shields.io/badge/license-MIT-green" />&nbsp;<img alt="Latest release" src="https://img.shields.io/github/v/release/pluk-inc/markdown-preview" /></p>
+<p align="center"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" />&nbsp;<img alt="Swift" src="https://img.shields.io/badge/swift-6.0-orange" />&nbsp;<img alt="License" src="https://img.shields.io/badge/license-MIT-green" />&nbsp;<img alt="Latest release" src="https://img.shields.io/github/v/release/pluk-inc/markdown-preview" />&nbsp;<img alt="Homebrew cask" src="https://img.shields.io/homebrew/cask/v/markdown-preview" /></p>
 
 ---
 
@@ -16,8 +16,10 @@
 
 ## Installation
 
+Markdown Preview is available in the official [Homebrew cask repository](https://formulae.brew.sh/cask/markdown-preview):
+
 ```sh
-brew install --cask pluk-inc/tap/markdown-preview
+brew install --cask markdown-preview
 ```
 
 Or grab the latest signed and notarized DMG from the [Releases](https://github.com/pluk-inc/markdown-preview/releases) page.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,9 +14,8 @@
 #   - Version.xcconfig  → MARKETING_VERSION, CURRENT_PROJECT_VERSION
 #   - CHANGELOG.md      → release notes (## [X.Y.Z] – YYYY-MM-DD)
 #
-# After amore publishes, this also bumps the Homebrew tap at
-# pluk-inc/homebrew-tap (Casks/markdown-preview.rb) so `brew upgrade
-# --cask` users converge on the new version. Skipped on --beta / --draft.
+# The official homebrew/cask cask (markdown-preview) is autobumped by
+# Homebrew from the GitHub release — no manual cask update needed.
 
 set -euo pipefail
 
@@ -170,50 +169,15 @@ if [[ -z "$DMG_URL" ]]; then
 fi
 echo "▸ DMG: $DMG_URL"
 
-# ── Download DMG (used by cask bump + GH release) ──────────────────────────
-SHOULD_BUMP_CASK=true
-[[ -n "$BETA_FLAG$DRAFT_FLAG" ]] && SHOULD_BUMP_CASK=false
-
-DMG_PATH=""
-if $SHOULD_BUMP_CASK || ! $SKIP_GH; then
-    DMG_PATH="$(mktemp -d)/Markdown-Preview.dmg"
-    echo "▸ Downloading DMG"
-    curl -fsSL -o "$DMG_PATH" "$DMG_URL"
-fi
-
-# ── Bump pluk-inc/homebrew-tap ─────────────────────────────────────────────
-if $SHOULD_BUMP_CASK; then
-    echo "▸ Bumping pluk-inc/homebrew-tap"
-    DMG_SHA="$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
-    TAP_DIR="$(mktemp -d)/homebrew-tap"
-    if git clone --depth=1 --quiet git@github.com:pluk-inc/homebrew-tap.git "$TAP_DIR"; then
-        CASK_FILE="$TAP_DIR/Casks/markdown-preview.rb"
-        /usr/bin/sed -i '' -E "s|^  version \".*\"|  version \"$VERSION,$BUILD\"|" "$CASK_FILE"
-        /usr/bin/sed -i '' -E "s|^  sha256 \".*\"|  sha256 \"$DMG_SHA\"|"          "$CASK_FILE"
-        if ! grep -q "version \"$VERSION,$BUILD\"" "$CASK_FILE" || \
-           ! grep -q "sha256 \"$DMG_SHA\""        "$CASK_FILE"; then
-            echo "  ✗ cask sed didn't take — fix Casks/markdown-preview.rb manually"
-        elif (cd "$TAP_DIR" && git diff --quiet); then
-            echo "  ⚠ cask already at $VERSION,$BUILD — nothing to push"
-        else
-            (cd "$TAP_DIR" && \
-                git -c user.name="$(git config user.name)" \
-                    -c user.email="$(git config user.email)" \
-                    commit -am "markdown-preview $VERSION,$BUILD" >/dev/null && \
-                git push --quiet origin HEAD) \
-                && echo "  ✓ pushed cask bump" \
-                || echo "  ✗ push failed — fix manually in pluk-inc/homebrew-tap"
-        fi
-    else
-        echo "  ⚠ failed to clone homebrew-tap — skipping cask bump"
-    fi
-    rm -rf "$(dirname "$TAP_DIR")"
-fi
-
 if $SKIP_GH; then
     echo "✓ Released $VERSION ($BUILD). GitHub step skipped."
     exit 0
 fi
+
+# ── Download DMG (GH release asset) ────────────────────────────────────────
+DMG_PATH="$(mktemp -d)/Markdown-Preview.dmg"
+echo "▸ Downloading DMG"
+curl -fsSL -o "$DMG_PATH" "$DMG_URL"
 
 # ── GitHub release ─────────────────────────────────────────────────────────
 TAG="v$VERSION"


### PR DESCRIPTION
## Summary
- `markdown-preview` was accepted into the official [homebrew/cask](https://formulae.brew.sh/cask/markdown-preview) repository, with `autobump` enabled — Homebrew now picks up new versions automatically from GitHub releases.
- README: install command is now `brew install --cask markdown-preview` (no tap prefix), plus a Homebrew cask version badge.
- `scripts/release.sh`: removed the `pluk-inc/homebrew-tap` cask-bump step; the DMG download now happens only for the GitHub release asset.

## Test plan
- `bash -n scripts/release.sh` passes.
- Verified via the Homebrew API that the official cask has `autobump: true` and `auto_updates: true`.
- Companion PR deprecates the cask in pluk-inc/homebrew-tap.