### PR TITLE
Bundle CLI tool for Homebrew cask linking

### DIFF
--- a/Resources/bin/markdown-preview
+++ b/Resources/bin/markdown-preview
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Managed by Markdown Preview CLI
+if [ "$#" -eq 0 ]; then
+  exec open -b "doc.md-preview" .
+else
+  exec open -b "doc.md-preview" "$@"
+fi

--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9A7B10012FB0000100010001 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 9A7B10032FB0000100010001 /* Sentry */; };
 		9A33940A2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3394092FA5AF500015D9A4 /* Markdown */; };
 		9A33940C2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A33940B2FA5AF500015D9A4 /* Markdown */; };
+		9AC100010000000000000001 /* markdown-preview in Copy CLI Tool */ = {isa = PBXBuildFile; fileRef = 9AC100010000000000000002 /* markdown-preview */; };
 		9AF000000000000000000003 /* mermaid.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 9AF000000000000000000101 /* mermaid.min.js */; };
 		9AF000000000000000000004 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 9AF000000000000000000102 /* LICENSE */; };
 		9AF000000000000000000005 /* katex.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 9AF000000000000000000103 /* katex.min.js */; };
@@ -37,6 +38,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		9AC100010000000000000003 /* Copy CLI Tool */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = bin;
+			dstSubfolderSpec = 7;
+			files = (
+				9AC100010000000000000001 /* markdown-preview in Copy CLI Tool */,
+			);
+			name = "Copy CLI Tool";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9A02093D2FA10D4C00092060 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -55,6 +67,7 @@
 		9A02092D2FA10D4C00092060 /* quick-look.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "quick-look.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A02092F2FA10D4C00092060 /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
 		9A0209A02FA1100100092060 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		9AC100010000000000000002 /* markdown-preview */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "bin/markdown-preview"; sourceTree = "<group>"; };
 		9AF000000000000000000101 /* mermaid.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = mermaid.min.js; path = "md-preview/Vendor/Mermaid/mermaid.min.js"; sourceTree = "<group>"; };
 		9AF000000000000000000102 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = "md-preview/Vendor/Mermaid/LICENSE"; sourceTree = "<group>"; };
 		9AF000000000000000000103 /* katex.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = katex.min.js; path = "md-preview/Vendor/KaTeX/katex.min.js"; sourceTree = "<group>"; };
@@ -137,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				9A0209A02FA1100100092060 /* Version.xcconfig */,
+				9AC100010000000000000004 /* Resources */,
 				9AF000000000000000000101 /* mermaid.min.js */,
 				9AF000000000000000000102 /* LICENSE */,
 				9AF000000000000000000103 /* katex.min.js */,
@@ -164,6 +178,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		9AC100010000000000000004 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				9AC100010000000000000002 /* markdown-preview */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		9A02092E2FA10D4C00092060 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -182,6 +204,7 @@
 				9A0207BD2FA0ED7C00092060 /* Sources */,
 				9A0207BE2FA0ED7C00092060 /* Frameworks */,
 				9A0207BF2FA0ED7C00092060 /* Resources */,
+				9AC100010000000000000003 /* Copy CLI Tool */,
 				9A02093D2FA10D4C00092060 /* Embed Foundation Extensions */,
 				9A7B10042FB0000100010001 /* Upload dSYMs to Sentry */,
 			);

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -10,6 +10,7 @@ import UniformTypeIdentifiers
 private enum CommandLineToolInstallError: LocalizedError {
     case terminalAutomationFailed(String?)
     case installerScriptWriteFailed(String)
+    case bundledToolMissing
 
     var errorDescription: String? {
         switch self {
@@ -20,6 +21,8 @@ private enum CommandLineToolInstallError: LocalizedError {
             return "Terminal automation failed."
         case .installerScriptWriteFailed(let message):
             return "Failed to write CLI installer script: \(message)"
+        case .bundledToolMissing:
+            return "The bundled Markdown Preview CLI could not be found."
         }
     }
 }
@@ -199,7 +202,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func installCommandLineTools(_ sender: Any?) {
         do {
-            let installerScriptURL = try writeCommandLineToolInstallerScript()
+            let commandLineToolURL = try bundledCommandLineToolURL()
+            let installerScriptURL = try writeCommandLineToolInstallerScript(
+                commandLineToolURL: commandLineToolURL
+            )
             let installCommand = makeCommandLineToolInstallCommand(scriptURL: installerScriptURL)
             try runInstallCommandInTerminal(installCommand)
         } catch {
@@ -354,22 +360,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return panel
     }
 
-    private func makeCommandLineToolInstallerScript() -> String {
-        let launcherScript = """
-        #!/bin/sh
-        # Managed by Markdown Preview CLI
-        if [ "$#" -eq 0 ]; then
-          exec open -b "doc.md-preview" .
-        else
-          exec open -b "doc.md-preview" "$@"
-        fi
+    private func makeCommandLineToolInstallerScript(commandLineToolURL: URL) -> String {
         """
-
-        let installerScript = """
         #!/bin/sh
         set -eu
         installer_path=$0
         trap 'rm -f "$installer_path"' EXIT
+        bundled_cli=\(commandLineToolURL.path.shellQuotedString)
 
         path_contains() {
           case ":$PATH:" in
@@ -487,22 +484,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
           can_replace_alias "$install_dir/$alias" || refuse_existing_command "$install_dir/$alias"
         done
 
-        tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/md-preview-cli.XXXXXX")
-        trap 'rm -rf "$tmp_dir"; rm -f "$installer_path"' EXIT
-
-        cat > "$tmp_dir/md-preview" <<'MD_PREVIEW_CLI'
-        \(launcherScript)
-        MD_PREVIEW_CLI
-
-        chmod 755 "$tmp_dir/md-preview"
-
         if [ "$needs_sudo" = "true" ]; then
           echo "Installing Markdown Preview command line tools to $install_dir requires your password."
           sudo mkdir -p "$install_dir"
-          sudo install -m 755 "$tmp_dir/md-preview" "$primary"
+          sudo install -m 755 "$bundled_cli" "$primary"
         else
           mkdir -p "$install_dir"
-          install -m 755 "$tmp_dir/md-preview" "$primary"
+          install -m 755 "$bundled_cli" "$primary"
         fi
 
         for alias in mdp markdown-preview; do
@@ -539,18 +527,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
           echo "Open a new terminal window, then try: mdp ."
         fi
         """
-
-        return installerScript
     }
 
-    private func writeCommandLineToolInstallerScript() throws -> URL {
+    private func bundledCommandLineToolURL() throws -> URL {
+        guard let url = Bundle.main.url(forResource: "markdown-preview",
+                                        withExtension: nil,
+                                        subdirectory: "bin") else {
+            throw CommandLineToolInstallError.bundledToolMissing
+        }
+        return url
+    }
+
+    private func writeCommandLineToolInstallerScript(commandLineToolURL: URL) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("install-markdown-preview-cli-\(UUID().uuidString).sh")
 
         do {
-            try makeCommandLineToolInstallerScript().write(to: url,
-                                                           atomically: true,
-                                                           encoding: .utf8)
+            try makeCommandLineToolInstallerScript(commandLineToolURL: commandLineToolURL)
+                .write(to: url, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o700],
                                                   ofItemAtPath: url.path)
             return url


### PR DESCRIPTION
## Summary

- bundle the existing launcher at `Markdown Preview.app/Contents/Resources/bin/markdown-preview`
- make the in-app installer install that canonical bundled launcher instead of generating a duplicate
- provide the stable executable path required for Homebrew to expose `mdp`, `md-preview`, and `markdown-preview` after the next app release

This prepares the app bundle for the cask change requested in #200 while preserving the existing app-menu installer for DMG users. Issue #200 should remain open until the release is published and the cask gains the binary stanzas plus the legacy-launcher migration.

Refs #200

## Validation

- Debug build: `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-issue-200 CODE_SIGNING_ALLOWED=NO build`
- Release build with production bundle identifier `doc.md-preview`
- verified the built launcher exists at the cask path, is executable (`755`), passes `/bin/sh -n`, and matches the source byte-for-byte
- exercised Homebrew-style `mdp`, `md-preview`, and `markdown-preview` symlinks against a file, folder, and current directory
- UI inspection confirmed the CLI-delivered `README.md` and `samples` folder opened successfully
- `swift test --package-path tests/swift-tests` (60 tests)
- CodeQL and Swift Tests GitHub checks passed