### PR TITLE
Fix stopped URL scheme task crash

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 				MarkdownFrontmatter.swift,
 				MarkdownHTML.swift,
 				MarkdownWebView.swift,
+				URLSchemeTaskCallbackGate.swift,
 			);
 			target = 9A02092C2FA10D4C00092060 /* quick-look */;
 		};

--- a/md-preview/MarkdownAssetSchemeHandler.swift
+++ b/md-preview/MarkdownAssetSchemeHandler.swift
@@ -32,6 +32,7 @@ nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
 
     private let queue = DispatchQueue(label: "doc.md-preview.asset-scheme", qos: .userInitiated)
     private let lock = NSLock()
+    private let tasks = TaskRegistry()
     private var _baseURL: URL?
 
     func setBaseURL(_ url: URL?) {
@@ -97,10 +98,13 @@ nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
         let request = urlSchemeTask.request
         let base = currentBaseURL()
         let wrapper = TaskWrapper(task: urlSchemeTask)
+        let taskRegistry = tasks
+        taskRegistry.insert(wrapper)
 
         queue.async {
+            defer { taskRegistry.remove(wrapper) }
             guard let requestURL = request.url else {
-                wrapper.task.didFailWithError(URLError(.badURL))
+                wrapper.fail(with: URLError(.badURL))
                 return
             }
 
@@ -108,29 +112,29 @@ nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
             // on the user-file base URL — they must load even before/without
             // sandbox access to the user's folder.
             if let vendorURL = Self.resolveVendor(requestURL) {
-                Self.serve(file: vendorURL, requestURL: requestURL, task: wrapper.task, cacheable: true)
+                Self.serve(file: vendorURL, requestURL: requestURL, task: wrapper, cacheable: true)
                 return
             }
 
             guard let base,
                   let resolved = Self.resolve(requestURL, against: base) else {
-                wrapper.task.didFailWithError(URLError(.badURL))
+                wrapper.fail(with: URLError(.badURL))
                 return
             }
-            Self.serve(file: resolved, requestURL: requestURL, task: wrapper.task, cacheable: false)
+            Self.serve(file: resolved, requestURL: requestURL, task: wrapper, cacheable: false)
         }
     }
 
     private nonisolated static func serve(file resolved: URL,
                                           requestURL: URL,
-                                          task: any WKURLSchemeTask,
+                                          task: TaskWrapper,
                                           cacheable: Bool) {
         let data: Data
         if cacheable, let cached = vendorDataCache.data(for: resolved) {
             data = cached
         } else {
             guard let read = try? Data(contentsOf: resolved) else {
-                task.didFailWithError(URLError(.fileDoesNotExist))
+                task.fail(with: URLError(.fileDoesNotExist))
                 return
             }
             if cacheable {
@@ -152,19 +156,74 @@ nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
                          mimeType: mime,
                          expectedContentLength: data.count,
                          textEncodingName: nil)
-        task.didReceive(response)
-        task.didReceive(data)
-        task.didFinish()
+        task.receive(response)
+        task.receive(data)
+        task.finish()
     }
 
-    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {}
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+        tasks.stop(urlSchemeTask)
+    }
 
     // `WKURLSchemeTask` is an Objective-C protocol without useful Sendable
     // annotations. The handler immediately moves work onto its private serial
     // queue and reports results for the same task from there, which matches
     // WKURLSchemeHandler's callback-style contract.
-    private struct TaskWrapper: @unchecked Sendable {
+    private final class TaskWrapper: @unchecked Sendable {
         let task: any WKURLSchemeTask
+        private let gate = URLSchemeTaskCallbackGate()
+
+        init(task: any WKURLSchemeTask) {
+            self.task = task
+        }
+
+        var identifier: ObjectIdentifier {
+            ObjectIdentifier(task as AnyObject)
+        }
+
+        func receive(_ response: URLResponse) {
+            gate.performIfActive { task.didReceive(response) }
+        }
+
+        func receive(_ data: Data) {
+            gate.performIfActive { task.didReceive(data) }
+        }
+
+        func finish() {
+            gate.performIfActive { task.didFinish() }
+        }
+
+        func fail(with error: Error) {
+            gate.performIfActive { task.didFailWithError(error) }
+        }
+
+        func stop() {
+            gate.stop()
+        }
+    }
+
+    private final class TaskRegistry: @unchecked Sendable {
+        private let lock = NSLock()
+        private var tasks: [ObjectIdentifier: TaskWrapper] = [:]
+
+        func insert(_ task: TaskWrapper) {
+            lock.lock()
+            tasks[task.identifier] = task
+            lock.unlock()
+        }
+
+        func remove(_ task: TaskWrapper) {
+            lock.lock()
+            tasks.removeValue(forKey: task.identifier)
+            lock.unlock()
+        }
+
+        func stop(_ task: any WKURLSchemeTask) {
+            lock.lock()
+            let wrapper = tasks[ObjectIdentifier(task as AnyObject)]
+            lock.unlock()
+            wrapper?.stop()
+        }
     }
 
     // `NSCache` is internally synchronized but is not annotated Sendable by

--- a/md-preview/URLSchemeTaskCallbackGate.swift
+++ b/md-preview/URLSchemeTaskCallbackGate.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Serializes cancellation with callbacks for a `WKURLSchemeTask`.
+///
+/// WebKit raises an Objective-C exception if a scheme handler sends any
+/// callback after `stop(_:)` returns. Holding the recursive lock while a
+/// callback runs gives `stop()` a precise boundary: it either cancels before
+/// the callback starts, or waits for that callback and prevents the next one.
+nonisolated final class URLSchemeTaskCallbackGate: @unchecked Sendable {
+    private let lock = NSRecursiveLock()
+    private var isStopped = false
+
+    func performIfActive(_ callback: () -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isStopped else { return }
+        callback()
+    }
+
+    func stop() {
+        lock.lock()
+        isStopped = true
+        lock.unlock()
+    }
+}

--- a/tests/swift-tests/Sources/MarkdownHelpers/URLSchemeTaskCallbackGate.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/URLSchemeTaskCallbackGate.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/URLSchemeTaskCallbackGate.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/URLSchemeTaskCallbackGateTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/URLSchemeTaskCallbackGateTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import MarkdownHelpers
+
+final class URLSchemeTaskCallbackGateTests: XCTestCase {
+    func testStopPreventsLaterCallbacks() {
+        let gate = URLSchemeTaskCallbackGate()
+        gate.stop()
+
+        var callbackRan = false
+        gate.performIfActive { callbackRan = true }
+
+        XCTAssertFalse(callbackRan)
+    }
+
+    func testStopWaitsForCurrentCallbackAndPreventsNextCallback() {
+        let gate = URLSchemeTaskCallbackGate()
+        let callbackStarted = DispatchSemaphore(value: 0)
+        let allowCallbackToFinish = DispatchSemaphore(value: 0)
+        let stopStarted = DispatchSemaphore(value: 0)
+        let stopReturned = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global().async {
+            gate.performIfActive {
+                callbackStarted.signal()
+                allowCallbackToFinish.wait()
+            }
+        }
+
+        XCTAssertEqual(callbackStarted.wait(timeout: .now() + 1), .success)
+        DispatchQueue.global().async {
+            stopStarted.signal()
+            gate.stop()
+            stopReturned.signal()
+        }
+
+        XCTAssertEqual(stopStarted.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(stopReturned.wait(timeout: .now() + 0.05), .timedOut)
+        allowCallbackToFinish.signal()
+        XCTAssertEqual(stopReturned.wait(timeout: .now() + 1), .success)
+
+        var laterCallbackRan = false
+        gate.performIfActive { laterCallbackRan = true }
+        XCTAssertFalse(laterCallbackRan)
+    }
+
+    func testCallbackCanStopReentrantly() {
+        let gate = URLSchemeTaskCallbackGate()
+        var callbackCount = 0
+
+        gate.performIfActive {
+            callbackCount += 1
+            gate.stop()
+        }
+        gate.performIfActive { callbackCount += 1 }
+
+        XCTAssertEqual(callbackCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary

- track active `WKURLSchemeTask` instances and honor WebKit cancellation
- serialize `stop` with response callbacks so no callback runs after a task has stopped
- add deterministic concurrency coverage for cancellation during an in-flight callback

## Root cause

[Sentry MARKDOWN-PREVIEW-3](https://pluk-inc.sentry.io/issues/7615888163/) showed `NSInternalInconsistencyException: This task has already been stopped` in `MarkdownAssetScheme.serve`. Asset data is loaded asynchronously, while WebKit can stop the scheme task before that work completes. The handler previously ignored `stop` and still called `didReceive`/`didFinish`, which WebKit treats as an internal inconsistency.

## Impact

Closing or replacing a Markdown preview while local or bundled assets are loading no longer crashes the app.

## Validation

- `swift test --package-path tests/swift-tests` — 63 tests passed
- isolated `xcodebuild` Debug build with code signing disabled — succeeded
- exact built app completed three asset-heavy open/close stress runs without crashing
- `git diff --check`
