### PR TITLE
Add Simplified Chinese localization

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"zh-Hans",
 			);
 			mainGroup = 9A0207B82FA0ED7C00092060;
 			minimizedProjectReferenceProxies = 1;

--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9A7B10012FB0000100010001 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 9A7B10032FB0000100010001 /* Sentry */; };
 		9A33940A2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3394092FA5AF500015D9A4 /* Markdown */; };
 		9A33940C2FA5AF500015D9A4 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 9A33940B2FA5AF500015D9A4 /* Markdown */; };
+		9A2040010000000000000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9A2040010000000000000004 /* Localizable.strings */; };
 		9AC100010000000000000001 /* markdown-preview in Copy CLI Tool */ = {isa = PBXBuildFile; fileRef = 9AC100010000000000000002 /* markdown-preview */; };
 		9AF000000000000000000003 /* mermaid.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 9AF000000000000000000101 /* mermaid.min.js */; };
 		9AF000000000000000000004 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 9AF000000000000000000102 /* LICENSE */; };
@@ -79,6 +80,8 @@
 		9AF000000000000000000109 /* Highlight-LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "Highlight-LICENSE.txt"; path = "md-preview/Vendor/Highlight/Highlight-LICENSE.txt"; sourceTree = "<group>"; };
 		9AF00000000000000000010A /* purify.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = purify.min.js; path = "md-preview/Vendor/DOMPurify/purify.min.js"; sourceTree = "<group>"; };
 		9AF00000000000000000010B /* DOMPurify-LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "DOMPurify-LICENSE.txt"; path = "md-preview/Vendor/DOMPurify/DOMPurify-LICENSE.txt"; sourceTree = "<group>"; };
+		9A2040010000000000000002 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = "md-preview/en.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		9A2040010000000000000003 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "md-preview/zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -150,6 +153,7 @@
 			isa = PBXGroup;
 			children = (
 				9A0209A02FA1100100092060 /* Version.xcconfig */,
+				9A2040010000000000000004 /* Localizable.strings */,
 				9AC100010000000000000004 /* Resources */,
 				9AF000000000000000000101 /* mermaid.min.js */,
 				9AF000000000000000000102 /* LICENSE */,
@@ -328,6 +332,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A2040010000000000000001 /* Localizable.strings in Resources */,
 				9AF000000000000000000003 /* mermaid.min.js in Resources */,
 				9AF000000000000000000004 /* LICENSE in Resources */,
 				9AF000000000000000000005 /* katex.min.js in Resources */,
@@ -360,6 +365,18 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		9A2040010000000000000004 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				9A2040010000000000000002 /* en */,
+				9A2040010000000000000003 /* zh-Hans */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin PBXTargetDependency section */
 		9A02093B2FA10D4C00092060 /* PBXTargetDependency */ = {

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -16,13 +16,28 @@ private enum CommandLineToolInstallError: LocalizedError {
         switch self {
         case .terminalAutomationFailed(let message):
             if let message, !message.isEmpty {
-                return "Terminal automation failed: \(message)"
+                return String(
+                    format: NSLocalizedString(
+                        "Terminal automation failed: %@",
+                        comment: "CLI installer error"
+                    ),
+                    message
+                )
             }
-            return "Terminal automation failed."
+            return NSLocalizedString("Terminal automation failed.", comment: "CLI installer error")
         case .installerScriptWriteFailed(let message):
-            return "Failed to write CLI installer script: \(message)"
+            return String(
+                format: NSLocalizedString(
+                    "Failed to write CLI installer script: %@",
+                    comment: "CLI installer error"
+                ),
+                message
+            )
         case .bundledToolMissing:
-            return "The bundled Markdown Preview CLI could not be found."
+            return NSLocalizedString(
+                "The bundled Markdown Preview CLI could not be found.",
+                comment: "CLI installer error"
+            )
         }
     }
 }

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -62,9 +62,9 @@ private enum AppAppearanceMode: String, CaseIterable {
 
     var title: String {
         switch self {
-        case .automatic: return "Automatic"
-        case .light: return "Light"
-        case .dark: return "Dark"
+        case .automatic: return NSLocalizedString("Automatic", comment: "Appearance mode")
+        case .light: return NSLocalizedString("Light", comment: "Appearance mode")
+        case .dark: return NSLocalizedString("Dark", comment: "Appearance mode")
         }
     }
 
@@ -354,7 +354,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = true
         panel.canChooseFiles = true
-        panel.message = "Choose a Markdown file or folder"
+        panel.message = NSLocalizedString("Choose a Markdown file or folder",
+                                          comment: "Open panel prompt")
         panel.allowedContentTypes = Self.markdownFileExtensions
             .compactMap { UTType(filenameExtension: $0) }
         return panel
@@ -579,8 +580,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installNewTabMenuItem() {
-        guard let fileMenu = NSApp.mainMenu?.items
-            .first(where: { $0.title == "File" })?.submenu,
+        guard let fileMenu = topLevelSubmenu(matching: Self.fileMenuTitles),
               fileMenu.items.first(where: {
                   $0.action == #selector(NSResponder.newWindowForTab(_:))
               }) == nil else { return }
@@ -588,7 +588,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // nil target: resolves through the responder chain to the key
         // document window's controller, and disables itself when no
         // document window is open.
-        let item = NSMenuItem(title: "New Tab",
+        let item = NSMenuItem(title: L("New Tab"),
                               action: #selector(NSResponder.newWindowForTab(_:)),
                               keyEquivalent: "t")
         let insertIndex = fileMenu.items
@@ -598,7 +598,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func installGoMenu() {
         guard let mainMenu = NSApp.mainMenu,
-              mainMenu.items.first(where: { $0.title == "Go" }) == nil else { return }
+              topLevelMenuItem(matching: Self.goMenuTitles) == nil else { return }
 
         func arrow(_ functionKey: Int) -> String {
             UnicodeScalar(functionKey).map { String(Character($0)) } ?? ""
@@ -606,11 +606,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let symbolConfig = NSImage.SymbolConfiguration(pointSize: 14, weight: .regular)
 
-        func makeItem(_ title: String,
+        func makeItem(_ titleKey: String,
                       action: Selector,
                       keyEquivalent: String,
                       modifiers: NSEvent.ModifierFlags,
                       symbol: String) -> NSMenuItem {
+            let title = L(titleKey)
             let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
             item.keyEquivalentModifierMask = modifiers
             if let image = NSImage(systemSymbolName: symbol, accessibilityDescription: title)?
@@ -621,7 +622,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return item
         }
 
-        let menu = NSMenu(title: "Go")
+        let goTitle = L("Go")
+        let menu = NSMenu(title: goTitle)
 
         menu.addItem(makeItem("Up",
                               action: #selector(NSResponder.scrollLineUp(_:)),
@@ -670,26 +672,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                               modifiers: .command,
                               symbol: "arrow.down.to.line"))
 
-        let goItem = NSMenuItem(title: "Go", action: nil, keyEquivalent: "")
+        let goItem = NSMenuItem(title: goTitle, action: nil, keyEquivalent: "")
         goItem.submenu = menu
 
-        let insertIndex = mainMenu.items.firstIndex(where: { $0.title == "Window" })
-            ?? mainMenu.items.count
+        let insertIndex = mainMenu.items.firstIndex(where: {
+            Self.windowMenuTitles.contains($0.title)
+        }) ?? mainMenu.items.count
         mainMenu.insertItem(goItem, at: insertIndex)
     }
 
     private func installZoomMenuItemIcons() {
-        guard let viewMenu = NSApp.mainMenu?.items
-            .first(where: { $0.title == "View" })?.submenu else { return }
-        let icons: [(title: String, symbol: String)] = [
-            ("Actual Size", "magnifyingglass"),
-            ("Zoom In", "plus.magnifyingglass"),
-            ("Zoom Out", "minus.magnifyingglass")
+        guard let viewMenu = topLevelSubmenu(matching: Self.viewMenuTitles) else { return }
+        let icons: [(titles: Set<String>, symbol: String)] = [
+            (["Actual Size", "实际大小"], "magnifyingglass"),
+            (["Zoom In", "放大"], "plus.magnifyingglass"),
+            (["Zoom Out", "缩小"], "minus.magnifyingglass")
         ]
-        for (title, symbol) in icons {
-            guard let item = viewMenu.items.first(where: { $0.title == title }),
+        for (titles, symbol) in icons {
+            guard let item = viewMenu.items.first(where: { titles.contains($0.title) }),
                   let image = NSImage(systemSymbolName: symbol,
-                                      accessibilityDescription: title)
+                                      accessibilityDescription: item.title)
             else { continue }
             image.isTemplate = true
             item.image = image
@@ -697,18 +699,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installAppearanceMenuItems() {
-        guard let viewMenu = NSApp.mainMenu?.items
-            .first(where: { $0.title == "View" })?.submenu,
-              viewMenu.items.first(where: { $0.title == "Appearance" }) == nil else { return }
+        guard let viewMenu = topLevelSubmenu(matching: Self.viewMenuTitles),
+              viewMenu.items.first(where: {
+                  Self.appearanceMenuTitles.contains($0.title)
+              }) == nil else { return }
 
-        let appearanceItem = NSMenuItem(title: "Appearance", action: nil, keyEquivalent: "")
+        let appearanceTitle = L("Appearance")
+        let appearanceItem = NSMenuItem(title: appearanceTitle, action: nil, keyEquivalent: "")
         if let image = NSImage(systemSymbolName: "circle.lefthalf.filled",
-                               accessibilityDescription: "Appearance") {
+                               accessibilityDescription: appearanceTitle) {
             image.isTemplate = true
             appearanceItem.image = image
         }
 
-        let submenu = NSMenu(title: "Appearance")
+        let submenu = NSMenu(title: appearanceTitle)
         for mode in AppAppearanceMode.allCases {
             let item = NSMenuItem(title: mode.title,
                                   action: #selector(selectAppearanceMode(_:)),
@@ -733,18 +737,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installContentWidthMenuItems() {
-        guard let viewMenu = NSApp.mainMenu?.items
-            .first(where: { $0.title == "View" })?.submenu,
-              viewMenu.items.first(where: { $0.title == "Content Width" }) == nil else { return }
+        guard let viewMenu = topLevelSubmenu(matching: Self.viewMenuTitles),
+              viewMenu.items.first(where: {
+                  Self.contentWidthMenuTitles.contains($0.title)
+              }) == nil else { return }
 
-        let widthItem = NSMenuItem(title: "Content Width", action: nil, keyEquivalent: "")
+        let widthTitle = L("Content Width")
+        let widthItem = NSMenuItem(title: widthTitle, action: nil, keyEquivalent: "")
         if let image = NSImage(systemSymbolName: "arrow.left.and.right.text.vertical",
-                               accessibilityDescription: "Content Width") {
+                               accessibilityDescription: widthTitle) {
             image.isTemplate = true
             widthItem.image = image
         }
 
-        let submenu = NSMenu(title: "Content Width")
+        let submenu = NSMenu(title: widthTitle)
         for setting in ContentWidthSetting.allCases {
             let item = NSMenuItem(title: setting.title,
                                   action: #selector(selectContentWidthSetting(_:)),
@@ -762,7 +768,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         widthItem.submenu = submenu
         let insertIndex = viewMenu.items
-            .firstIndex(where: { $0.title == "Appearance" })
+            .firstIndex(where: { Self.appearanceMenuTitles.contains($0.title) })
             .map { $0 + 1 } ?? 0
         viewMenu.insertItem(widthItem, at: insertIndex)
         syncContentWidthMenuState()
@@ -808,7 +814,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               let appMenu = updatesItem.menu
         else { return }
 
-        let cliItem = NSMenuItem(title: "Install CLI...",
+        let cliItem = NSMenuItem(title: L("Install CLI..."),
                                  action: #selector(installCommandLineTools(_:)),
                                  keyEquivalent: "")
         cliItem.target = self
@@ -829,10 +835,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installSidebarViewMenuItems() {
-        guard let viewMenu = NSApp.mainMenu?.items
-            .first(where: { $0.title == "View" })?.submenu else { return }
+        guard let viewMenu = topLevelSubmenu(matching: Self.viewMenuTitles) else { return }
 
-        if let existing = viewMenu.items.first(where: { $0.title == "Show Sidebar" }) {
+        if let existing = viewMenu.items.first(where: {
+            Self.showSidebarMenuTitles.contains($0.title)
+        }) {
             viewMenu.removeItem(existing)
         }
         guard viewMenu.items.first(where: { $0.action == #selector(hideSidebarFromMenu(_:)) }) == nil else {
@@ -841,21 +848,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let insertIndex = (viewMenu.items.firstIndex(where: { $0.isSeparatorItem }) ?? -1) + 1
 
-        let hide = makeSidebarViewMenuItem(title: "Hide Sidebar",
+        let hide = makeSidebarViewMenuItem(title: L("Hide Sidebar"),
                                            symbol: "sidebar.leading",
                                            keyEquivalent: "1",
                                            action: #selector(hideSidebarFromMenu(_:)))
         viewMenu.insertItem(hide, at: insertIndex)
         hideSidebarMenuItem = hide
 
-        let outline = makeSidebarViewMenuItem(title: "Table of Contents",
+        let outline = makeSidebarViewMenuItem(title: L("Table of Contents"),
                                               symbol: "list.bullet.indent",
                                               keyEquivalent: "2",
                                               action: #selector(selectOutlineMode(_:)))
         viewMenu.insertItem(outline, at: insertIndex + 1)
         outlineMenuItem = outline
 
-        let files = makeSidebarViewMenuItem(title: "Project Navigator",
+        let files = makeSidebarViewMenuItem(title: L("Project Navigator"),
                                             symbol: "folder",
                                             keyEquivalent: "3",
                                             action: #selector(selectFilesMode(_:)))
@@ -866,20 +873,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installEditModeMenuItem() {
-        guard let viewMenu = NSApp.mainMenu?.items
-            .first(where: { $0.title == "View" })?.submenu,
+        guard let viewMenu = topLevelSubmenu(matching: Self.viewMenuTitles),
               viewMenu.items.first(where: {
                   $0.action == #selector(toggleEditModeFromMenu(_:))
               }) == nil else { return }
 
-        let item = NSMenuItem(title: "Toggle Edit Mode",
+        let item = NSMenuItem(title: L("Toggle Edit Mode"),
                               action: #selector(toggleEditModeFromMenu(_:)),
                               keyEquivalent: "e")
         item.keyEquivalentModifierMask = [.command]
         item.target = self
 
-        let insertIndex = viewMenu.items.firstIndex(where: { $0.title == "Actual Size" })
-            ?? viewMenu.numberOfItems
+        let insertIndex = viewMenu.items.firstIndex(where: {
+            Self.actualSizeMenuTitles.contains($0.title)
+        }) ?? viewMenu.numberOfItems
         viewMenu.insertItem(item, at: insertIndex)
         viewMenu.insertItem(.separator(), at: insertIndex + 1)
     }
@@ -890,13 +897,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func installFormatMenu() {
         guard let mainMenu = NSApp.mainMenu,
-              mainMenu.items.first(where: { $0.title == "Format" }) == nil else { return }
+              topLevelMenuItem(matching: Self.formatMenuTitles) == nil else { return }
 
-        func item(_ title: String,
+        func item(_ titleKey: String,
                   command: String,
                   key: String = "",
                   modifiers: NSEvent.ModifierFlags = [.command]) -> NSMenuItem {
-            let item = NSMenuItem(title: title,
+            let item = NSMenuItem(title: L(titleKey),
                                   action: #selector(formatMarkdownFromMenu(_:)),
                                   keyEquivalent: key)
             item.target = self
@@ -905,7 +912,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return item
         }
 
-        let menu = NSMenu(title: "Format")
+        let formatTitle = L("Format")
+        let menu = NSMenu(title: formatTitle)
         menu.addItem(item("Body", command: "h0"))
         menu.addItem(item("Heading 1", command: "h1", key: "1", modifiers: [.shift, .command]))
         menu.addItem(item("Heading 2", command: "h2", key: "2", modifiers: [.shift, .command]))
@@ -922,10 +930,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(item("Checklist", command: "taskList", key: "l", modifiers: [.shift, .command]))
         menu.addItem(item("Block Quote", command: "quote", key: "'"))
 
-        let rootItem = NSMenuItem(title: "Format", action: nil, keyEquivalent: "")
+        let rootItem = NSMenuItem(title: formatTitle, action: nil, keyEquivalent: "")
         rootItem.submenu = menu
-        let insertIndex = mainMenu.items.firstIndex(where: { $0.title == "View" })
-            ?? mainMenu.items.count
+        let insertIndex = mainMenu.items.firstIndex(where: {
+            Self.viewMenuTitles.contains($0.title)
+        }) ?? mainMenu.items.count
         mainMenu.insertItem(rootItem, at: insertIndex)
     }
 
@@ -959,4 +968,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         outlineMenuItem?.state = (state.sidebarVisible && state.mode == .outline) ? .on : .off
         filesMenuItem?.state = (state.sidebarVisible && state.mode == .files) ? .on : .off
     }
+
+    private func L(_ key: String) -> String {
+        NSLocalizedString(key, comment: "")
+    }
+
+    private func topLevelMenuItem(matching titles: Set<String>) -> NSMenuItem? {
+        NSApp.mainMenu?.items.first { titles.contains($0.title) }
+    }
+
+    private func topLevelSubmenu(matching titles: Set<String>) -> NSMenu? {
+        topLevelMenuItem(matching: titles)?.submenu
+    }
+
+    private static let fileMenuTitles: Set<String> = ["File", "文件"]
+    private static let viewMenuTitles: Set<String> = ["View", "显示"]
+    private static let windowMenuTitles: Set<String> = ["Window", "窗口"]
+    private static let formatMenuTitles: Set<String> = ["Format", "格式"]
+    private static let goMenuTitles: Set<String> = ["Go", "前往"]
+    private static let appearanceMenuTitles: Set<String> = ["Appearance", "外观"]
+    private static let contentWidthMenuTitles: Set<String> = ["Content Width", "内容宽度"]
+    private static let showSidebarMenuTitles: Set<String> = ["Show Sidebar", "显示边栏"]
+    private static let actualSizeMenuTitles: Set<String> = ["Actual Size", "实际大小"]
 }

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -97,7 +97,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private var hasUnsavedEditorChanges = false {
         didSet {
             guard oldValue != hasUnsavedEditorChanges else { return }
-            documentWindow.subtitle = hasUnsavedEditorChanges ? "Edited" : ""
+            documentWindow.subtitle = hasUnsavedEditorChanges
+                ? NSLocalizedString("Edited", comment: "Window subtitle for unsaved changes")
+                : ""
         }
     }
     private weak var editAccessory: NSTitlebarAccessoryViewController?
@@ -258,7 +260,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         tableUndoManager.removeAllActions()
         currentFileURL = fileURL
         currentMarkdown = markdown
-        documentWindow.title = fileURL?.lastPathComponent ?? "Untitled"
+        documentWindow.title = fileURL?.lastPathComponent
+            ?? NSLocalizedString("Untitled", comment: "Window title when no document is open")
         attachToExistingTabGroupIfNeeded()
         documentWindow.makeKeyAndOrderFront(nil)
         // Tab placement is settled once the window is shown; a window opened
@@ -1173,12 +1176,22 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Do you want to save your changes?"
-        let fileName = currentFileURL?.lastPathComponent ?? "this document"
-        alert.informativeText = "Your changes to \(fileName) will be lost if you don’t save them."
-        alert.addButton(withTitle: "Save")
-        alert.addButton(withTitle: "Cancel")
-        alert.addButton(withTitle: "Don’t Save")
+        alert.messageText = NSLocalizedString(
+            "Do you want to save your changes?",
+            comment: "Unsaved changes alert title"
+        )
+        let fileName = currentFileURL?.lastPathComponent
+            ?? NSLocalizedString("this document", comment: "Fallback document name in alerts")
+        alert.informativeText = String(
+            format: NSLocalizedString(
+                "Your changes to %@ will be lost if you don’t save them.",
+                comment: "Unsaved changes alert message"
+            ),
+            fileName
+        )
+        alert.addButton(withTitle: NSLocalizedString("Save", comment: "Alert button"))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Alert button"))
+        alert.addButton(withTitle: NSLocalizedString("Don’t Save", comment: "Alert button"))
         alert.beginSheetModal(for: documentWindow) { response in
             switch response {
             case .alertFirstButtonReturn:
@@ -1444,14 +1457,26 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         case .missing:
             presentUnavailableFileConflict(localMarkdown: text,
                                            fileURL: url,
-                                           reason: "The file was removed while it was open.",
-                                           overwriteTitle: "Recreate File",
+                                           reason: NSLocalizedString(
+                                               "The file was removed while it was open.",
+                                               comment: "Unavailable file conflict reason"
+                                           ),
+                                           overwriteTitle: NSLocalizedString(
+                                               "Recreate File",
+                                               comment: "Unavailable file conflict button"
+                                           ),
                                            completion: completion)
         case .unreadable:
             presentUnavailableFileConflict(localMarkdown: text,
                                            fileURL: url,
-                                           reason: "The file could not be read to verify that it is unchanged.",
-                                           overwriteTitle: "Save Anyway",
+                                           reason: NSLocalizedString(
+                                               "The file could not be read to verify that it is unchanged.",
+                                               comment: "Unavailable file conflict reason"
+                                           ),
+                                           overwriteTitle: NSLocalizedString(
+                                               "Save Anyway",
+                                               comment: "Unavailable file conflict button"
+                                           ),
                                            completion: completion)
         }
     }
@@ -1545,18 +1570,18 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         for edit in edits.reversed() {
             switch edit {
             case .setCell:
-                return "Edit Table Cell"
+                return NSLocalizedString("Edit Table Cell", comment: "Table edit undo action")
             case .insertRowBefore, .insertRowAfter:
-                return "Add Row"
+                return NSLocalizedString("Add Row", comment: "Table edit undo action")
             case .deleteRow:
-                return "Delete Row"
+                return NSLocalizedString("Delete Row", comment: "Table edit undo action")
             case .insertColumnBefore, .insertColumnAfter:
-                return "Add Column"
+                return NSLocalizedString("Add Column", comment: "Table edit undo action")
             case .deleteColumn:
-                return "Delete Column"
+                return NSLocalizedString("Delete Column", comment: "Table edit undo action")
             }
         }
-        return "Edit Table"
+        return NSLocalizedString("Edit Table", comment: "Table edit undo action")
     }
 
     private func registerTableUndo(restoring markdown: String,
@@ -1634,11 +1659,20 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     ) {
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "This document changed on disk"
-        alert.informativeText = "Another app changed \(fileURL.lastPathComponent). Cancel keeps your changes unsaved. Choose which version to keep."
-        alert.addButton(withTitle: "Keep My Changes")
-        alert.addButton(withTitle: "Reload from Disk")
-        alert.addButton(withTitle: "Cancel")
+        alert.messageText = NSLocalizedString(
+            "This document changed on disk",
+            comment: "External edit conflict alert title"
+        )
+        alert.informativeText = String(
+            format: NSLocalizedString(
+                "Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep.",
+                comment: "External edit conflict alert message"
+            ),
+            fileURL.lastPathComponent
+        )
+        alert.addButton(withTitle: NSLocalizedString("Keep My Changes", comment: "Conflict alert button"))
+        alert.addButton(withTitle: NSLocalizedString("Reload from Disk", comment: "Conflict alert button"))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Alert button"))
         alert.beginSheetModal(for: documentWindow) { [weak self] response in
             guard let self else {
                 completion(.cancelled)
@@ -1671,10 +1705,19 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     ) {
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Unable to verify the document on disk"
-        alert.informativeText = "\(reason) Cancel keeps your changes unsaved."
+        alert.messageText = NSLocalizedString(
+            "Unable to verify the document on disk",
+            comment: "Unavailable file conflict alert title"
+        )
+        alert.informativeText = String(
+            format: NSLocalizedString(
+                "%@ Cancel keeps your changes unsaved.",
+                comment: "Unavailable file conflict alert message"
+            ),
+            reason
+        )
         alert.addButton(withTitle: overwriteTitle)
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Alert button"))
         alert.beginSheetModal(for: documentWindow) { [weak self] response in
             guard let self, response == .alertFirstButtonReturn else {
                 completion(.cancelled)
@@ -1700,7 +1743,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let panel = NSSavePanel()
         panel.directoryURL = url.deletingLastPathComponent()
         panel.nameFieldStringValue = url.lastPathComponent
-        panel.message = "Markdown Preview needs your permission to save this file."
+        panel.message = NSLocalizedString(
+            "Markdown Preview needs your permission to save this file.",
+            comment: "Save panel permission message"
+        )
         panel.beginSheetModal(for: documentWindow) { [weak self] response in
             guard let self, response == .OK, let chosen = panel.url else {
                 completion(.cancelled)
@@ -1851,18 +1897,18 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let menu = NSMenu()
 
         guard currentFileURL != nil else {
-            menu.addItem(disabledItem("No document open"))
+            menu.addItem(disabledItem(NSLocalizedString("No document open", comment: "Open menu empty state")))
             return menu
         }
 
         if editorCandidates.isEmpty && llmCandidates.isEmpty {
-            menu.addItem(disabledItem("No apps available"))
+            menu.addItem(disabledItem(NSLocalizedString("No apps available", comment: "Open menu empty state")))
             return menu
         }
 
         if !llmCandidates.isEmpty {
             let header = NSMenuItem()
-            header.title = "AI Apps"
+            header.title = NSLocalizedString("AI Apps", comment: "Open menu section header")
             header.isEnabled = false
             menu.addItem(header)
 
@@ -1891,7 +1937,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             }
 
             let header = NSMenuItem()
-            header.title = "Editors"
+            header.title = NSLocalizedString("Editors", comment: "Open menu section header")
             header.isEnabled = false
             menu.addItem(header)
 
@@ -2063,16 +2109,16 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let menu = NSMenu()
 
         guard currentFileURL != nil else {
-            menu.addItem(disabledItem("No document open"))
+            menu.addItem(disabledItem(NSLocalizedString("No document open", comment: "Open menu empty state")))
             return menu
         }
         guard !candidates.isEmpty else {
-            menu.addItem(disabledItem("No LLM apps available"))
+            menu.addItem(disabledItem(NSLocalizedString("No LLM apps available", comment: "Open menu empty state")))
             return menu
         }
 
         let header = NSMenuItem()
-        header.title = "Open in LLM…"
+        header.title = NSLocalizedString("Open in LLM…", comment: "Open in LLM menu header")
         header.isEnabled = false
         menu.addItem(header)
 
@@ -2641,16 +2687,16 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let menu = NSMenu()
 
         guard currentFileURL != nil else {
-            menu.addItem(disabledItem("No document open"))
+            menu.addItem(disabledItem(NSLocalizedString("No document open", comment: "Open menu empty state")))
             return menu
         }
         guard !candidates.isEmpty else {
-            menu.addItem(disabledItem("No editors available"))
+            menu.addItem(disabledItem(NSLocalizedString("No editors available", comment: "Open menu empty state")))
             return menu
         }
 
         let header = NSMenuItem()
-        header.title = "Open with…"
+        header.title = NSLocalizedString("Open with…", comment: "Open With menu header")
         header.isEnabled = false
         menu.addItem(header)
 
@@ -2906,7 +2952,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = true
         panel.canChooseFiles = true
-        panel.message = "Choose a Markdown file or folder"
+        panel.message = NSLocalizedString(
+            "Choose a Markdown file or folder",
+            comment: "Open panel prompt"
+        )
         panel.allowedContentTypes = Self.markdownFileExtensions
             .compactMap { UTType(filenameExtension: $0) }
         return panel

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -482,8 +482,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeNavigationItem() -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .navigation)
-        item.label = "Navigation"
-        item.paletteLabel = "Back and Forward"
+        let back = NSLocalizedString("Back", comment: "Navigation toolbar back button")
+        let forward = NSLocalizedString("Forward", comment: "Navigation toolbar forward button")
+        item.label = NSLocalizedString("Navigation", comment: "Navigation toolbar item label")
+        item.paletteLabel = NSLocalizedString("Back and Forward", comment: "Navigation toolbar palette label")
         item.isNavigational = true
         item.autovalidates = false
 
@@ -492,12 +494,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                                          target: self,
                                          action: #selector(navigateHistory(_:)))
         control.segmentStyle = .automatic
-        control.setImage(NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Back"),
+        control.setImage(NSImage(systemSymbolName: "chevron.left", accessibilityDescription: back),
                          forSegment: 0)
-        control.setImage(NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Forward"),
+        control.setImage(NSImage(systemSymbolName: "chevron.right", accessibilityDescription: forward),
                          forSegment: 1)
-        control.setToolTip("Back", forSegment: 0)
-        control.setToolTip("Forward", forSegment: 1)
+        control.setToolTip(back, forSegment: 0)
+        control.setToolTip(forward, forSegment: 1)
         item.view = control
         navigationItem = item
         navigationControl = control
@@ -529,9 +531,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeSidebarMenuItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .sidebarMenu)
-        item.label = "Sidebar"
-        item.paletteLabel = "Sidebar"
-        item.toolTip = "Sidebar options"
+        item.label = NSLocalizedString("Sidebar", comment: "Sidebar toolbar item label")
+        item.paletteLabel = NSLocalizedString("Sidebar", comment: "Sidebar toolbar palette label")
+        item.toolTip = NSLocalizedString("Sidebar options", comment: "Sidebar toolbar item tooltip")
 
         // NSPopUpButton (pull-down) so a single click anywhere on the button
         // opens the menu and the chevron renders natively. NSMenuToolbarItem
@@ -636,7 +638,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func sidebarFaceImage() -> NSImage {
         let image = NSImage(systemSymbolName: "sidebar.leading",
-                            accessibilityDescription: "Sidebar") ?? NSImage()
+                            accessibilityDescription: NSLocalizedString("Sidebar", comment: "Sidebar toolbar image")) ?? NSImage()
         image.isTemplate = true
         return image
     }
@@ -677,9 +679,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeInspectorItem() -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .inspector)
-        item.label = "Inspector"
-        item.paletteLabel = "Get Info"
-        item.toolTip = "Show the inspector"
+        item.label = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
+        item.paletteLabel = NSLocalizedString("Get Info", comment: "Inspector toolbar palette label")
+        item.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
 
         let button = NSButton(image: inspectorImage(),
                               target: self,
@@ -710,20 +712,21 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeShareItem() -> NSToolbarItem {
         let item = NSSharingServicePickerToolbarItem(itemIdentifier: .share)
-        item.label = "Share"
-        item.paletteLabel = "Share"
-        item.toolTip = "Share document"
+        item.label = NSLocalizedString("Share", comment: "Share toolbar item label")
+        item.paletteLabel = NSLocalizedString("Share", comment: "Share toolbar palette label")
+        item.toolTip = NSLocalizedString("Share document", comment: "Share toolbar item tooltip")
         item.delegate = self
         return item
     }
 
     private func makePrintItem() -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .printDocument)
-        item.label = "Print"
-        item.paletteLabel = "Print"
-        item.toolTip = "Print document"
+        let print = NSLocalizedString("Print", comment: "Print toolbar item label")
+        item.label = print
+        item.paletteLabel = print
+        item.toolTip = NSLocalizedString("Print document", comment: "Print toolbar item tooltip")
         item.image = NSImage(systemSymbolName: "printer",
-                             accessibilityDescription: "Print")
+                             accessibilityDescription: print)
         item.isBordered = true
         item.action = #selector(MainSplitViewController.printMarkdown(_:))
         return item
@@ -731,9 +734,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeCopyItem() -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .copyMarkdown)
-        item.label = "Copy"
-        item.paletteLabel = "Copy"
-        item.toolTip = "Copy Markdown source to clipboard"
+        let copy = NSLocalizedString("Copy", comment: "Copy toolbar item label")
+        item.label = copy
+        item.paletteLabel = copy
+        item.toolTip = NSLocalizedString("Copy Markdown source to clipboard", comment: "Copy toolbar item tooltip")
         item.image = copyIdleImage()
         item.isBordered = true
         item.target = self
@@ -770,12 +774,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func copyIdleImage() -> NSImage? {
         NSImage(systemSymbolName: "document.on.document",
-                accessibilityDescription: "Copy")
+                accessibilityDescription: NSLocalizedString("Copy", comment: "Copy toolbar image"))
     }
 
     private func copyConfirmedImage() -> NSImage? {
         NSImage(systemSymbolName: "checkmark",
-                accessibilityDescription: "Copied")
+                accessibilityDescription: NSLocalizedString("Copied", comment: "Copy confirmation image"))
     }
 
     // MARK: - Edit mode
@@ -813,12 +817,13 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeEditItem() -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .editDocument)
-        item.label = "Edit"
-        item.paletteLabel = "Edit"
-        item.toolTip = "Edit document"
+        let edit = NSLocalizedString("Edit", comment: "Edit toolbar item label")
+        item.label = edit
+        item.paletteLabel = edit
+        item.toolTip = NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
 
         let image = NSImage(systemSymbolName: "highlighter",
-                            accessibilityDescription: "Edit") ?? NSImage()
+                            accessibilityDescription: edit) ?? NSImage()
         image.isTemplate = true
         let button = NSButton(image: image,
                               target: self,
@@ -851,8 +856,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let editing = isEditing
         editButton?.state = editing ? .on : .off
         editItem?.toolTip = editing
-            ? "Stop editing and return to preview"
-            : "Edit document"
+            ? NSLocalizedString("Stop editing and return to preview", comment: "Edit toolbar item tooltip while editing")
+            : NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
         editButton?.toolTip = editItem?.toolTip
         editButton?.isEnabled = editing || (currentFileURL != nil && currentMarkdown != nil)
     }
@@ -896,8 +901,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
         // Plain button with a composed icon+chevron face: unlike a pull-down,
         // the chevron stays visible when the hover-only bezel is hidden.
+        let headingTitle = NSLocalizedString("Heading", comment: "Formatting toolbar heading button")
         let headingIcon = NSImage(systemSymbolName: "textformat.size",
-                                  accessibilityDescription: "Heading")?
+                                  accessibilityDescription: headingTitle)?
             .withSymbolConfiguration(symbolConfig) ?? NSImage()
         let headingChevron = NSImage(systemSymbolName: "chevron.down",
                                      accessibilityDescription: nil)?
@@ -919,24 +925,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         headings.bezelStyle = .accessoryBarAction
         headings.controlSize = .small
         headings.showsBorderOnlyWhileMouseInside = true
-        headings.toolTip = "Heading"
+        headings.toolTip = headingTitle
         headings.translatesAutoresizingMaskIntoConstraints = false
         headings.widthAnchor.constraint(equalToConstant: 44).isActive = true
 
         let views: [NSView] = [
             headings,
             separatorView(),
-            formatButton("bold", "bold", "Bold"),
-            formatButton("italic", "italic", "Italic"),
-            formatButton("strikethrough", "strikethrough", "Strikethrough"),
+            formatButton("bold", "bold", NSLocalizedString("Bold", comment: "Formatting toolbar tooltip")),
+            formatButton("italic", "italic", NSLocalizedString("Italic", comment: "Formatting toolbar tooltip")),
+            formatButton("strikethrough", "strikethrough", NSLocalizedString("Strikethrough", comment: "Formatting toolbar tooltip")),
             separatorView(),
-            formatButton("list.bullet", "bulletList", "Bulleted List"),
-            formatButton("list.number", "orderedList", "Numbered List"),
-            formatButton("checklist", "taskList", "Task List"),
-            formatButton("text.quote", "quote", "Block Quote"),
+            formatButton("list.bullet", "bulletList", NSLocalizedString("Bulleted List", comment: "Formatting toolbar tooltip")),
+            formatButton("list.number", "orderedList", NSLocalizedString("Numbered List", comment: "Formatting toolbar tooltip")),
+            formatButton("checklist", "taskList", NSLocalizedString("Task List", comment: "Formatting toolbar tooltip")),
+            formatButton("text.quote", "quote", NSLocalizedString("Block Quote", comment: "Formatting toolbar tooltip")),
             separatorView(),
-            formatButton("chevron.left.forwardslash.chevron.right", "code", "Inline Code"),
-            formatButton("link", "link", "Link"),
+            formatButton("chevron.left.forwardslash.chevron.right", "code", NSLocalizedString("Inline Code", comment: "Formatting toolbar tooltip")),
+            formatButton("link", "link", NSLocalizedString("Link", comment: "Formatting toolbar tooltip")),
         ]
         let stack = NSStackView(views: views)
         stack.orientation = .horizontal
@@ -992,7 +998,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     @objc private func showHeadingMenu(_ sender: NSButton) {
         let menu = NSMenu()
-        let normalText = NSMenuItem(title: "Normal Text",
+        let normalText = NSMenuItem(title: NSLocalizedString("Normal Text", comment: "Formatting toolbar heading menu"),
                                     action: #selector(headingCommand(_:)),
                                     keyEquivalent: "")
         normalText.target = self
@@ -1000,7 +1006,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         menu.addItem(normalText)
         menu.addItem(.separator())
         for level in 1...3 {
-            let item = NSMenuItem(title: "Heading \(level)",
+            let item = NSMenuItem(title: String(
+                format: NSLocalizedString("Heading %d", comment: "Formatting toolbar heading menu level"),
+                level
+            ),
                                   action: #selector(headingCommand(_:)),
                                   keyEquivalent: "")
             item.target = self
@@ -1700,9 +1709,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeOpenActionsItem() -> NSToolbarItem {
         let item = NSMenuToolbarItem(itemIdentifier: .openActions)
-        item.label = "Open"
-        item.paletteLabel = "Open"
-        item.toolTip = "Open document in another app"
+        let open = NSLocalizedString("Open", comment: "Open toolbar item label")
+        item.label = open
+        item.paletteLabel = open
+        item.toolTip = NSLocalizedString("Open document in another app", comment: "Open toolbar item tooltip")
         item.target = self
         item.action = #selector(openActionsPrimaryAction(_:))
         item.showsIndicator = true
@@ -1723,9 +1733,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
         let primaryTitle = openActionsTitle(for: defaultAction)
 
-        openActionsItem?.label = "Open"
+        openActionsItem?.label = NSLocalizedString("Open", comment: "Open toolbar item label")
         openActionsItem?.image = openActionsImage(for: defaultAction)
-        openActionsItem?.toolTip = primaryTitle ?? "Open document in another app"
+        openActionsItem?.toolTip = primaryTitle ?? NSLocalizedString(
+            "Open document in another app",
+            comment: "Open toolbar item tooltip"
+        )
         openActionsItem?.menu = buildOpenActionsMenu(editorCandidates: editors,
                                                      llmCandidates: llmApps,
                                                      defaultAction: defaultAction)
@@ -1734,12 +1747,19 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func openActionsTitle(for selection: OpenActionSelection?) -> String? {
         switch selection {
         case .editor(let editor):
-            return "Open in \(displayName(for: editor.url))"
+            return localizedOpenIn(displayName(for: editor.url))
         case .llm(let candidate):
-            return "Open in \(candidate.target.title)"
+            return localizedOpenIn(candidate.target.title)
         case nil:
             return nil
         }
+    }
+
+    private func localizedOpenIn(_ applicationName: String) -> String {
+        String(
+            format: NSLocalizedString("Open in %@", comment: "Open toolbar item for a named application"),
+            applicationName
+        )
     }
 
     private func openActionsImage(for selection: OpenActionSelection?) -> NSImage {
@@ -1927,9 +1947,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeOpenInLLMItem() -> NSToolbarItem {
         let item = NSMenuToolbarItem(itemIdentifier: .openInLLM)
-        item.label = "Open in LLM"
-        item.paletteLabel = "Open in LLM"
-        item.toolTip = "Open document in an LLM app"
+        let openInLLM = NSLocalizedString("Open in LLM", comment: "Open in LLM toolbar item label")
+        item.label = openInLLM
+        item.paletteLabel = openInLLM
+        item.toolTip = NSLocalizedString("Open document in an LLM app", comment: "Open in LLM toolbar item tooltip")
         item.target = self
         item.action = #selector(openInLLMPrimaryAction(_:))
         item.showsIndicator = true
@@ -1945,10 +1966,13 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             return
         }
         let resolvedDefault = resolveDefaultLLM(among: candidates)
-        let openInTitle = resolvedDefault.map { "Open in \($0.target.title)" }
-        openInLLMItem?.label = openInTitle ?? "Open in LLM"
+        let openInTitle = resolvedDefault.map { localizedOpenIn($0.target.title) }
+        openInLLMItem?.label = openInTitle ?? NSLocalizedString("Open in LLM", comment: "Open in LLM toolbar item label")
         openInLLMItem?.image = openInLLMImage(for: resolvedDefault)
-        openInLLMItem?.toolTip = openInTitle ?? "Open document in an LLM app"
+        openInLLMItem?.toolTip = openInTitle ?? NSLocalizedString(
+            "Open document in an LLM app",
+            comment: "Open in LLM toolbar item tooltip"
+        )
         openInLLMItem?.menu = buildOpenInLLMMenu(candidates: candidates,
                                                  defaultTarget: resolvedDefault)
     }
@@ -1968,7 +1992,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             return icon
         }
         return NSImage(systemSymbolName: "sparkles",
-                       accessibilityDescription: "Open in LLM") ?? NSImage()
+                       accessibilityDescription: NSLocalizedString("Open in LLM", comment: "Open in LLM toolbar image")) ?? NSImage()
     }
 
     private func llmCandidates() -> [LLMCandidate] {
@@ -2205,30 +2229,33 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     }
 
     private func makeZoomItem() -> NSToolbarItemGroup {
+        let zoomOut = NSLocalizedString("Zoom Out", comment: "Zoom toolbar button")
+        let zoomIn = NSLocalizedString("Zoom In", comment: "Zoom toolbar button")
+        let zoom = NSLocalizedString("Zoom", comment: "Zoom toolbar item label")
         let smaller = NSImage(systemSymbolName: "textformat.size.smaller",
-                              accessibilityDescription: "Zoom Out") ?? NSImage()
+                              accessibilityDescription: zoomOut) ?? NSImage()
         let larger = NSImage(systemSymbolName: "textformat.size.larger",
-                             accessibilityDescription: "Zoom In") ?? NSImage()
+                             accessibilityDescription: zoomIn) ?? NSImage()
         let group = NSToolbarItemGroup(
             itemIdentifier: .zoom,
             images: [smaller, larger],
             selectionMode: .momentary,
-            labels: ["Zoom Out", "Zoom In"],
+            labels: [zoomOut, zoomIn],
             target: self,
             action: #selector(zoomSegmentAction(_:))
         )
-        group.label = "Zoom"
-        group.paletteLabel = "Zoom"
-        group.toolTip = "Zoom"
-        for (subitem, tooltip) in zip(group.subitems, ["Zoom Out", "Zoom In"]) {
+        group.label = zoom
+        group.paletteLabel = zoom
+        group.toolTip = zoom
+        for (subitem, tooltip) in zip(group.subitems, [zoomOut, zoomIn]) {
             subitem.toolTip = tooltip
         }
         // .expanded keeps the two-segment "A A" pair visible like Books / Reader,
         // instead of collapsing into a single button + menu when space is tight.
         group.controlRepresentation = .expanded
         if let segmented = group.view as? NSSegmentedControl {
-            segmented.setToolTip("Zoom Out", forSegment: 0)
-            segmented.setToolTip("Zoom In", forSegment: 1)
+            segmented.setToolTip(zoomOut, forSegment: 0)
+            segmented.setToolTip(zoomIn, forSegment: 1)
         }
         return group
     }
@@ -2244,7 +2271,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func inspectorImage() -> NSImage {
         let image = NSImage(systemSymbolName: "info.circle",
-                            accessibilityDescription: "Inspector") ?? NSImage()
+                            accessibilityDescription: NSLocalizedString("Inspector", comment: "Inspector toolbar image")) ?? NSImage()
         image.isTemplate = true
         return image
     }
@@ -2465,9 +2492,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeOpenWithItem() -> NSToolbarItem {
         let item = NSMenuToolbarItem(itemIdentifier: .openWith)
-        item.label = "Open With"
-        item.paletteLabel = "Open With"
-        item.toolTip = "Open in another editor"
+        let openWith = NSLocalizedString("Open With", comment: "Open With toolbar item label")
+        item.label = openWith
+        item.paletteLabel = openWith
+        item.toolTip = NSLocalizedString("Open in another editor", comment: "Open With toolbar item tooltip")
         item.target = self
         item.action = #selector(openWithPrimaryAction(_:))
         item.showsIndicator = true
@@ -2484,10 +2512,13 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func refreshOpenWithItem() {
         let candidates = currentFileURL.map { editorCandidates(for: $0) } ?? []
         let resolvedDefault = resolveDefaultEditor(among: candidates)
-        let openInTitle = resolvedDefault.map { "Open in \(displayName(for: $0.url))" }
-        openWithItem?.label = openInTitle ?? "Open With"
+        let openInTitle = resolvedDefault.map { localizedOpenIn(displayName(for: $0.url)) }
+        openWithItem?.label = openInTitle ?? NSLocalizedString("Open With", comment: "Open With toolbar item label")
         openWithItem?.image = openWithImage(for: resolvedDefault?.url)
-        openWithItem?.toolTip = openInTitle ?? "Open in another editor"
+        openWithItem?.toolTip = openInTitle ?? NSLocalizedString(
+            "Open in another editor",
+            comment: "Open With toolbar item tooltip"
+        )
         openWithItem?.menu = buildOpenWithMenu(candidates: candidates,
                                                defaultEditor: resolvedDefault)
     }
@@ -2499,7 +2530,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             return icon
         }
         return NSImage(systemSymbolName: "highlighter",
-                       accessibilityDescription: "Open With") ?? NSImage()
+                       accessibilityDescription: NSLocalizedString("Open With", comment: "Open With toolbar image")) ?? NSImage()
     }
 
     @objc private func openWithPrimaryAction(_ sender: Any?) {
@@ -2751,7 +2782,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         var items: [NSMenuItem] = []
 
         let externalItem = NSMenuItem(
-            title: "Open with External Editor",
+            title: NSLocalizedString("Open with External Editor", comment: "Context menu item"),
             action: #selector(contextLaunchEditor(_:)),
             keyEquivalent: ""
         )
@@ -2760,16 +2791,20 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         if let defaultEditor {
             externalItem.target = self
             externalItem.representedObject = ContextOpenPayload(fileURL: fileURL, appURL: defaultEditor.url)
-            externalItem.toolTip = "Open in \(displayName(for: defaultEditor.url))"
+            externalItem.toolTip = localizedOpenIn(displayName(for: defaultEditor.url))
         } else {
             externalItem.isEnabled = false
         }
         items.append(externalItem)
 
-        let openAs = NSMenuItem(title: "Open As", action: nil, keyEquivalent: "")
+        let openAs = NSMenuItem(
+            title: NSLocalizedString("Open As", comment: "Context menu submenu"),
+            action: nil,
+            keyEquivalent: ""
+        )
         let submenu = NSMenu()
         if candidates.isEmpty {
-            submenu.addItem(disabledItem("No editors available"))
+            submenu.addItem(disabledItem(NSLocalizedString("No editors available", comment: "Open As empty state")))
         } else {
             for candidate in candidates {
                 let item = NSMenuItem(

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -587,19 +587,19 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         face.image = sidebarFaceImage()
         menu.addItem(face)
 
-        let hide = NSMenuItem(title: "Hide Sidebar",
+        let hide = NSMenuItem(title: NSLocalizedString("Hide Sidebar", comment: "Sidebar dropdown item"),
                               action: #selector(hideSidebarFromMenu(_:)),
                               keyEquivalent: "")
         hide.target = self
         menu.addItem(hide)
 
-        let outline = NSMenuItem(title: "Table of Contents",
+        let outline = NSMenuItem(title: NSLocalizedString("Table of Contents", comment: "Sidebar dropdown item"),
                                  action: #selector(selectOutlineMode(_:)),
                                  keyEquivalent: "")
         outline.target = self
         menu.addItem(outline)
 
-        let files = NSMenuItem(title: "Project Navigator",
+        let files = NSMenuItem(title: NSLocalizedString("Project Navigator", comment: "Sidebar dropdown item"),
                                action: #selector(selectFilesMode(_:)),
                                keyEquivalent: "")
         files.target = self

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -2273,10 +2273,14 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func makeSearchItem() -> NSToolbarItem {
         let item = NSSearchToolbarItem(itemIdentifier: .search)
-        item.label = "Search"
-        item.toolTip = "Search in document"
+        let searchInDocument = NSLocalizedString(
+            "Search in Document",
+            comment: "Toolbar search field tooltip and placeholder"
+        )
+        item.label = NSLocalizedString("Search", comment: "Toolbar search item label")
+        item.toolTip = searchInDocument
         item.preferredWidthForSearchField = 320
-        item.searchField.placeholderString = "Search in Document"
+        item.searchField.placeholderString = searchInDocument
         item.searchField.sendsSearchStringImmediately = true
         item.searchField.target = self
         item.searchField.action = #selector(searchFieldDidChange(_:))

--- a/md-preview/FindBar.swift
+++ b/md-preview/FindBar.swift
@@ -16,12 +16,24 @@ final class FindBar: NSView {
     var onDone: (() -> Void)?
     var onModeChanged: ((SearchMode) -> Void)?
 
-    private let modeLabel = NSTextField(labelWithString: "Match:")
-    private let containsButton = NSButton(title: "Contains", target: nil, action: nil)
-    private let beginsWithButton = NSButton(title: "Begins With", target: nil, action: nil)
+    private let modeLabel = NSTextField(labelWithString: NSLocalizedString("Match:", comment: "Find bar match mode label"))
+    private let containsButton = NSButton(
+        title: NSLocalizedString("Contains", comment: "Find bar match mode"),
+        target: nil,
+        action: nil
+    )
+    private let beginsWithButton = NSButton(
+        title: NSLocalizedString("Begins With", comment: "Find bar match mode"),
+        target: nil,
+        action: nil
+    )
     private let countLabel = NSTextField(labelWithString: "")
     private let navigationControl = NSSegmentedControl()
-    private let doneButton = NSButton(title: "Done", target: nil, action: nil)
+    private let doneButton = NSButton(
+        title: NSLocalizedString("Done", comment: "Find bar close button"),
+        target: nil,
+        action: nil
+    )
     private let bottomSeparator = HairlineSeparator()
 
     private enum NavigationSegment: Int {
@@ -41,9 +53,13 @@ final class FindBar: NSView {
 
     func update(matchCount: Int, currentIndex: Int) {
         if matchCount == 0 {
-            countLabel.stringValue = "Not found"
+            countLabel.stringValue = NSLocalizedString("Not found", comment: "Find bar empty result")
         } else {
-            countLabel.stringValue = "\(currentIndex) of \(matchCount)"
+            countLabel.stringValue = String(
+                format: NSLocalizedString("%d of %d", comment: "Find bar current and total match count"),
+                currentIndex,
+                matchCount
+            )
         }
         let hasMatches = matchCount > 0
         navigationControl.setEnabled(hasMatches, forSegment: NavigationSegment.previous.rawValue)
@@ -128,10 +144,12 @@ final class FindBar: NSView {
     }
 
     private func configureNavigationControl() {
+        let previousMatch = NSLocalizedString("Previous match", comment: "Find bar navigation button")
+        let nextMatch = NSLocalizedString("Next match", comment: "Find bar navigation button")
         let previous = NSImage(systemSymbolName: "chevron.left",
-                               accessibilityDescription: "Previous match") ?? NSImage()
+                               accessibilityDescription: previousMatch) ?? NSImage()
         let next = NSImage(systemSymbolName: "chevron.right",
-                           accessibilityDescription: "Next match") ?? NSImage()
+                           accessibilityDescription: nextMatch) ?? NSImage()
         previous.isTemplate = true
         next.isTemplate = true
 
@@ -140,6 +158,8 @@ final class FindBar: NSView {
         navigationControl.segmentCount = 2
         navigationControl.setImage(previous, forSegment: NavigationSegment.previous.rawValue)
         navigationControl.setImage(next, forSegment: NavigationSegment.next.rawValue)
+        navigationControl.setToolTip(previousMatch, forSegment: NavigationSegment.previous.rawValue)
+        navigationControl.setToolTip(nextMatch, forSegment: NavigationSegment.next.rawValue)
         navigationControl.setImageScaling(.scaleProportionallyDown,
                                           forSegment: NavigationSegment.previous.rawValue)
         navigationControl.setImageScaling(.scaleProportionallyDown,

--- a/md-preview/InspectorView.swift
+++ b/md-preview/InspectorView.swift
@@ -21,7 +21,8 @@ struct DocumentMetadata: Equatable {
 extension DocumentMetadata {
     static func make(url: URL?, markdown: String) -> DocumentMetadata {
         var meta = DocumentMetadata()
-        meta.fileName = url?.lastPathComponent ?? "Untitled"
+        meta.fileName = url?.lastPathComponent
+            ?? NSLocalizedString("Untitled", comment: "Inspector file name when no document is open")
 
         let split = MarkdownFrontmatter.split(markdown)
         if let raw = split.raw {
@@ -57,6 +58,10 @@ struct InspectorView: View {
         case properties = "Properties"
         var id: String { rawValue }
 
+        var localizedTitle: String {
+            NSLocalizedString(rawValue, comment: "Inspector tab title")
+        }
+
         var systemImage: String {
             switch self {
             case .document: return "doc"
@@ -81,10 +86,10 @@ struct InspectorView: View {
     }
 
     private var tabPicker: some View {
-        Picker("Inspector tab", selection: $tab) {
+        Picker(NSLocalizedString("Inspector tab", comment: "Inspector tab picker accessibility label"), selection: $tab) {
             ForEach(Tab.allCases) { tab in
                 Image(systemName: tab.systemImage)
-                    .accessibilityLabel(tab.rawValue)
+                    .accessibilityLabel(tab.localizedTitle)
                     .tag(tab)
             }
         }
@@ -97,28 +102,55 @@ struct InspectorView: View {
     private var documentTab: some View {
         Form {
             Section {
-                LabeledContent("File Name", value: metadata.fileName)
-                LabeledContent("Document Type", value: "Markdown Document")
+                LabeledContent(
+                    NSLocalizedString("File Name", comment: "Inspector field label"),
+                    value: metadata.fileName
+                )
+                LabeledContent(
+                    NSLocalizedString("Document Type", comment: "Inspector field label"),
+                    value: NSLocalizedString("Markdown Document", comment: "Inspector document type")
+                )
                 if let size = metadata.fileSize {
-                    LabeledContent("File Size", value: size.formatted(.byteCount(style: .file)))
+                    LabeledContent(
+                        NSLocalizedString("File Size", comment: "Inspector field label"),
+                        value: size.formatted(.byteCount(style: .file))
+                    )
                 }
             }
 
             Section {
-                LabeledContent("Words", value: metadata.wordCount.formatted())
-                LabeledContent("Characters", value: metadata.characterCount.formatted())
-                LabeledContent("Lines", value: metadata.lineCount.formatted())
+                LabeledContent(
+                    NSLocalizedString("Words", comment: "Inspector field label"),
+                    value: metadata.wordCount.formatted()
+                )
+                LabeledContent(
+                    NSLocalizedString("Characters", comment: "Inspector field label"),
+                    value: metadata.characterCount.formatted()
+                )
+                LabeledContent(
+                    NSLocalizedString("Lines", comment: "Inspector field label"),
+                    value: metadata.lineCount.formatted()
+                )
             }
 
             Section {
-                LabeledContent("Headings", value: metadata.headingCount.formatted())
-                LabeledContent("Links", value: metadata.linkCount.formatted())
-                LabeledContent("Images", value: metadata.imageCount.formatted())
+                LabeledContent(
+                    NSLocalizedString("Headings", comment: "Inspector field label"),
+                    value: metadata.headingCount.formatted()
+                )
+                LabeledContent(
+                    NSLocalizedString("Links", comment: "Inspector field label"),
+                    value: metadata.linkCount.formatted()
+                )
+                LabeledContent(
+                    NSLocalizedString("Images", comment: "Inspector field label"),
+                    value: metadata.imageCount.formatted()
+                )
             }
 
             if let modified = metadata.modifiedDate {
                 Section {
-                    LabeledContent("Modified") {
+                    LabeledContent(NSLocalizedString("Modified", comment: "Inspector field label")) {
                         Text(modified, format: .dateTime.year().month().day().hour().minute())
                     }
                 }
@@ -130,7 +162,7 @@ struct InspectorView: View {
     @ViewBuilder
     private var propertiesTab: some View {
         if metadata.frontmatter.isEmpty {
-            Text("No frontmatter")
+            Text(NSLocalizedString("No frontmatter", comment: "Inspector empty frontmatter message"))
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -492,8 +492,12 @@ nonisolated enum MarkdownHTML {
         for reference in footnotes.references {
             let refID = footnoteReferenceID(number: reference.number, ordinal: reference.ordinal)
             let footnoteID = footnoteDefinitionID(number: reference.number)
+            let accessibilityLabel = htmlEscape(String(
+                format: NSLocalizedString("Footnote %d", comment: "Footnote accessibility label"),
+                reference.number
+            ))
             let replacement = """
-            <sup class="footnote-ref"><a id="\(refID)" href="#\(footnoteID)" aria-label="Footnote \(reference.number)">\(reference.number)</a></sup>
+            <sup class="footnote-ref"><a id="\(refID)" href="#\(footnoteID)" aria-label="\(accessibilityLabel)">\(reference.number)</a></sup>
             """
             rendered = rendered.replacingOccurrences(of: reference.token, with: replacement)
         }
@@ -523,8 +527,15 @@ nonisolated enum MarkdownHTML {
             containsMath = containsMath || renderedContent.containsMath
             containsMermaid = containsMermaid || renderedContent.containsMermaid
             let backrefs = (referencesByNumber[definition.number] ?? []).map { reference in
-                """
-                <a href="#\(footnoteReferenceID(number: reference.number, ordinal: reference.ordinal))" class="footnote-backref" aria-label="Back to reference \(reference.number)">&#8617;</a>
+                let accessibilityLabel = htmlEscape(String(
+                    format: NSLocalizedString(
+                        "Back to reference %d",
+                        comment: "Footnote back-reference accessibility label"
+                    ),
+                    reference.number
+                ))
+                return """
+                <a href="#\(footnoteReferenceID(number: reference.number, ordinal: reference.ordinal))" class="footnote-backref" aria-label="\(accessibilityLabel)">&#8617;</a>
                 """
             }.joined(separator: " ")
             let contentHTML = appendFootnoteBackrefs(backrefs, to: renderedContent.html)
@@ -845,6 +856,12 @@ nonisolated enum MarkdownHTML {
     private static let hostBridgeScript: String = """
     <script>
     (() => {
+        const localized = {
+            copy: \(javaScriptStringLiteral(NSLocalizedString("Copy", comment: "Code block copy button"))),
+            copied: \(javaScriptStringLiteral(NSLocalizedString("Copied", comment: "Code block copy confirmation"))),
+            copyCode: \(javaScriptStringLiteral(NSLocalizedString("Copy code", comment: "Code block copy button accessibility label"))),
+            codeCopied: \(javaScriptStringLiteral(NSLocalizedString("Code copied", comment: "Code block copy confirmation accessibility label")))
+        };
         let hasHostBridge = false;
         const post = (() => {
             try {
@@ -974,7 +991,8 @@ nonisolated enum MarkdownHTML {
                 const button = document.createElement('button');
                 button.type = 'button';
                 button.className = 'md-code-copy';
-                button.setAttribute('aria-label', 'Copy code');
+                button.textContent = localized.copy;
+                button.setAttribute('aria-label', localized.copyCode);
                 wrap.appendChild(button);
             });
         }
@@ -1018,11 +1036,13 @@ nonisolated enum MarkdownHTML {
                 } catch (e) {}
             }
             if (!copied) return;
-            button.setAttribute('aria-label', 'Code copied');
+            button.textContent = localized.copied;
+            button.setAttribute('aria-label', localized.codeCopied);
             button.classList.add('is-copied');
             clearTimeout(button.__mdCopyTimer);
             button.__mdCopyTimer = setTimeout(() => {
-                button.setAttribute('aria-label', 'Copy code');
+                button.textContent = localized.copy;
+                button.setAttribute('aria-label', localized.copyCode);
                 button.classList.remove('is-copied');
             }, 1100);
         }
@@ -1586,7 +1606,12 @@ nonisolated enum MarkdownHTML {
     window.addEventListener('load', () => {
         document.querySelectorAll('.math').forEach((node) => {
             node.classList.add('math-error');
-            node.textContent = 'KaTeX renderer is unavailable.\\n\\n' + node.textContent;
+            node.textContent = \(javaScriptStringLiteral(
+                NSLocalizedString(
+                    "KaTeX renderer is unavailable.\n\n",
+                    comment: "Math rendering error"
+                )
+            )) + node.textContent;
         });
     });
     </script>
@@ -1759,6 +1784,14 @@ nonisolated enum MarkdownHTML {
         return out
     }
 
+    private static func javaScriptStringLiteral(_ string: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [string]),
+              let json = String(data: data, encoding: .utf8) else {
+            return "\"\""
+        }
+        return String(json.dropFirst().dropLast())
+    }
+
     // MARK: - Code highlighting (highlight.js)
 
     // Excludes `language-mermaid` since renderMermaidBlocks already lifted
@@ -1888,6 +1921,11 @@ nonisolated enum MarkdownHTML {
         var rendered = ""
         rendered.reserveCapacity(html.count)
         var cursor = 0
+        let diagramLabel = htmlEscape(NSLocalizedString("Mermaid diagram", comment: "Mermaid diagram accessibility label"))
+        let zoomOut = htmlEscape(NSLocalizedString("Zoom Out", comment: "Mermaid diagram control"))
+        let resetZoom = htmlEscape(NSLocalizedString("Reset zoom", comment: "Mermaid diagram control"))
+        let zoomIn = htmlEscape(NSLocalizedString("Zoom In", comment: "Mermaid diagram control"))
+        let fillWidth = htmlEscape(NSLocalizedString("Fill width", comment: "Mermaid diagram control"))
         for match in matches {
             rendered += nsHTML.substring(with: NSRange(
                 location: cursor,
@@ -1896,15 +1934,15 @@ nonisolated enum MarkdownHTML {
             let sourceAttributes = nsHTML.substring(with: match.range(at: 1))
             let diagram = nsHTML.substring(with: match.range(at: 2))
             rendered += """
-            <figure\(sourceAttributes) class="mermaid-figure" tabindex="0" role="img" aria-label="Mermaid diagram">
+            <figure\(sourceAttributes) class="mermaid-figure" tabindex="0" role="img" aria-label="\(diagramLabel)">
             <div class="mermaid-stage"><div class="mermaid">
             \(diagram)
             </div></div>
             <div class="mermaid-hud" aria-hidden="true">
-            <button type="button" class="mermaid-hud-btn" data-mm-act="out" tabindex="-1" aria-label="Zoom out">−</button>
-            <button type="button" class="mermaid-hud-btn mermaid-hud-level" data-mm-act="reset" tabindex="-1" aria-label="Reset zoom">100%</button>
-            <button type="button" class="mermaid-hud-btn" data-mm-act="in" tabindex="-1" aria-label="Zoom in">+</button>
-            <button type="button" class="mermaid-hud-btn mermaid-hud-width" data-mm-act="width" tabindex="-1" aria-label="Fill width" aria-pressed="false" title="Fill width">⤢</button>
+            <button type="button" class="mermaid-hud-btn" data-mm-act="out" tabindex="-1" aria-label="\(zoomOut)">−</button>
+            <button type="button" class="mermaid-hud-btn mermaid-hud-level" data-mm-act="reset" tabindex="-1" aria-label="\(resetZoom)">100%</button>
+            <button type="button" class="mermaid-hud-btn" data-mm-act="in" tabindex="-1" aria-label="\(zoomIn)">+</button>
+            <button type="button" class="mermaid-hud-btn mermaid-hud-width" data-mm-act="width" tabindex="-1" aria-label="\(fillWidth)" aria-pressed="false" title="\(fillWidth)">⤢</button>
             </div>
             </figure>
             """
@@ -1919,7 +1957,12 @@ nonisolated enum MarkdownHTML {
     window.addEventListener('load', () => {
         document.querySelectorAll('.mermaid').forEach((node) => {
             node.classList.add('mermaid-error');
-            node.textContent = 'Mermaid renderer is unavailable.\\n\\n' + node.textContent;
+            node.textContent = \(javaScriptStringLiteral(
+                NSLocalizedString(
+                    "Mermaid renderer is unavailable.\n\n",
+                    comment: "Mermaid rendering error"
+                )
+            )) + node.textContent;
         });
     });
     </script>
@@ -1931,6 +1974,12 @@ nonisolated enum MarkdownHTML {
     /// scripts run before DOMContentLoaded.
     private static let mermaidInitWiring = """
     (() => {
+            const fillWidthLabel = \(javaScriptStringLiteral(
+                NSLocalizedString("Fill width", comment: "Mermaid diagram control")
+            ));
+            const fitDiagramLabel = \(javaScriptStringLiteral(
+                NSLocalizedString("Fit diagram", comment: "Mermaid diagram control")
+            ));
             const states = new WeakMap();
             const queue = [];
             let draining = false;
@@ -2068,7 +2117,7 @@ nonisolated enum MarkdownHTML {
                 const expanded = figure.classList.toggle('mermaid-width-expanded');
                 const btn = figure.querySelector('[data-mm-act="width"]');
                 if (btn) {
-                    const label = expanded ? 'Fit diagram' : 'Fill width';
+                    const label = expanded ? fitDiagramLabel : fillWidthLabel;
                     btn.textContent = expanded ? '⤡' : '⤢';
                     btn.setAttribute('aria-label', label);
                     btn.setAttribute('aria-pressed', String(expanded));
@@ -2478,12 +2527,6 @@ nonisolated enum MarkdownHTML {
         user-select: none;
         -webkit-user-select: none;
         z-index: 2;
-    }
-    .md-code-copy::after {
-        content: "Copy";
-    }
-    .md-code-copy.is-copied::after {
-        content: "Copied";
     }
     .md-code-wrap:hover .md-code-copy,
     .md-code-wrap:focus-within .md-code-copy,

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -146,8 +146,8 @@ enum ContentWidthSetting: String, CaseIterable {
 
     var title: String {
         switch self {
-        case .normal: return "Normal"
-        case .fullWidth: return "Full Width"
+        case .normal: return NSLocalizedString("Normal", comment: "Content width")
+        case .fullWidth: return NSLocalizedString("Full Width", comment: "Content width")
         }
     }
 

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -28,14 +28,22 @@ final class TableContextMenuPresenter: NSObject {
     }
 
     func present(in view: NSView) {
-        let menu = NSMenu(title: "Table")
+        let menu = NSMenu(title: NSLocalizedString("Table", comment: "Table context menu title"))
         menu.autoenablesItems = false
 
-        let rowItem = NSMenuItem(title: "Row", action: nil, keyEquivalent: "")
+        let rowItem = NSMenuItem(
+            title: NSLocalizedString("Row", comment: "Table context menu submenu"),
+            action: nil,
+            keyEquivalent: ""
+        )
         rowItem.submenu = rowMenu()
         menu.addItem(rowItem)
 
-        let columnItem = NSMenuItem(title: "Column", action: nil, keyEquivalent: "")
+        let columnItem = NSMenuItem(
+            title: NSLocalizedString("Column", comment: "Table context menu submenu"),
+            action: nil,
+            keyEquivalent: ""
+        )
         columnItem.submenu = columnMenu()
         menu.addItem(columnItem)
 
@@ -46,35 +54,35 @@ final class TableContextMenuPresenter: NSObject {
     }
 
     private func rowMenu() -> NSMenu {
-        let menu = NSMenu(title: "Row")
+        let menu = NSMenu(title: NSLocalizedString("Row", comment: "Table row context menu title"))
         menu.autoenablesItems = false
-        menu.addItem(command("Select Row", operation: "selectRow",
+        menu.addItem(command(NSLocalizedString("Select Row", comment: "Table context menu item"), operation: "selectRow",
                              enabled: context.canDeleteRow))
         menu.addItem(.separator())
-        menu.addItem(command("Add Row Above", operation: "insertRowBefore",
+        menu.addItem(command(NSLocalizedString("Add Row Above", comment: "Table context menu item"), operation: "insertRowBefore",
                              enabled: context.canInsertRowAbove))
-        menu.addItem(command("Add Row Below", operation: "insertRowAfter"))
+        menu.addItem(command(NSLocalizedString("Add Row Below", comment: "Table context menu item"), operation: "insertRowAfter"))
         if context.showsDuplicateRow {
             menu.addItem(.separator())
-            menu.addItem(command("Duplicate Row", operation: "duplicateRow",
+            menu.addItem(command(NSLocalizedString("Duplicate Row", comment: "Table context menu item"), operation: "duplicateRow",
                                  enabled: context.canDuplicateRow))
         }
         menu.addItem(.separator())
-        menu.addItem(command("Delete Row", operation: "deleteRow",
+        menu.addItem(command(NSLocalizedString("Delete Row", comment: "Table context menu item"), operation: "deleteRow",
                              enabled: context.canDeleteRow))
         return menu
     }
 
     private func columnMenu() -> NSMenu {
-        let menu = NSMenu(title: "Column")
+        let menu = NSMenu(title: NSLocalizedString("Column", comment: "Table column context menu title"))
         menu.autoenablesItems = false
-        menu.addItem(command("Select Column", operation: "selectColumn",
+        menu.addItem(command(NSLocalizedString("Select Column", comment: "Table context menu item"), operation: "selectColumn",
                              enabled: context.canDeleteColumn))
         menu.addItem(.separator())
-        menu.addItem(command("Add Column Left", operation: "insertColumnBefore"))
-        menu.addItem(command("Add Column Right", operation: "insertColumnAfter"))
+        menu.addItem(command(NSLocalizedString("Add Column Left", comment: "Table context menu item"), operation: "insertColumnBefore"))
+        menu.addItem(command(NSLocalizedString("Add Column Right", comment: "Table context menu item"), operation: "insertColumnAfter"))
         menu.addItem(.separator())
-        menu.addItem(command("Delete Column", operation: "deleteColumn",
+        menu.addItem(command(NSLocalizedString("Delete Column", comment: "Table context menu item"), operation: "deleteColumn",
                              enabled: context.canDeleteColumn))
         return menu
     }

--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -680,18 +680,18 @@ extension ProjectNavigatorView: NSMenuDelegate {
         guard row >= 0, let node = outlineView.item(atRow: row) as? FileNode else { return }
         let url = node.url
 
-        menu.addItem(makeMenuItem(title: "Show in Finder",
+        menu.addItem(makeMenuItem(title: NSLocalizedString("Show in Finder", comment: "Project navigator context menu"),
                                   symbol: "folder",
                                   action: #selector(showInFinder(_:)),
                                   url: url))
 
         if !node.isDirectory {
             menu.addItem(.separator())
-            menu.addItem(makeMenuItem(title: "Open in New Tab",
+            menu.addItem(makeMenuItem(title: NSLocalizedString("Open in New Tab", comment: "Project navigator context menu"),
                                       symbol: "macwindow",
                                       action: #selector(openInNewTab(_:)),
                                       url: url))
-            menu.addItem(makeMenuItem(title: "Open in New Window",
+            menu.addItem(makeMenuItem(title: NSLocalizedString("Open in New Window", comment: "Project navigator context menu"),
                                       symbol: "macwindow.badge.plus",
                                       action: #selector(openInNewWindow(_:)),
                                       url: url))
@@ -701,7 +701,7 @@ extension ProjectNavigatorView: NSMenuDelegate {
                 }
             }
             menu.addItem(.separator())
-            menu.addItem(makeMenuItem(title: "Copy",
+            menu.addItem(makeMenuItem(title: NSLocalizedString("Copy", comment: "Project navigator context menu"),
                                       symbol: "document.on.clipboard",
                                       action: #selector(copyContents(_:)),
                                       url: url))
@@ -709,7 +709,7 @@ extension ProjectNavigatorView: NSMenuDelegate {
             menu.addItem(.separator())
         }
 
-        menu.addItem(makeMenuItem(title: "Copy Path",
+        menu.addItem(makeMenuItem(title: NSLocalizedString("Copy Path", comment: "Project navigator context menu"),
                                   symbol: "document.on.document",
                                   action: #selector(copyPath(_:)),
                                   url: url))

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -50,3 +50,54 @@
 /* Search toolbar */
 "Search" = "Search";
 "Search in Document" = "Search in Document";
+
+/* Main toolbar */
+"Navigation" = "Navigation";
+"Back and Forward" = "Back and Forward";
+"Back" = "Back";
+"Forward" = "Forward";
+"Sidebar" = "Sidebar";
+"Sidebar options" = "Sidebar options";
+"Inspector" = "Inspector";
+"Get Info" = "Get Info";
+"Show the inspector" = "Show the inspector";
+"Share" = "Share";
+"Share document" = "Share document";
+"Print" = "Print";
+"Print document" = "Print document";
+"Copy" = "Copy";
+"Copy Markdown source to clipboard" = "Copy Markdown source to clipboard";
+"Copied" = "Copied";
+"Edit" = "Edit";
+"Edit document" = "Edit document";
+"Stop editing and return to preview" = "Stop editing and return to preview";
+"Open" = "Open";
+"Open document in another app" = "Open document in another app";
+"Open in %@" = "Open in %@";
+"Open in LLM" = "Open in LLM";
+"Open document in an LLM app" = "Open document in an LLM app";
+"Zoom" = "Zoom";
+"Zoom Out" = "Zoom Out";
+"Zoom In" = "Zoom In";
+"Open With" = "Open With";
+"Open in another editor" = "Open in another editor";
+
+/* Formatting toolbar */
+"Task List" = "Task List";
+"Normal Text" = "Normal Text";
+"Heading %d" = "Heading %d";
+
+/* Find bar */
+"Match:" = "Match:";
+"Contains" = "Contains";
+"Begins With" = "Begins With";
+"Done" = "Done";
+"Not found" = "Not found";
+"%d of %d" = "%d of %d";
+"Previous match" = "Previous match";
+"Next match" = "Next match";
+
+/* Open With context menu */
+"Open with External Editor" = "Open with External Editor";
+"Open As" = "Open As";
+"No editors available" = "No editors available";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -1,0 +1,48 @@
+/* App menu */
+"Install CLI..." = "Install CLI...";
+
+/* View menu */
+"Appearance" = "Appearance";
+"Automatic" = "Automatic";
+"Light" = "Light";
+"Dark" = "Dark";
+"Content Width" = "Content Width";
+"Normal" = "Normal";
+"Full Width" = "Full Width";
+"Hide Sidebar" = "Hide Sidebar";
+"Table of Contents" = "Table of Contents";
+"Project Navigator" = "Project Navigator";
+"Toggle Edit Mode" = "Toggle Edit Mode";
+
+/* File menu */
+"New Tab" = "New Tab";
+
+/* Go menu */
+"Go" = "Go";
+"Up" = "Up";
+"Down" = "Down";
+"Page Up" = "Page Up";
+"Page Down" = "Page Down";
+"Previous Item" = "Previous Item";
+"Next Item" = "Next Item";
+"Top of Document" = "Top of Document";
+"Bottom of Document" = "Bottom of Document";
+
+/* Format menu */
+"Format" = "Format";
+"Body" = "Body";
+"Heading 1" = "Heading 1";
+"Heading 2" = "Heading 2";
+"Heading 3" = "Heading 3";
+"Bold" = "Bold";
+"Italic" = "Italic";
+"Strikethrough" = "Strikethrough";
+"Inline Code" = "Inline Code";
+"Link" = "Link";
+"Bulleted List" = "Bulleted List";
+"Numbered List" = "Numbered List";
+"Checklist" = "Checklist";
+"Block Quote" = "Block Quote";
+
+/* Open panel */
+"Choose a Markdown file or folder" = "Choose a Markdown file or folder";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -119,3 +119,75 @@
 "Modified" = "Modified";
 "No frontmatter" = "No frontmatter";
 "Untitled" = "Untitled";
+
+/* Document state and save dialogs */
+"Edited" = "Edited";
+"Do you want to save your changes?" = "Do you want to save your changes?";
+"this document" = "this document";
+"Your changes to %@ will be lost if you don’t save them." = "Your changes to %@ will be lost if you don’t save them.";
+"Save" = "Save";
+"Cancel" = "Cancel";
+"Don’t Save" = "Don’t Save";
+"The file was removed while it was open." = "The file was removed while it was open.";
+"Recreate File" = "Recreate File";
+"The file could not be read to verify that it is unchanged." = "The file could not be read to verify that it is unchanged.";
+"Save Anyway" = "Save Anyway";
+"This document changed on disk" = "This document changed on disk";
+"Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep." = "Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep.";
+"Keep My Changes" = "Keep My Changes";
+"Reload from Disk" = "Reload from Disk";
+"Unable to verify the document on disk" = "Unable to verify the document on disk";
+"%@ Cancel keeps your changes unsaved." = "%@ Cancel keeps your changes unsaved.";
+"Markdown Preview needs your permission to save this file." = "Markdown Preview needs your permission to save this file.";
+
+/* Open menus */
+"No document open" = "No document open";
+"No apps available" = "No apps available";
+"Editors" = "Editors";
+"AI Apps" = "AI Apps";
+"No LLM apps available" = "No LLM apps available";
+"Open in LLM…" = "Open in LLM…";
+"Open with…" = "Open with…";
+
+/* Project navigator context menu */
+"Show in Finder" = "Show in Finder";
+"Open in New Tab" = "Open in New Tab";
+"Open in New Window" = "Open in New Window";
+"Copy Path" = "Copy Path";
+
+/* Table editing */
+"Table" = "Table";
+"Row" = "Row";
+"Column" = "Column";
+"Select Row" = "Select Row";
+"Add Row Above" = "Add Row Above";
+"Add Row Below" = "Add Row Below";
+"Duplicate Row" = "Duplicate Row";
+"Delete Row" = "Delete Row";
+"Select Column" = "Select Column";
+"Add Column Left" = "Add Column Left";
+"Add Column Right" = "Add Column Right";
+"Delete Column" = "Delete Column";
+"Edit Table Cell" = "Edit Table Cell";
+"Add Row" = "Add Row";
+"Add Column" = "Add Column";
+"Edit Table" = "Edit Table";
+
+/* Rendered preview controls */
+"Heading" = "Heading";
+"Copy code" = "Copy code";
+"Code copied" = "Code copied";
+"Mermaid diagram" = "Mermaid diagram";
+"Reset zoom" = "Reset zoom";
+"Fill width" = "Fill width";
+"Fit diagram" = "Fit diagram";
+"Mermaid renderer is unavailable.\n\n" = "Mermaid renderer is unavailable.\n\n";
+"Footnote %d" = "Footnote %d";
+"Back to reference %d" = "Back to reference %d";
+"KaTeX renderer is unavailable.\n\n" = "KaTeX renderer is unavailable.\n\n";
+
+/* CLI installer errors */
+"Terminal automation failed: %@" = "Terminal automation failed: %@";
+"Terminal automation failed." = "Terminal automation failed.";
+"Failed to write CLI installer script: %@" = "Failed to write CLI installer script: %@";
+"The bundled Markdown Preview CLI could not be found." = "The bundled Markdown Preview CLI could not be found.";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -101,3 +101,21 @@
 "Open with External Editor" = "Open with External Editor";
 "Open As" = "Open As";
 "No editors available" = "No editors available";
+
+/* Inspector */
+"Inspector tab" = "Inspector tab";
+"Document" = "Document";
+"Properties" = "Properties";
+"File Name" = "File Name";
+"Document Type" = "Document Type";
+"Markdown Document" = "Markdown Document";
+"File Size" = "File Size";
+"Words" = "Words";
+"Characters" = "Characters";
+"Lines" = "Lines";
+"Headings" = "Headings";
+"Links" = "Links";
+"Images" = "Images";
+"Modified" = "Modified";
+"No frontmatter" = "No frontmatter";
+"Untitled" = "Untitled";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -46,3 +46,7 @@
 
 /* Open panel */
 "Choose a Markdown file or folder" = "Choose a Markdown file or folder";
+
+/* Search toolbar */
+"Search" = "Search";
+"Search in Document" = "Search in Document";

--- a/md-preview/en.lproj/MainMenu.strings
+++ b/md-preview/en.lproj/MainMenu.strings
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>1UK-8n-QPP.title</key>
+	<string>Customize Toolbar…</string>
+	<key>1Xt-HY-uBw.title</key>
+	<string>Markdown Preview</string>
+	<key>1b7-l0-nxx.title</key>
+	<string>Find</string>
+	<key>2oI-Rn-ZJC.title</key>
+	<string>Transformations</string>
+	<key>3IN-sU-3Bg.title</key>
+	<string>Spelling</string>
+	<key>3rS-ZA-NoH.title</key>
+	<string>Speech</string>
+	<key>4EN-yA-p0u.title</key>
+	<string>Find</string>
+	<key>4J7-dP-txa.title</key>
+	<string>Enter Full Screen</string>
+	<key>4sb-4s-VLi.title</key>
+	<string>Quit Markdown Preview</string>
+	<key>5QF-Oa-p0T.title</key>
+	<string>Edit</string>
+	<key>5kV-Vb-QxS.title</key>
+	<string>About Markdown Preview</string>
+	<key>6dh-zS-Vam.title</key>
+	<string>Redo</string>
+	<key>78Y-hA-62v.title</key>
+	<string>Correct Spelling Automatically</string>
+	<key>9ic-FL-obx.title</key>
+	<string>Substitutions</string>
+	<key>9yt-4B-nSM.title</key>
+	<string>Smart Copy/Paste</string>
+	<key>AYu-sK-qS6.title</key>
+	<string>Main Menu</string>
+	<key>BOF-NM-1cW.title</key>
+	<string>Send Anonymous Crash Reports</string>
+	<key>Bw7-FT-i3A.title</key>
+	<string>Save As…</string>
+	<key>DVo-aG-piG.title</key>
+	<string>Close</string>
+	<key>Dv1-io-Yv7.title</key>
+	<string>Spelling and Grammar</string>
+	<key>F2S-fz-NVQ.title</key>
+	<string>Help</string>
+	<key>FKE-Sm-Kum.title</key>
+	<string>Markdown Preview Help</string>
+	<key>FeM-D8-WVr.title</key>
+	<string>Substitutions</string>
+	<key>H8h-7b-M4v.title</key>
+	<string>View</string>
+	<key>HFQ-gK-NFA.title</key>
+	<string>Text Replacement</string>
+	<key>HFo-cy-zxI.title</key>
+	<string>Show Spelling and Grammar</string>
+	<key>HyV-fh-RgO.title</key>
+	<string>View</string>
+	<key>IAo-SY-fd9.title</key>
+	<string>Open…</string>
+	<key>KaW-ft-85H.title</key>
+	<string>Revert to Saved</string>
+	<key>Kd2-mp-pUS.title</key>
+	<string>Show All</string>
+	<key>LE2-aR-0XJ.title</key>
+	<string>Bring All to Front</string>
+	<key>NMo-om-nkz.title</key>
+	<string>Services</string>
+	<key>OY7-WF-poV.title</key>
+	<string>Minimize</string>
+	<key>Olw-nP-bQN.title</key>
+	<string>Hide Markdown Preview</string>
+	<key>OwM-mh-QMV.title</key>
+	<string>Find Previous</string>
+	<key>Oyz-dy-DGm.title</key>
+	<string>Stop Speaking</string>
+	<key>R4o-n2-Eq4.title</key>
+	<string>Zoom</string>
+	<key>Ruw-6m-B2m.title</key>
+	<string>Select All</string>
+	<key>S0p-oC-mLd.title</key>
+	<string>Jump to Selection</string>
+	<key>Td7-aD-5lo.title</key>
+	<string>Window</string>
+	<key>UEZ-Bs-lqG.title</key>
+	<string>Capitalize</string>
+	<key>Vdr-fp-XzO.title</key>
+	<string>Hide Others</string>
+	<key>W48-6f-4Dl.title</key>
+	<string>Edit</string>
+	<key>Was-JA-tGl.title</key>
+	<string>New</string>
+	<key>WeT-3V-zwk.title</key>
+	<string>Paste and Match Style</string>
+	<key>Xz5-n4-O0W.title</key>
+	<string>Find…</string>
+	<key>YEy-JH-Tfz.title</key>
+	<string>Find and Replace…</string>
+	<key>Ynk-f8-cLZ.title</key>
+	<string>Start Speaking</string>
+	<key>aTl-1u-JFS.title</key>
+	<string>Print…</string>
+	<key>aUF-d1-5bR.title</key>
+	<string>Window</string>
+	<key>bib-Uj-vzu.title</key>
+	<string>File</string>
+	<key>buJ-ug-pKt.title</key>
+	<string>Use Selection for Find</string>
+	<key>c8a-y6-VQd.title</key>
+	<string>Transformations</string>
+	<key>cwL-P1-jid.title</key>
+	<string>Smart Links</string>
+	<key>d9M-CD-aMd.title</key>
+	<string>Make Lower Case</string>
+	<key>dMs-cI-mzQ.title</key>
+	<string>File</string>
+	<key>dRJ-4n-Yzg.title</key>
+	<string>Undo</string>
+	<key>gVA-U4-sdL.title</key>
+	<string>Paste</string>
+	<key>hQb-2v-fYv.title</key>
+	<string>Smart Quotes</string>
+	<key>hz2-CU-CR7.title</key>
+	<string>Check Document Now</string>
+	<key>hz9-B4-Xy5.title</key>
+	<string>Services</string>
+	<key>kIP-vf-haE.title</key>
+	<string>Show Sidebar</string>
+	<key>mK6-2p-4JG.title</key>
+	<string>Check Grammar With Spelling</string>
+	<key>mdp-zi-itm.title</key>
+	<string>Zoom In</string>
+	<key>mdp-zo-itm.title</key>
+	<string>Zoom Out</string>
+	<key>mdp-zr-itm.title</key>
+	<string>Actual Size</string>
+	<key>oas-Oc-fiZ.title</key>
+	<string>Open Recent</string>
+	<key>pa3-QI-u2k.title</key>
+	<string>Delete</string>
+	<key>pxx-59-PXV.title</key>
+	<string>Save…</string>
+	<key>q09-fT-Sye.title</key>
+	<string>Find Next</string>
+	<key>qIS-W8-SiK.title</key>
+	<string>Page Setup…</string>
+	<key>rbD-Rh-wIN.title</key>
+	<string>Check Spelling While Typing</string>
+	<key>rgM-f4-ycn.title</key>
+	<string>Smart Dashes</string>
+	<key>snW-S8-Cw5.title</key>
+	<string>Show Toolbar</string>
+	<key>spk-cu-itm.title</key>
+	<string>Check for Updates…</string>
+	<key>tRr-pd-1PS.title</key>
+	<string>Data Detectors</string>
+	<key>tXI-mr-wws.title</key>
+	<string>Open Recent</string>
+	<key>uQy-DD-JDr.title</key>
+	<string>Markdown Preview</string>
+	<key>uRl-iY-unG.title</key>
+	<string>Cut</string>
+	<key>vNY-rz-j42.title</key>
+	<string>Clear Menu</string>
+	<key>vmV-6d-7jI.title</key>
+	<string>Make Upper Case</string>
+	<key>wpr-3q-Mcd.title</key>
+	<string>Help</string>
+	<key>x3v-GG-iWU.title</key>
+	<string>Copy</string>
+	<key>xrE-MZ-jX0.title</key>
+	<string>Speech</string>
+	<key>z6F-FW-3nz.title</key>
+	<string>Show Substitutions</string>
+</dict>
+</plist>

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -50,3 +50,54 @@
 /* Search toolbar */
 "Search" = "搜索";
 "Search in Document" = "在文稿中搜索";
+
+/* Main toolbar */
+"Navigation" = "导航";
+"Back and Forward" = "后退与前进";
+"Back" = "后退";
+"Forward" = "前进";
+"Sidebar" = "边栏";
+"Sidebar options" = "边栏选项";
+"Inspector" = "检查器";
+"Get Info" = "显示简介";
+"Show the inspector" = "显示检查器";
+"Share" = "共享";
+"Share document" = "共享文稿";
+"Print" = "打印";
+"Print document" = "打印文稿";
+"Copy" = "拷贝";
+"Copy Markdown source to clipboard" = "将 Markdown 源文本拷贝到剪贴板";
+"Copied" = "已拷贝";
+"Edit" = "编辑";
+"Edit document" = "编辑文稿";
+"Stop editing and return to preview" = "停止编辑并返回预览";
+"Open" = "打开";
+"Open document in another app" = "在其他 App 中打开文稿";
+"Open in %@" = "在 %@ 中打开";
+"Open in LLM" = "在 LLM 中打开";
+"Open document in an LLM app" = "在 LLM App 中打开文稿";
+"Zoom" = "缩放";
+"Zoom Out" = "缩小";
+"Zoom In" = "放大";
+"Open With" = "打开方式";
+"Open in another editor" = "在其他编辑器中打开";
+
+/* Formatting toolbar */
+"Task List" = "任务列表";
+"Normal Text" = "普通文本";
+"Heading %d" = "标题 %d";
+
+/* Find bar */
+"Match:" = "匹配：";
+"Contains" = "包含";
+"Begins With" = "开头为";
+"Done" = "完成";
+"Not found" = "未找到";
+"%d of %d" = "第 %1$d 个，共 %2$d 个";
+"Previous match" = "上一个匹配项";
+"Next match" = "下一个匹配项";
+
+/* Open With context menu */
+"Open with External Editor" = "使用外部编辑器打开";
+"Open As" = "打开为";
+"No editors available" = "没有可用的编辑器";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,48 @@
+/* App menu */
+"Install CLI..." = "安装命令行工具…";
+
+/* View menu */
+"Appearance" = "外观";
+"Automatic" = "自动";
+"Light" = "浅色";
+"Dark" = "深色";
+"Content Width" = "内容宽度";
+"Normal" = "标准";
+"Full Width" = "全宽";
+"Hide Sidebar" = "隐藏边栏";
+"Table of Contents" = "目录";
+"Project Navigator" = "项目导航";
+"Toggle Edit Mode" = "切换编辑模式";
+
+/* File menu */
+"New Tab" = "新建标签页";
+
+/* Go menu */
+"Go" = "前往";
+"Up" = "向上";
+"Down" = "向下";
+"Page Up" = "上一页";
+"Page Down" = "下一页";
+"Previous Item" = "上一项";
+"Next Item" = "下一项";
+"Top of Document" = "文稿开头";
+"Bottom of Document" = "文稿结尾";
+
+/* Format menu */
+"Format" = "格式";
+"Body" = "正文";
+"Heading 1" = "标题 1";
+"Heading 2" = "标题 2";
+"Heading 3" = "标题 3";
+"Bold" = "粗体";
+"Italic" = "斜体";
+"Strikethrough" = "删除线";
+"Inline Code" = "行内代码";
+"Link" = "链接";
+"Bulleted List" = "项目符号列表";
+"Numbered List" = "编号列表";
+"Checklist" = "核对清单";
+"Block Quote" = "引用";
+
+/* Open panel */
+"Choose a Markdown file or folder" = "选择 Markdown 文件或文件夹";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 "Full Width" = "全宽";
 "Hide Sidebar" = "隐藏边栏";
 "Table of Contents" = "目录";
-"Project Navigator" = "项目导航";
+"Project Navigator" = "项目导航器";
 "Toggle Edit Mode" = "切换编辑模式";
 
 /* File menu */
@@ -41,7 +41,7 @@
 "Link" = "链接";
 "Bulleted List" = "项目符号列表";
 "Numbered List" = "编号列表";
-"Checklist" = "核对清单";
+"Checklist" = "任务列表";
 "Block Quote" = "引用";
 
 /* Open panel */
@@ -84,7 +84,7 @@
 
 /* Formatting toolbar */
 "Task List" = "任务列表";
-"Normal Text" = "普通文本";
+"Normal Text" = "正文";
 "Heading %d" = "标题 %d";
 
 /* Find bar */
@@ -99,18 +99,18 @@
 
 /* Open With context menu */
 "Open with External Editor" = "使用外部编辑器打开";
-"Open As" = "打开为";
+"Open As" = "打开方式";
 "No editors available" = "没有可用的编辑器";
 
 /* Inspector */
 "Inspector tab" = "检查器标签页";
 "Document" = "文稿";
 "Properties" = "属性";
-"File Name" = "文件名称";
+"File Name" = "文件名";
 "Document Type" = "文稿类型";
 "Markdown Document" = "Markdown 文稿";
 "File Size" = "文件大小";
-"Words" = "字数";
+"Words" = "单词数";
 "Characters" = "字符数";
 "Lines" = "行数";
 "Headings" = "标题";
@@ -130,14 +130,14 @@
 "Don’t Save" = "不存储";
 "The file was removed while it was open." = "文件在打开期间被移除。";
 "Recreate File" = "重新创建文件";
-"The file could not be read to verify that it is unchanged." = "无法读取文件以验证其未被更改。";
+"The file could not be read to verify that it is unchanged." = "无法读取文件，因此无法确认文件是否已更改。";
 "Save Anyway" = "仍要存储";
-"This document changed on disk" = "此文稿已在磁盘上更改";
-"Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep." = "另一个 App 更改了 %@。取消可保留未存储的更改。请选择要保留的版本。";
+"This document changed on disk" = "磁盘上的文稿已被更改";
+"Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep." = "另一个 App 已更改 %@。选择“取消”会保留您的未存储更改。请选择要保留的版本。";
 "Keep My Changes" = "保留我的更改";
 "Reload from Disk" = "从磁盘重新载入";
 "Unable to verify the document on disk" = "无法验证磁盘上的文稿";
-"%@ Cancel keeps your changes unsaved." = "%@ 取消可保留未存储的更改。";
+"%@ Cancel keeps your changes unsaved." = "%@选择“取消”会保留您的未存储更改。";
 "Markdown Preview needs your permission to save this file." = "Markdown Preview 需要您的权限才能存储此文件。";
 
 /* Open menus */
@@ -183,7 +183,7 @@
 "Fit diagram" = "适应图表";
 "Mermaid renderer is unavailable.\n\n" = "Mermaid 渲染器不可用。\n\n";
 "Footnote %d" = "脚注 %d";
-"Back to reference %d" = "返回引用 %d";
+"Back to reference %d" = "返回脚注引用 %d";
 "KaTeX renderer is unavailable.\n\n" = "KaTeX 渲染器不可用。\n\n";
 
 /* CLI installer errors */

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "No document open" = "未打开文稿";
 "No apps available" = "没有可用的 App";
 "Editors" = "编辑器";
-"AI Apps" = "AI App";
+"AI Apps" = "AI 应用";
 "No LLM apps available" = "没有可用的 LLM App";
 "Open in LLM…" = "在 LLM 中打开…";
 "Open with…" = "打开方式…";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -119,3 +119,75 @@
 "Modified" = "修改日期";
 "No frontmatter" = "无前置元数据";
 "Untitled" = "未命名";
+
+/* Document state and save dialogs */
+"Edited" = "已编辑";
+"Do you want to save your changes?" = "要存储您的更改吗？";
+"this document" = "此文稿";
+"Your changes to %@ will be lost if you don’t save them." = "如果不存储，对 %@ 所做的更改将丢失。";
+"Save" = "存储";
+"Cancel" = "取消";
+"Don’t Save" = "不存储";
+"The file was removed while it was open." = "文件在打开期间被移除。";
+"Recreate File" = "重新创建文件";
+"The file could not be read to verify that it is unchanged." = "无法读取文件以验证其未被更改。";
+"Save Anyway" = "仍要存储";
+"This document changed on disk" = "此文稿已在磁盘上更改";
+"Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep." = "另一个 App 更改了 %@。取消可保留未存储的更改。请选择要保留的版本。";
+"Keep My Changes" = "保留我的更改";
+"Reload from Disk" = "从磁盘重新载入";
+"Unable to verify the document on disk" = "无法验证磁盘上的文稿";
+"%@ Cancel keeps your changes unsaved." = "%@ 取消可保留未存储的更改。";
+"Markdown Preview needs your permission to save this file." = "Markdown Preview 需要您的权限才能存储此文件。";
+
+/* Open menus */
+"No document open" = "未打开文稿";
+"No apps available" = "没有可用的 App";
+"Editors" = "编辑器";
+"AI Apps" = "AI App";
+"No LLM apps available" = "没有可用的 LLM App";
+"Open in LLM…" = "在 LLM 中打开…";
+"Open with…" = "打开方式…";
+
+/* Project navigator context menu */
+"Show in Finder" = "在“访达”中显示";
+"Open in New Tab" = "在新标签页中打开";
+"Open in New Window" = "在新窗口中打开";
+"Copy Path" = "拷贝路径";
+
+/* Table editing */
+"Table" = "表格";
+"Row" = "行";
+"Column" = "列";
+"Select Row" = "选择行";
+"Add Row Above" = "在上方添加行";
+"Add Row Below" = "在下方添加行";
+"Duplicate Row" = "复制行";
+"Delete Row" = "删除行";
+"Select Column" = "选择列";
+"Add Column Left" = "在左侧添加列";
+"Add Column Right" = "在右侧添加列";
+"Delete Column" = "删除列";
+"Edit Table Cell" = "编辑表格单元格";
+"Add Row" = "添加行";
+"Add Column" = "添加列";
+"Edit Table" = "编辑表格";
+
+/* Rendered preview controls */
+"Heading" = "标题";
+"Copy code" = "拷贝代码";
+"Code copied" = "代码已拷贝";
+"Mermaid diagram" = "Mermaid 图表";
+"Reset zoom" = "重置缩放";
+"Fill width" = "填满宽度";
+"Fit diagram" = "适应图表";
+"Mermaid renderer is unavailable.\n\n" = "Mermaid 渲染器不可用。\n\n";
+"Footnote %d" = "脚注 %d";
+"Back to reference %d" = "返回引用 %d";
+"KaTeX renderer is unavailable.\n\n" = "KaTeX 渲染器不可用。\n\n";
+
+/* CLI installer errors */
+"Terminal automation failed: %@" = "终端自动化失败：%@";
+"Terminal automation failed." = "终端自动化失败。";
+"Failed to write CLI installer script: %@" = "无法写入 CLI 安装脚本：%@";
+"The bundled Markdown Preview CLI could not be found." = "找不到随附的 Markdown Preview CLI。";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -46,3 +46,7 @@
 
 /* Open panel */
 "Choose a Markdown file or folder" = "选择 Markdown 文件或文件夹";
+
+/* Search toolbar */
+"Search" = "搜索";
+"Search in Document" = "在文稿中搜索";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -101,3 +101,21 @@
 "Open with External Editor" = "使用外部编辑器打开";
 "Open As" = "打开为";
 "No editors available" = "没有可用的编辑器";
+
+/* Inspector */
+"Inspector tab" = "检查器标签页";
+"Document" = "文稿";
+"Properties" = "属性";
+"File Name" = "文件名称";
+"Document Type" = "文稿类型";
+"Markdown Document" = "Markdown 文稿";
+"File Size" = "文件大小";
+"Words" = "字数";
+"Characters" = "字符数";
+"Lines" = "行数";
+"Headings" = "标题";
+"Links" = "链接";
+"Images" = "图像";
+"Modified" = "修改日期";
+"No frontmatter" = "无前置元数据";
+"Untitled" = "未命名";

--- a/md-preview/zh-Hans.lproj/MainMenu.strings
+++ b/md-preview/zh-Hans.lproj/MainMenu.strings
@@ -1,5 +1,5 @@
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1UK-8n-QPP"; */
-"1UK-8n-QPP.title" = "自定工具栏…";
+"1UK-8n-QPP.title" = "自定义工具栏…";
 
 /* Class = "NSMenuItem"; title = "Markdown Preview"; ObjectID = "1Xt-HY-uBw"; */
 "1Xt-HY-uBw.title" = "Markdown Preview";
@@ -119,7 +119,7 @@
 "Td7-aD-5lo.title" = "窗口";
 
 /* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "UEZ-Bs-lqG"; */
-"UEZ-Bs-lqG.title" = "大写";
+"UEZ-Bs-lqG.title" = "首字母大写";
 
 /* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
 "Vdr-fp-XzO.title" = "隐藏其他";
@@ -161,7 +161,7 @@
 "cwL-P1-jid.title" = "智能链接";
 
 /* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "d9M-CD-aMd"; */
-"d9M-CD-aMd.title" = "变成小写";
+"d9M-CD-aMd.title" = "变为小写";
 
 /* Class = "NSMenuItem"; title = "File"; ObjectID = "dMs-cI-mzQ"; */
 "dMs-cI-mzQ.title" = "文件";
@@ -239,7 +239,7 @@
 "vNY-rz-j42.title" = "清除菜单";
 
 /* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "vmV-6d-7jI"; */
-"vmV-6d-7jI.title" = "变成大写";
+"vmV-6d-7jI.title" = "变为大写";
 
 /* Class = "NSMenu"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
 "wpr-3q-Mcd.title" = "帮助";

--- a/md-preview/zh-Hans.lproj/MainMenu.strings
+++ b/md-preview/zh-Hans.lproj/MainMenu.strings
@@ -1,0 +1,254 @@
+/* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1UK-8n-QPP"; */
+"1UK-8n-QPP.title" = "自定工具栏…";
+
+/* Class = "NSMenuItem"; title = "Markdown Preview"; ObjectID = "1Xt-HY-uBw"; */
+"1Xt-HY-uBw.title" = "Markdown Preview";
+
+/* Class = "NSMenu"; title = "Find"; ObjectID = "1b7-l0-nxx"; */
+"1b7-l0-nxx.title" = "查找";
+
+/* Class = "NSMenu"; title = "Transformations"; ObjectID = "2oI-Rn-ZJC"; */
+"2oI-Rn-ZJC.title" = "转换";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "3IN-sU-3Bg"; */
+"3IN-sU-3Bg.title" = "拼写";
+
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "3rS-ZA-NoH"; */
+"3rS-ZA-NoH.title" = "语音";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "4EN-yA-p0u"; */
+"4EN-yA-p0u.title" = "查找";
+
+/* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "4J7-dP-txa"; */
+"4J7-dP-txa.title" = "进入全屏幕";
+
+/* Class = "NSMenuItem"; title = "Quit Markdown Preview"; ObjectID = "4sb-4s-VLi"; */
+"4sb-4s-VLi.title" = "退出 Markdown Preview";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
+"5QF-Oa-p0T.title" = "编辑";
+
+/* Class = "NSMenuItem"; title = "About Markdown Preview"; ObjectID = "5kV-Vb-QxS"; */
+"5kV-Vb-QxS.title" = "关于 Markdown Preview";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "6dh-zS-Vam"; */
+"6dh-zS-Vam.title" = "重做";
+
+/* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "78Y-hA-62v"; */
+"78Y-hA-62v.title" = "自动纠正拼写";
+
+/* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "9ic-FL-obx"; */
+"9ic-FL-obx.title" = "替换";
+
+/* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "9yt-4B-nSM"; */
+"9yt-4B-nSM.title" = "智能拷贝/粘贴";
+
+/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "主菜单";
+
+/* Class = "NSMenuItem"; title = "Send Anonymous Crash Reports"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "发送匿名崩溃报告";
+
+/* Class = "NSMenuItem"; title = "Save As…"; ObjectID = "Bw7-FT-i3A"; */
+"Bw7-FT-i3A.title" = "存储为…";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
+"DVo-aG-piG.title" = "关闭";
+
+/* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "Dv1-io-Yv7"; */
+"Dv1-io-Yv7.title" = "拼写和语法";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+"F2S-fz-NVQ.title" = "帮助";
+
+/* Class = "NSMenuItem"; title = "Markdown Preview Help"; ObjectID = "FKE-Sm-Kum"; */
+"FKE-Sm-Kum.title" = "Markdown Preview 帮助";
+
+/* Class = "NSMenu"; title = "Substitutions"; ObjectID = "FeM-D8-WVr"; */
+"FeM-D8-WVr.title" = "替换";
+
+/* Class = "NSMenu"; title = "View"; ObjectID = "H8h-7b-M4v"; */
+"H8h-7b-M4v.title" = "显示";
+
+/* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "HFQ-gK-NFA"; */
+"HFQ-gK-NFA.title" = "文本替换";
+
+/* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "HFo-cy-zxI"; */
+"HFo-cy-zxI.title" = "显示拼写和语法";
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "HyV-fh-RgO"; */
+"HyV-fh-RgO.title" = "显示";
+
+/* Class = "NSMenuItem"; title = "Open…"; ObjectID = "IAo-SY-fd9"; */
+"IAo-SY-fd9.title" = "打开…";
+
+/* Class = "NSMenuItem"; title = "Revert to Saved"; ObjectID = "KaW-ft-85H"; */
+"KaW-ft-85H.title" = "复原到已存储的版本";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+"Kd2-mp-pUS.title" = "全部显示";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
+"LE2-aR-0XJ.title" = "前置全部窗口";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+"NMo-om-nkz.title" = "服务";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
+"OY7-WF-poV.title" = "最小化";
+
+/* Class = "NSMenuItem"; title = "Hide Markdown Preview"; ObjectID = "Olw-nP-bQN"; */
+"Olw-nP-bQN.title" = "隐藏 Markdown Preview";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
+"OwM-mh-QMV.title" = "查找上一个";
+
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "Oyz-dy-DGm"; */
+"Oyz-dy-DGm.title" = "停止朗读";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
+"R4o-n2-Eq4.title" = "缩放";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "Ruw-6m-B2m"; */
+"Ruw-6m-B2m.title" = "全选";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "S0p-oC-mLd"; */
+"S0p-oC-mLd.title" = "跳到所选内容";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
+"Td7-aD-5lo.title" = "窗口";
+
+/* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "UEZ-Bs-lqG"; */
+"UEZ-Bs-lqG.title" = "大写";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+"Vdr-fp-XzO.title" = "隐藏其他";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "W48-6f-4Dl"; */
+"W48-6f-4Dl.title" = "编辑";
+
+/* Class = "NSMenuItem"; title = "New"; ObjectID = "Was-JA-tGl"; */
+"Was-JA-tGl.title" = "新建";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "WeT-3V-zwk"; */
+"WeT-3V-zwk.title" = "粘贴并匹配样式";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "Xz5-n4-O0W"; */
+"Xz5-n4-O0W.title" = "查找…";
+
+/* Class = "NSMenuItem"; title = "Find and Replace…"; ObjectID = "YEy-JH-Tfz"; */
+"YEy-JH-Tfz.title" = "查找和替换…";
+
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "Ynk-f8-cLZ"; */
+"Ynk-f8-cLZ.title" = "开始朗读";
+
+/* Class = "NSMenuItem"; title = "Print…"; ObjectID = "aTl-1u-JFS"; */
+"aTl-1u-JFS.title" = "打印…";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "aUF-d1-5bR"; */
+"aUF-d1-5bR.title" = "窗口";
+
+/* Class = "NSMenu"; title = "File"; ObjectID = "bib-Uj-vzu"; */
+"bib-Uj-vzu.title" = "文件";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "buJ-ug-pKt"; */
+"buJ-ug-pKt.title" = "使用所选内容查找";
+
+/* Class = "NSMenuItem"; title = "Transformations"; ObjectID = "c8a-y6-VQd"; */
+"c8a-y6-VQd.title" = "转换";
+
+/* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "cwL-P1-jid"; */
+"cwL-P1-jid.title" = "智能链接";
+
+/* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "d9M-CD-aMd"; */
+"d9M-CD-aMd.title" = "变成小写";
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "dMs-cI-mzQ"; */
+"dMs-cI-mzQ.title" = "文件";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "dRJ-4n-Yzg"; */
+"dRJ-4n-Yzg.title" = "撤销";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
+"gVA-U4-sdL.title" = "粘贴";
+
+/* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
+"hQb-2v-fYv.title" = "智能引号";
+
+/* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hz2-CU-CR7"; */
+"hz2-CU-CR7.title" = "立即检查文稿";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+"hz9-B4-Xy5.title" = "服务";
+
+/* Class = "NSMenuItem"; title = "Show Sidebar"; ObjectID = "kIP-vf-haE"; */
+"kIP-vf-haE.title" = "显示边栏";
+
+/* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "mK6-2p-4JG"; */
+"mK6-2p-4JG.title" = "检查拼写和语法";
+
+/* Class = "NSMenuItem"; title = "Zoom In"; ObjectID = "mdp-zi-itm"; */
+"mdp-zi-itm.title" = "放大";
+
+/* Class = "NSMenuItem"; title = "Zoom Out"; ObjectID = "mdp-zo-itm"; */
+"mdp-zo-itm.title" = "缩小";
+
+/* Class = "NSMenuItem"; title = "Actual Size"; ObjectID = "mdp-zr-itm"; */
+"mdp-zr-itm.title" = "实际大小";
+
+/* Class = "NSMenu"; title = "Open Recent"; ObjectID = "oas-Oc-fiZ"; */
+"oas-Oc-fiZ.title" = "打开最近使用";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "pa3-QI-u2k"; */
+"pa3-QI-u2k.title" = "删除";
+
+/* Class = "NSMenuItem"; title = "Save…"; ObjectID = "pxx-59-PXV"; */
+"pxx-59-PXV.title" = "存储…";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "q09-fT-Sye"; */
+"q09-fT-Sye.title" = "查找下一个";
+
+/* Class = "NSMenuItem"; title = "Page Setup…"; ObjectID = "qIS-W8-SiK"; */
+"qIS-W8-SiK.title" = "页面设置…";
+
+/* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "rbD-Rh-wIN"; */
+"rbD-Rh-wIN.title" = "键入时检查拼写";
+
+/* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "rgM-f4-ycn"; */
+"rgM-f4-ycn.title" = "智能破折号";
+
+/* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "snW-S8-Cw5"; */
+"snW-S8-Cw5.title" = "显示工具栏";
+
+/* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "spk-cu-itm"; */
+"spk-cu-itm.title" = "检查更新…";
+
+/* Class = "NSMenuItem"; title = "Data Detectors"; ObjectID = "tRr-pd-1PS"; */
+"tRr-pd-1PS.title" = "数据检测器";
+
+/* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "tXI-mr-wws"; */
+"tXI-mr-wws.title" = "打开最近使用";
+
+/* Class = "NSMenu"; title = "Markdown Preview"; ObjectID = "uQy-DD-JDr"; */
+"uQy-DD-JDr.title" = "Markdown Preview";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "uRl-iY-unG"; */
+"uRl-iY-unG.title" = "剪切";
+
+/* Class = "NSMenuItem"; title = "Clear Menu"; ObjectID = "vNY-rz-j42"; */
+"vNY-rz-j42.title" = "清除菜单";
+
+/* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "vmV-6d-7jI"; */
+"vmV-6d-7jI.title" = "变成大写";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+"wpr-3q-Mcd.title" = "帮助";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
+"x3v-GG-iWU.title" = "拷贝";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "xrE-MZ-jX0"; */
+"xrE-MZ-jX0.title" = "语音";
+
+/* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
+"z6F-FW-3nz.title" = "显示替换";


### PR DESCRIPTION
## Summary

Hi! This PR adds Simplified Chinese (`zh-Hans`) localization to Markdown Preview.

The app now relies on the standard macOS bundle localization mechanism. macOS selects the language from the user's preferred languages or the per-app override in System Settings.

Related issues

None.

## Motivation

Markdown Preview currently ships an English-only interface. This change localizes the existing menu bar and dynamically created interface strings while preserving the platform's native language-selection behavior.

## Features Added

- Simplified Chinese localization for the main menu.
- Simplified Chinese localization for dynamically created menus and prompts.
- English source localizations for the same dynamic strings.
- Native system and per-app language selection through macOS.

## Changes

- Add English and Simplified Chinese `MainMenu.strings` resources for static menu items.
- Add English and Simplified Chinese `Localizable.strings` resources for dynamic interface text.
- Use `NSLocalizedString` when creating dynamic menu titles and prompts.
- Make menu lookup work with both English and Simplified Chinese titles.
- Register `zh-Hans` as a known project region.

## Benefits

- Users with Simplified Chinese selected in macOS receive a localized interface automatically.
- Users can override the app language through System Settings without a separate in-app preference.
- Existing English behavior remains unchanged.
- Additional localizations can follow the same bundle-based structure.

## Testing

- `swift test --package-path tests/swift-tests` (64 tests passed)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- `plutil -lint` for all four localization resource files

Happy to adjust the localization resource format or wording if you would prefer a different approach. Thanks for taking a look!
