### PR TITLE
Fix editor layout recursion crash

### DIFF
--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -245,7 +245,6 @@ final class MainSplitViewController: NSSplitViewController {
                                      sourceAnchor: pendingSourceScrollAnchor) { [weak self, weak editorVC] in
             DispatchQueue.main.async {
                 guard let self, let editorVC, self.isEditorPreparing else { return }
-                editorVC.view.superview?.layoutSubtreeIfNeeded()
                 NSAnimationContext.runAnimationGroup { context in
                     context.duration = 0.10
                     context.timingFunction = CAMediaTimingFunction(name: .easeOut)


### PR DESCRIPTION
## Summary

- remove the forced nested AppKit layout pass before revealing the editor
- keep the existing next-run-loop reveal and fade transition

## Root cause

Sentry issue [MARKDOWN-PREVIEW-4](https://pluk-inc.sentry.io/issues/7616484454/) shows repeated `_NSViewLayout` frames ending in `+[NSApplication _crashOnException:]`. The editor reveal path explicitly called `layoutSubtreeIfNeeded()`, which can recurse when AppKit is already processing a layout cycle.

## Validation

- `swift test --package-path tests/swift-tests` (60 tests passed)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-layout-recursion-fix CODE_SIGNING_ALLOWED=NO build`
- launched the exact DerivedData binary and completed four preview/edit round trips without a crash or layout-recursion output
