### PR TITLE
Fix Retina rendering in long documents

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -10,13 +10,9 @@ final class ContentViewController: NSViewController {
     private static let pageZoomDefaultsKey = "MarkdownPreview.pageZoom"
 
     private var webView: MarkdownWebView!
-    private var documentHeightConstraint: NSLayoutConstraint!
-    private var webViewHeightConstraint: NSLayoutConstraint!
     private var webViewPageWidthConstraint: NSLayoutConstraint?
     private var webViewCenteredConstraints: [NSLayoutConstraint] = []
     private var webViewFullWidthConstraints: [NSLayoutConstraint] = []
-    private var measuredDocumentHeight: CGFloat = 1
-    private var lastLaidOutSize: NSSize = .zero
     private var pendingFlashWork: DispatchWorkItem?
     private var pendingPreviewScrollAnchor: SourceScrollAnchor?
     private var shouldApplyPendingAnchorOnHeight = false
@@ -52,25 +48,16 @@ final class ContentViewController: NSViewController {
     var localMarkdownLinkActivated: ((URL) -> Void)?
 
     override func loadView() {
-        let scrollView = NSScrollView()
-        scrollView.drawsBackground = false
-        scrollView.hasVerticalScroller = true
-        scrollView.autohidesScrollers = true
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-
-        let documentView = FlippedDocumentView()
-        documentView.translatesAutoresizingMaskIntoConstraints = false
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        view = container
 
         webView = MarkdownWebView()
         webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.heightDidChange = { [weak self] height in
+        webView.heightDidChange = { [weak self] _ in
             guard let self else { return }
-            if abs(height - self.measuredDocumentHeight) > 0.5 {
-                self.measuredDocumentHeight = height
-                self.applyDocumentHeight()
-                // Image load / font reflow shifted layout — re-measure offsets.
-                self.scheduleHeadingOffsetsRefresh()
-            }
+            // Image load / font reflow shifted layout — re-measure offsets.
+            self.scheduleHeadingOffsetsRefresh()
             if self.shouldApplyPendingAnchorOnHeight,
                let anchor = self.pendingPreviewScrollAnchor {
                 self.shouldApplyPendingAnchorOnHeight = false
@@ -93,29 +80,12 @@ final class ContentViewController: NSViewController {
         webView.zoomDidChange = { [weak self] zoom in
             self?.webViewPageWidthConstraint?.constant = MarkdownHTML.preferredPageWidth * zoom
         }
+        webView.scrollDidChange = { [weak self] in
+            self?.evaluateActiveHeading()
+        }
         webView.enablePersistentZoom(defaultsKey: Self.pageZoomDefaultsKey)
 
-        documentView.addSubview(webView)
-        scrollView.documentView = documentView
-        view = scrollView
-
-        // The WKWebView is sized to full document height with internal
-        // scrolling disabled — all scroll happens at the clip view. The
-        // scrollspy listens for actual position changes (not gesture-begin
-        // signals), so a trackpad gesture that can't scroll the doc — short
-        // doc — leaves a click pin intact. queue: .main lets `assumeIsolated`
-        // hop cleanly under Swift 6.
-        scrollView.contentView.postsBoundsChangedNotifications = true
-        NotificationCenter.default.addObserver(
-            forName: NSView.boundsDidChangeNotification,
-            object: scrollView.contentView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.evaluateActiveHeading() }
-        }
-
-        documentHeightConstraint = documentView.heightAnchor.constraint(equalToConstant: 1)
-        webViewHeightConstraint = webView.heightAnchor.constraint(equalToConstant: 1)
+        container.addSubview(webView)
 
         // Normal (centered) mode caps the web view at the page width and
         // centers it in AppKit rather than letting CSS auto-margins center
@@ -134,37 +104,23 @@ final class ContentViewController: NSViewController {
         pageWidth.priority = .init(249)
         webViewPageWidthConstraint = pageWidth
         webViewCenteredConstraints = [
-            webView.centerXAnchor.constraint(equalTo: documentView.centerXAnchor),
-            webView.widthAnchor.constraint(lessThanOrEqualTo: documentView.widthAnchor),
+            webView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            webView.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor),
             pageWidth
         ]
         webViewFullWidthConstraints = [
-            webView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor)
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor)
         ]
 
-        // Shared: document view tracks the clip width, web view pinned to
-        // the top and sized to the measured content height.
+        // Keep the WKWebView viewport-sized and let WebKit own vertical
+        // scrolling. Expanding it to the full document height creates an
+        // enormous backing surface that loses Retina resolution on long docs.
         NSLayoutConstraint.activate([
-            documentView.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
-            documentView.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
-            documentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
-            documentHeightConstraint,
-
-            webView.topAnchor.constraint(equalTo: documentView.topAnchor),
-            webViewHeightConstraint
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
         ])
         applyContentWidthMode()
-    }
-
-    override func viewDidLayout() {
-        super.viewDidLayout()
-
-        let laidOutSize = view.bounds.size
-        guard laidOutSize != lastLaidOutSize else { return }
-
-        lastLaidOutSize = laidOutSize
-        applyDocumentHeight()
     }
 
     func display(markdown: String, assetBaseURL: URL? = nil) {
@@ -225,12 +181,9 @@ final class ContentViewController: NSViewController {
     }
 
     private func isMatchVisible(top: CGFloat, bottom: CGFloat) -> Bool {
-        guard let scrollView = view as? NSScrollView else { return true }
-        let clipView = scrollView.contentView
-        let visibleTop = clipView.bounds.origin.y + clipView.contentInsets.top
-        let visibleBottom = clipView.bounds.origin.y
-            + clipView.bounds.height
-            - clipView.contentInsets.bottom
+        let metrics = webView.scrollMetrics
+        let visibleTop = metrics.position
+        let visibleBottom = metrics.position + metrics.viewportHeight
         return top >= visibleTop && bottom <= visibleBottom
     }
 
@@ -247,22 +200,14 @@ final class ContentViewController: NSViewController {
     /// Normalized top-of-viewport position used when handing the document to
     /// the editor, whose content height differs slightly from the preview.
     var scrollProgress: CGFloat {
-        guard let scrollView = view as? NSScrollView else { return 0 }
-        let clipView = scrollView.contentView
-        let minY = -clipView.contentInsets.top
-        let maxY = max(documentHeightConstraint.constant - clipView.bounds.height
-                       + clipView.contentInsets.bottom, minY)
-        guard maxY > minY else { return 0 }
-        return min(max((clipView.bounds.origin.y - minY) / (maxY - minY), 0), 1)
+        let metrics = webView.scrollMetrics
+        let maxY = max(metrics.documentHeight - metrics.viewportHeight, 0)
+        guard maxY > 0 else { return 0 }
+        return min(max(metrics.position / maxY, 0), 1)
     }
 
     func sourceScrollAnchor(completion: @escaping (SourceScrollAnchor?) -> Void) {
-        guard let scrollView = view as? NSScrollView else {
-            completion(nil)
-            return
-        }
-        let clipView = scrollView.contentView
-        let visibleTop = clipView.bounds.origin.y + clipView.contentInsets.top
+        let visibleTop = webView.scrollMetrics.position
         webView.sourceAnchor(atDocumentY: visibleTop / webView.pageZoom, completion: completion)
     }
 
@@ -310,8 +255,7 @@ final class ContentViewController: NSViewController {
     /// the click landed releases it.
     func markHeadingActiveFromClick(_ headingID: Int) {
         let anchor = expectedScrollPosition(forHeading: headingID)
-            ?? (view as? NSScrollView)?.contentView.bounds.origin.y
-            ?? 0
+            ?? webView.scrollMetrics.position
         sticky = StickyPin(headingID: headingID,
                            holdUntil: .now() + Self.stickyHoldDuration,
                            anchor: anchor)
@@ -323,18 +267,13 @@ final class ContentViewController: NSViewController {
     /// distance reference.
     private func expectedScrollPosition(forHeading headingID: Int) -> CGFloat? {
         guard headingID >= 0,
-              headingID < headingOffsetsCSS.count,
-              let scrollView = view as? NSScrollView else { return nil }
-        let clipView = scrollView.contentView
+              headingID < headingOffsetsCSS.count else { return nil }
+        let metrics = webView.scrollMetrics
         let zoom = max(webView.pageZoom, 0.001)
-        let topInset = clipView.contentInsets.top
-        let bottomInset = clipView.contentInsets.bottom
         let topMargin: CGFloat = 12
         let y = headingOffsetsCSS[headingID] * zoom
-        let minY = -topInset
-        let maxY = max(documentHeightConstraint.constant - clipView.bounds.height + bottomInset,
-                       minY)
-        return max(minY, min(y - topInset - topMargin, maxY))
+        let maxY = max(metrics.documentHeight - metrics.viewportHeight, 0)
+        return max(0, min(y - topMargin, maxY))
     }
 
     private func scrollToElement(id: String) {
@@ -345,27 +284,7 @@ final class ContentViewController: NSViewController {
     }
 
     private func scrollDocument(to y: CGFloat, topMargin: CGFloat = 12) {
-        guard let scrollView = view as? NSScrollView else { return }
-        let clipView = scrollView.contentView
-        let topInset = clipView.contentInsets.top
-        let bottomInset = clipView.contentInsets.bottom
-        let adjusted = y - topInset - topMargin
-        let minY = -topInset
-        let maxY = max(documentHeightConstraint.constant - clipView.bounds.height + bottomInset, minY)
-        let target = max(minY, min(adjusted, maxY))
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.25
-            context.allowsImplicitAnimation = true
-            clipView.animator().setBoundsOrigin(NSPoint(x: clipView.bounds.origin.x, y: target))
-        }
-        scrollView.reflectScrolledClipView(clipView)
-    }
-
-    private func applyDocumentHeight() {
-        let resolvedHeight = max(measuredDocumentHeight, view.bounds.height, 1)
-        documentHeightConstraint.constant = resolvedHeight
-        webViewHeightConstraint.constant = resolvedHeight
-        clampScrollPosition(toDocumentHeight: resolvedHeight)
+        webView.scrollDocument(to: y, topMargin: topMargin)
     }
 
     // MARK: - Scrollspy
@@ -406,25 +325,20 @@ final class ContentViewController: NSViewController {
     }
 
     private func hasMovedFar(from anchor: CGFloat) -> Bool {
-        guard let scrollView = view as? NSScrollView else { return true }
-        let clipView = scrollView.contentView
-        let delta = abs(clipView.bounds.origin.y - anchor)
-        return delta >= clipView.bounds.height * Self.stickyReleaseFraction
+        let metrics = webView.scrollMetrics
+        let delta = abs(metrics.position - anchor)
+        return delta >= metrics.viewportHeight * Self.stickyReleaseFraction
     }
 
     /// Last heading whose top has scrolled above the activation line.
     /// Lead-heading bump handles the doc-starts-with-a-heading case;
     /// short-doc-last-heading is handled by `markHeadingActiveFromClick`.
     private func computeActiveHeadingID() -> Int? {
-        guard !headingOffsetsCSS.isEmpty,
-              let scrollView = view as? NSScrollView else { return nil }
-        let clipView = scrollView.contentView
+        guard !headingOffsetsCSS.isEmpty else { return nil }
+        let metrics = webView.scrollMetrics
         let zoom = max(webView.pageZoom, 0.001)
         let topMargin: CGFloat = 12
-        var activationLine = (clipView.bounds.origin.y
-                              + clipView.contentInsets.top
-                              + topMargin
-                              + 8) / zoom
+        var activationLine = (metrics.position + topMargin + 8) / zoom
 
         if let firstOffset = headingOffsetsCSS.first,
            firstOffset <= Self.leadHeadingThreshold,
@@ -438,24 +352,4 @@ final class ContentViewController: NSViewController {
         }
         return active
     }
-
-    private func clampScrollPosition(toDocumentHeight documentHeight: CGFloat) {
-        guard let scrollView = view as? NSScrollView else { return }
-
-        let clipView = scrollView.contentView
-        let maxY = max(documentHeight - clipView.bounds.height, 0)
-        guard clipView.bounds.origin.y > maxY else {
-            scrollView.reflectScrolledClipView(clipView)
-            return
-        }
-
-        clipView.scroll(to: NSPoint(x: clipView.bounds.origin.x, y: maxY))
-        scrollView.reflectScrolledClipView(clipView)
-    }
-}
-
-private final class FlippedDocumentView: NSView {
-    // AppKit may query view geometry from its background printing thread.
-    // This override is immutable and does not touch main-actor-owned state.
-    nonisolated override var isFlipped: Bool { true }
 }

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -107,7 +107,8 @@ nonisolated enum MarkdownHTML {
         let containsCode = detectHighlightableCode(in: bodyHTML)
         let scrollOverride = allowsScroll ? """
         <style>
-        html, body { overflow: auto !important; }
+        html { overflow: auto !important; }
+        body { overflow: visible !important; }
         </style>
         """ : ""
         let contentWidthOverride = contentWidth == .full ? """

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -177,6 +177,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     var localMarkdownLinkActivated: ((URL) -> Void)?
     var taskCheckboxToggled: ((Int, Bool) -> Void)?
     var tableEditRequested: ((MarkdownTableEditRequest) -> Void)?
+    var scrollDidChange: (() -> Void)?
     private let assetScheme = MarkdownAssetScheme()
     private var currentAssetBase: URL?
     private let messageBridge = HostBridge()
@@ -210,13 +211,15 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     private var didMagnifyDuringCurrentGesture = false
     private var isPointerOverMermaidFigure = false
     private var currentMarkdown: String?
+    private weak var webScrollView: NSScrollView?
+    nonisolated(unsafe) private var scrollBoundsObserver: NSObjectProtocol?
 
     override init(frame frameRect: NSRect) {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(assetScheme, forURLScheme: MarkdownAssetScheme.scheme)
         config.userContentController.addUserScript(Self.disableContextMenuScript)
         config.userContentController.add(messageBridge, name: HostBridge.name)
-        webView = NonScrollingWKWebView(frame: .zero, configuration: config)
+        webView = PreviewWKWebView(frame: .zero, configuration: config)
         super.init(frame: frameRect)
 
         messageBridge.owner = self
@@ -231,8 +234,14 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             webView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
         DispatchQueue.main.async { [weak self] in
-            self?.neutralizeWebKitScrollEdgeInsets()
+            self?.configureWebKitScrollView()
             self?.warmupVendors()
+        }
+    }
+
+    deinit {
+        if let scrollBoundsObserver {
+            NotificationCenter.default.removeObserver(scrollBoundsObserver)
         }
     }
 
@@ -296,12 +305,12 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     override func layout() {
         super.layout()
-        neutralizeWebKitScrollEdgeInsets()
+        configureWebKitScrollView()
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        neutralizeWebKitScrollEdgeInsets()
+        configureWebKitScrollView()
     }
 
     /// Empties the visible article without unloading the page, so the next
@@ -339,6 +348,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                                                 warmup: Bool = false) -> MarkdownHTML.RenderedHTML {
         let t0 = DispatchTime.now()
         let rendered = MarkdownHTML.render(markdown: markdown,
+                                           allowsScroll: true,
                                            assetBaseHref: assetBaseHref,
                                            vendorLoading: .lazy,
                                            contentWidth: contentWidth,
@@ -961,10 +971,8 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             const current = marks[index];
             current.classList.add('md-search-highlight-current');
 
-            // The WKWebView host disables internal scrolling and forwards it to
-            // an outer NSScrollView, so scrollIntoView() is a no-op. Hand the
-            // document-space bounds back so AppKit can scroll the clip view —
-            // and only when the match isn't already on screen.
+            // Return document-space bounds so the native host can decide
+            // whether the match is already visible before scrolling to it.
             const rect = current.getBoundingClientRect();
             const scrollY = window.scrollY || document.documentElement.scrollTop || 0;
             return {
@@ -1001,11 +1009,34 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         case lineUp, lineDown, pageUp, pageDown, top, bottom, previousHeading, nextHeading
     }
 
-    /// Returns true when the action was handled (false if there's no outer
-    /// scroll view yet, so the keyDown forwarder falls back to super).
+    struct ScrollMetrics {
+        let position: CGFloat
+        let viewportHeight: CGFloat
+        let documentHeight: CGFloat
+    }
+
+    var scrollMetrics: ScrollMetrics {
+        guard let scrollView = webScrollView else {
+            return ScrollMetrics(
+                position: 0,
+                viewportHeight: bounds.height,
+                documentHeight: max(lastReportedDocumentHeight * webView.pageZoom, bounds.height)
+            )
+        }
+        let clipView = scrollView.contentView
+        return ScrollMetrics(
+            position: clipView.bounds.origin.y,
+            viewportHeight: clipView.bounds.height,
+            documentHeight: scrollView.documentView?.bounds.height ?? clipView.bounds.height
+        )
+    }
+
+    /// Returns true when the action was handled (false while WebKit's internal
+    /// scroll view is not available, so the keyDown forwarder falls back to
+    /// the standard implementation).
     @discardableResult
     func performScrollAction(_ action: ScrollAction) -> Bool {
-        guard let scrollView = enclosingScrollView else { return false }
+        guard let scrollView = webScrollView else { return false }
         let clipView = scrollView.contentView
         let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
         let topInset = clipView.contentInsets.top
@@ -1048,13 +1079,25 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         case .previousHeading, .nextHeading:
             return true
         }
-        animateOuterScroll(to: target, in: scrollView, duration: duration)
+        animateScroll(to: target, in: scrollView, duration: duration)
         return true
     }
 
-    private func animateOuterScroll(to y: CGFloat,
-                                    in scrollView: NSScrollView,
-                                    duration: TimeInterval) {
+    func scrollDocument(to y: CGFloat,
+                        topMargin: CGFloat = 12,
+                        duration: TimeInterval = 0.25) {
+        guard let scrollView = webScrollView else { return }
+        let clipView = scrollView.contentView
+        let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
+        let minY = -clipView.contentInsets.top
+        let maxY = max(documentHeight - clipView.bounds.height + clipView.contentInsets.bottom, minY)
+        let target = max(minY, min(y - clipView.contentInsets.top - topMargin, maxY))
+        animateScroll(to: target, in: scrollView, duration: duration)
+    }
+
+    private func animateScroll(to y: CGFloat,
+                               in scrollView: NSScrollView,
+                               duration: TimeInterval) {
         let clipView = scrollView.contentView
         NSAnimationContext.runAnimationGroup { context in
             context.duration = duration
@@ -1091,7 +1134,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             let minY = -topInset
             let maxY = max(documentHeight - clipView.bounds.height + bottomInset, minY)
             let target = max(minY, min((headingY * zoom) - topInset - topMargin, maxY))
-            self.animateOuterScroll(to: target, in: scrollView, duration: 0.2)
+            self.animateScroll(to: target, in: scrollView, duration: 0.2)
         }
     }
 
@@ -1108,31 +1151,44 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     @objc func mdScrollPreviousHeading(_ sender: Any?) { performScrollAction(.previousHeading) }
     @objc func mdScrollNextHeading(_ sender: Any?)     { performScrollAction(.nextHeading) }
 
-    private func neutralizeWebKitScrollEdgeInsets() {
+    private func configureWebKitScrollView() {
+        guard let scrollView = webView.descendantViews.first(where: { $0 is NSScrollView })
+                as? NSScrollView else { return }
+
+        if webScrollView !== scrollView {
+            if let scrollBoundsObserver {
+                NotificationCenter.default.removeObserver(scrollBoundsObserver)
+            }
+            scrollBoundsObserver = nil
+            webScrollView = scrollView
+        }
+
         let zeroInsets = NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        for view in webView.descendantViews {
-            if let scrollView = view as? NSScrollView {
-                scrollView.automaticallyAdjustsContentInsets = false
-                scrollView.hasVerticalScroller = false
-                scrollView.hasHorizontalScroller = false
-                scrollView.autohidesScrollers = true
-                scrollView.verticalScrollElasticity = .none
-                scrollView.horizontalScrollElasticity = .none
-                scrollView.contentInsets = zeroInsets
-                scrollView.scrollerInsets = zeroInsets
-                scrollView.verticalScroller?.isHidden = true
-                scrollView.verticalScroller?.alphaValue = 0
-                scrollView.horizontalScroller?.isHidden = true
-                scrollView.horizontalScroller?.alphaValue = 0
-            }
-            if let scroller = view as? NSScroller {
-                scroller.isHidden = true
-                scroller.alphaValue = 0
-            }
-            if let clipView = view as? NSClipView {
-                clipView.automaticallyAdjustsContentInsets = false
-                clipView.contentInsets = zeroInsets
-            }
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.verticalScrollElasticity = .none
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.contentInsets = zeroInsets
+        scrollView.scrollerInsets = zeroInsets
+        scrollView.verticalScroller?.isHidden = false
+        scrollView.verticalScroller?.alphaValue = 1
+        scrollView.horizontalScroller?.isHidden = true
+        scrollView.horizontalScroller?.alphaValue = 0
+
+        let clipView = scrollView.contentView
+        clipView.automaticallyAdjustsContentInsets = false
+        clipView.contentInsets = zeroInsets
+
+        guard scrollBoundsObserver == nil else { return }
+        clipView.postsBoundsChangedNotifications = true
+        scrollBoundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: clipView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.scrollDidChange?() }
         }
     }
 
@@ -1164,7 +1220,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        neutralizeWebKitScrollEdgeInsets()
+        configureWebKitScrollView()
         isPageReady = true
     }
 
@@ -1194,10 +1250,7 @@ private extension NSView {
     }
 }
 
-private final class NonScrollingWKWebView: WKWebView {
-    private enum Axis { case horizontal, vertical }
-    private var lockedAxis: Axis?
-
+private final class PreviewWKWebView: WKWebView {
     override func keyDown(with event: NSEvent) {
         if forwardHeadingKey(event) { return }
         if isStandardScrollKey(event) {
@@ -1332,43 +1385,10 @@ private final class NonScrollingWKWebView: WKWebView {
     }
 
     override func scrollWheel(with event: NSEvent) {
-        let axis = decideAxis(for: event)
-        if axis == .horizontal {
-            // Inner overflow:auto element (wide <pre>, table, math) handles it.
-            super.scrollWheel(with: event)
-            return
-        }
-        if let outerScrollView = superview?.enclosingScrollView {
-            outerScrollView.scrollWheel(with: event)
-        } else {
-            super.scrollWheel(with: event)
-        }
-    }
-
-    /// Lock routing axis at the start of a trackpad gesture and carry it
-    /// through .changed/.ended and any momentum that follows. Without this,
-    /// a momentary Y-dominant event mid-horizontal-swipe routes one frame
-    /// to the outer page scroller and the user sees a lurch. Mouse-wheel
-    /// events (phase empty) clear the lock and decide per-event.
-    private func decideAxis(for event: NSEvent) -> Axis {
-        let perEvent: Axis = abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY)
-            ? .horizontal : .vertical
-
-        if event.phase == .began {
-            lockedAxis = perEvent
-            return perEvent
-        }
-
-        let isTrackpadEvent = !event.phase.isEmpty || !event.momentumPhase.isEmpty
-        if isTrackpadEvent, let locked = lockedAxis {
-            if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
-                lockedAxis = nil
-            }
-            return locked
-        }
-
-        lockedAxis = nil
-        return perEvent
+        // WebKit owns both page scrolling and nested horizontal overflow.
+        // Keeping the WKWebView viewport-sized lets its tiled backing store
+        // stay at the display's native scale for very long documents.
+        super.scrollWheel(with: event)
     }
 }
 

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -4,6 +4,69 @@ import WebKit
 
 final class MarkdownHTMLRenderTests: XCTestCase {
     @MainActor
+    func testScrollableLongTableKeepsWebKitViewportAndScrollsDocument() async throws {
+        let rows = (1...750).map { "| \($0) | Function \($0) | 100.00% |" }
+            .joined(separator: "\n")
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            | State | Function | Match |
+            | --- | --- | ---: |
+            \(rows)
+            """,
+            allowsScroll: true,
+            vendorLoading: .lazy
+        )
+        let styleBlocks = rendered.html
+            .components(separatedBy: "<style>")
+            .dropFirst()
+            .compactMap { $0.components(separatedBy: "</style>").first }
+            .map { "<style>\($0)</style>" }
+            .joined(separator: "\n")
+        let html = """
+        <!DOCTYPE html>
+        <html><head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        \(styleBlocks)
+        </head><body><article class="markdown-body">\(rendered.articleHTML)</article></body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let result = try await webView.evaluateJavaScript("""
+        (() => {
+            const root = document.scrollingElement;
+            window.scrollTo(0, root.scrollHeight);
+            return JSON.stringify({
+                viewportHeight: window.innerHeight,
+                documentHeight: root.scrollHeight,
+                scrollPosition: root.scrollTop,
+                articleHeight: document.querySelector('article')?.getBoundingClientRect().height || 0,
+                rowCount: document.querySelectorAll('tbody tr').length,
+                overflowY: getComputedStyle(document.documentElement).overflowY,
+                bodyOverflowY: getComputedStyle(document.body).overflowY,
+            });
+        })()
+        """)
+        let json = try XCTUnwrap(result as? String)
+        let metrics = try JSONDecoder().decode(
+            LongDocumentScrollMetrics.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(metrics.viewportHeight, 600, accuracy: 1)
+        XCTAssertEqual(metrics.rowCount, 750, json)
+        XCTAssertGreaterThan(metrics.articleHeight, metrics.viewportHeight * 5, json)
+        XCTAssertGreaterThan(metrics.documentHeight, metrics.viewportHeight * 5, json)
+        XCTAssertGreaterThan(metrics.scrollPosition, metrics.viewportHeight, json)
+        XCTAssertEqual(metrics.overflowY, "auto")
+        XCTAssertEqual(metrics.bodyOverflowY, "visible")
+    }
+
+    @MainActor
     func testLongInlineCodeInHeadingStaysWithinViewport() async throws {
         let rendered = MarkdownHTML.render(
             markdown: "## 1. New port — `src/features/imageUpload/application/repositoryInterfaces/imageProcessedPublisherInterface.ts`",
@@ -471,6 +534,16 @@ private struct HeadingLayoutMetrics: Decodable {
     let codeRight: CGFloat
     let viewportRight: CGFloat
     let boxDecorationBreak: String
+}
+
+private struct LongDocumentScrollMetrics: Decodable {
+    let viewportHeight: CGFloat
+    let documentHeight: CGFloat
+    let scrollPosition: CGFloat
+    let articleHeight: CGFloat
+    let rowCount: Int
+    let overflowY: String
+    let bodyOverflowY: String
 }
 
 private struct MermaidLayoutMetrics: Decodable {


### PR DESCRIPTION
## Summary

- keep the preview WKWebView viewport-sized and let WebKit own document scrolling
- route search, source-position restoration, scrollspy, and keyboard navigation through WebKit's scroll view
- add a 750-row long-table regression test

## Root cause

The main app disabled WKWebView's internal scrolling, expanded it to the entire document height, and scrolled an outer AppKit scroll view. Very long documents therefore created an enormous WebKit backing surface, which was rasterized below the display's native scale. Quick Look stayed sharp because its WKWebView remained viewport-sized.

## Validation

- swift test --package-path tests/swift-tests (64 tests)
- xcodebuild -quiet -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /private/tmp/markdown-preview-derived -packageAuthorizationProvider netrc CODE_SIGNING_ALLOWED=NO build
- opened the original 2,173-function Crimson STATUS.md in the source-built app and visually checked the table at the top and at 80% scroll; text remained sharp and the native scroller tracked correctly
