### PR TITLE
fix(links): fix navigation to section links

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -5,6 +5,13 @@
 
 import Cocoa
 
+/// Where the preview should land after the next document render — a link
+/// fragment or a restored history scroll offset.
+enum NavigationScrollTarget {
+    case anchor(String)
+    case position(CGFloat)
+}
+
 final class ContentViewController: NSViewController {
 
     private static let pageZoomDefaultsKey = "MarkdownPreview.pageZoom"
@@ -16,6 +23,14 @@ final class ContentViewController: NSViewController {
     private var pendingFlashWork: DispatchWorkItem?
     private var pendingPreviewScrollAnchor: SourceScrollAnchor?
     private var shouldApplyPendingAnchorOnHeight = false
+    private var pendingNavigationScrollTarget: NavigationScrollTarget?
+    private var shouldApplyNavigationTargetOnHeight = false
+    /// Early attempts run against the blanked page shown during a file
+    /// switch, where the target can't resolve yet — retry on a short timer
+    /// (height events accelerate it), giving up after ~2s.
+    private var navigationTargetRetriesLeft = 0
+    private static let navigationTargetMaxRetries = 25
+    private static let navigationTargetRetryInterval: TimeInterval = 0.08
 
     // Heading top offsets in CSS pixels, indexed by heading id. Compared in
     // CSS units so page zoom doesn't invalidate them.
@@ -63,6 +78,11 @@ final class ContentViewController: NSViewController {
                 self.shouldApplyPendingAnchorOnHeight = false
                 self.pendingPreviewScrollAnchor = nil
                 self.restoreSourceScrollAnchor(anchor)
+            }
+            if self.shouldApplyNavigationTargetOnHeight,
+               let target = self.pendingNavigationScrollTarget {
+                self.shouldApplyNavigationTargetOnHeight = false
+                self.attemptNavigationScrollTarget(target)
             }
         }
         webView.fragmentLinkActivated = { [weak self] fragment in
@@ -126,6 +146,12 @@ final class ContentViewController: NSViewController {
     func display(markdown: String, assetBaseURL: URL? = nil) {
         if pendingPreviewScrollAnchor != nil {
             shouldApplyPendingAnchorOnHeight = true
+        }
+        if pendingNavigationScrollTarget != nil {
+            shouldApplyNavigationTargetOnHeight = true
+            // Height events don't re-fire when the new document lays out at
+            // the same height — the timer guarantees an attempt.
+            scheduleNavigationTargetAttempt()
         }
         resetScrollspy()
         webView.display(markdown: markdown, assetBaseURL: assetBaseURL)
@@ -274,6 +300,72 @@ final class ContentViewController: NSViewController {
         let y = headingOffsetsCSS[headingID] * zoom
         let maxY = max(metrics.documentHeight - metrics.viewportHeight, 0)
         return max(0, min(y - topMargin, maxY))
+    }
+
+    /// Scroll target applied once the next `display()` has rendered;
+    /// `nil` drops a stale target.
+    func prepareToScrollAfterNavigation(to target: NavigationScrollTarget?) {
+        pendingNavigationScrollTarget = target
+        shouldApplyNavigationTargetOnHeight = false
+        navigationTargetRetriesLeft = target == nil ? 0 : Self.navigationTargetMaxRetries
+    }
+
+    /// Immediate fragment scroll within the already-rendered document.
+    func scrollToAnchor(_ fragment: String) {
+        scrollToElement(id: fragment)
+    }
+
+    var currentScrollPosition: CGFloat {
+        webView.scrollMetrics.position
+    }
+
+    private func attemptNavigationScrollTarget(_ target: NavigationScrollTarget) {
+        guard webView.isScrollGeometrySynced else {
+            retryNavigationTarget()
+            return
+        }
+        switch target {
+        case .anchor(let fragment):
+            webView.elementOffset(id: fragment) { [weak self] offset in
+                guard let self,
+                      self.pendingNavigationScrollTarget != nil else { return }
+                guard let offset else {
+                    self.retryNavigationTarget()
+                    return
+                }
+                self.pendingNavigationScrollTarget = nil
+                self.scrollDocument(to: offset)
+            }
+        case .position(let y):
+            // Synced geometry can still be the blank page — hold out until
+            // the offset is reachable, clamping only as a last resort.
+            let metrics = webView.scrollMetrics
+            let reachable = max(metrics.documentHeight - metrics.viewportHeight, 0)
+            guard y <= reachable || navigationTargetRetriesLeft <= 0 else {
+                retryNavigationTarget()
+                return
+            }
+            pendingNavigationScrollTarget = nil
+            // Exact restore: no top margin, no animation.
+            webView.scrollDocument(to: y, topMargin: 0, duration: 0)
+        }
+    }
+
+    private func retryNavigationTarget() {
+        guard navigationTargetRetriesLeft > 0 else {
+            pendingNavigationScrollTarget = nil
+            return
+        }
+        navigationTargetRetriesLeft -= 1
+        shouldApplyNavigationTargetOnHeight = true
+        scheduleNavigationTargetAttempt()
+    }
+
+    private func scheduleNavigationTargetAttempt() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.navigationTargetRetryInterval) { [weak self] in
+            guard let self, let target = self.pendingNavigationScrollTarget else { return }
+            self.attemptNavigationScrollTarget(target)
+        }
     }
 
     private func scrollToElement(id: String) {

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -60,10 +60,16 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         case cancel
     }
 
+    private struct HistoryEntry {
+        let url: URL
+        /// Scroll offset when the user navigated away; restored on back/forward.
+        let scrollPosition: CGFloat
+    }
+
     private var currentFileURL: URL?
     private var currentMarkdown: String?
-    private var backHistory: [URL] = []
-    private var forwardHistory: [URL] = []
+    private var backHistory: [HistoryEntry] = []
+    private var forwardHistory: [HistoryEntry] = []
     private weak var navigationItem: NSToolbarItem?
     private weak var navigationControl: NSSegmentedControl?
     private var fileWatcher: FileWatcher?
@@ -278,27 +284,35 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     }
 
     private func present(url: URL, intent: NavigationIntent) {
+        let fragment = url.fragment?.removingPercentEncoding
         let url = Self.fileURLWithoutFragment(url)
         let preserveEditMode = isEditing || pendingEditModeURL != nil
         if isEditing || hasPendingEditorChanges {
             requestEndEditing(keepAccessoryMounted: true) { [weak self] success in
                 guard success else { return }
-                self?.present(url: url, preservingEditMode: preserveEditMode, intent: intent)
+                self?.present(url: url, preservingEditMode: preserveEditMode,
+                              intent: intent, fragment: fragment)
             }
             return
         }
-        present(url: url, preservingEditMode: preserveEditMode, intent: intent)
+        present(url: url, preservingEditMode: preserveEditMode, intent: intent, fragment: fragment)
     }
 
-    private func present(url: URL, preservingEditMode: Bool, intent: NavigationIntent) {
+    private func present(url: URL, preservingEditMode: Bool,
+                         intent: NavigationIntent, fragment: String?) {
         if url.isExistingDirectory {
             pendingEditModeURL = nil
             openFolder(url)
             return
         }
 
-        guard currentFileURL?.standardizedFileURL != url.standardizedFileURL else { return }
-        commitNavigation(to: url, intent: intent)
+        let split = documentWindow.contentViewController as? MainSplitViewController
+        guard currentFileURL?.standardizedFileURL != url.standardizedFileURL else {
+            // Link into the already-open document — just scroll.
+            if let fragment { split?.scrollToAnchor(fragment) }
+            return
+        }
+        let restoredScrollPosition = commitNavigation(to: url, intent: intent)
         tableUndoManager.removeAllActions()
 
         // Switching to a different file blanks the preview so the previous
@@ -310,7 +324,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         markdownDocument?.replaceFileURL(url)
         documentWindow.title = url.lastPathComponent
         if isFileSwitch {
-            (documentWindow.contentViewController as? MainSplitViewController)?.clearContent()
+            split?.clearContent()
         }
         documentWindow.makeKeyAndOrderFront(nil)
         NSApp.activate()
@@ -319,32 +333,56 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         refreshOpenInLLMItem()
         refreshOpenActionsItem()
         updateEditToolbarItem()
+        // History restore wins over the link fragment — back/forward returns
+        // to where the user actually was.
+        if let restoredScrollPosition {
+            split?.prepareToScrollAfterNavigation(to: .position(restoredScrollPosition))
+        } else if let fragment {
+            split?.prepareToScrollAfterNavigation(to: .anchor(fragment))
+        } else {
+            split?.prepareToScrollAfterNavigation(to: nil)
+        }
         loadFile(at: url)
         startWatching(url)
         offerToBecomeDefaultHandlerIfNeeded()
     }
 
-    private func commitNavigation(to url: URL, intent: NavigationIntent) {
-        guard let currentFileURL else { return }
+    /// Records the navigation in history, capturing the departing scroll
+    /// offset. Returns the position to restore for back/forward, nil otherwise.
+    private func commitNavigation(to url: URL, intent: NavigationIntent) -> CGFloat? {
+        guard let currentFileURL else { return nil }
+        let departed = HistoryEntry(
+            url: currentFileURL.standardizedFileURL,
+            scrollPosition: (documentWindow.contentViewController as? MainSplitViewController)?
+                .previewScrollPosition ?? 0
+        )
+        defer { updateNavigationControl() }
         switch intent {
         case .normal:
-            Self.appendHistory(currentFileURL, to: &backHistory)
+            Self.appendHistory(departed, to: &backHistory)
             forwardHistory.removeAll()
+            return nil
         case .back:
-            guard backHistory.last?.standardizedFileURL == url.standardizedFileURL else { return }
+            guard let target = backHistory.last,
+                  target.url == url.standardizedFileURL else { return nil }
             backHistory.removeLast()
-            Self.appendHistory(currentFileURL, to: &forwardHistory)
+            Self.appendHistory(departed, to: &forwardHistory)
+            return target.scrollPosition
         case .forward:
-            guard forwardHistory.last?.standardizedFileURL == url.standardizedFileURL else { return }
+            guard let target = forwardHistory.last,
+                  target.url == url.standardizedFileURL else { return nil }
             forwardHistory.removeLast()
-            Self.appendHistory(currentFileURL, to: &backHistory)
+            Self.appendHistory(departed, to: &backHistory)
+            return target.scrollPosition
         }
-        updateNavigationControl()
     }
 
-    private static func appendHistory(_ url: URL, to history: inout [URL]) {
-        if history.last?.standardizedFileURL != url.standardizedFileURL {
-            history.append(url.standardizedFileURL)
+    private static func appendHistory(_ entry: HistoryEntry, to history: inout [HistoryEntry]) {
+        if history.last?.url == entry.url {
+            // Same document again — keep one entry with the latest scroll.
+            history[history.count - 1] = entry
+        } else {
+            history.append(entry)
         }
     }
 
@@ -508,11 +546,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     @objc private func navigateHistory(_ sender: NSSegmentedControl) {
         switch sender.selectedSegment {
         case 0:
-            guard let url = backHistory.last else { return }
-            present(url: url, intent: .back)
+            guard let entry = backHistory.last else { return }
+            present(url: entry.url, intent: .back)
         case 1:
-            guard let url = forwardHistory.last else { return }
-            present(url: url, intent: .forward)
+            guard let entry = forwardHistory.last else { return }
+            present(url: entry.url, intent: .forward)
         default:
             break
         }

--- a/md-preview/MainSplitViewController.swift
+++ b/md-preview/MainSplitViewController.swift
@@ -86,6 +86,18 @@ final class MainSplitViewController: NSSplitViewController {
         contentViewController?.clearContent()
     }
 
+    func prepareToScrollAfterNavigation(to target: NavigationScrollTarget?) {
+        contentViewController?.prepareToScrollAfterNavigation(to: target)
+    }
+
+    func scrollToAnchor(_ fragment: String) {
+        contentViewController?.scrollToAnchor(fragment)
+    }
+
+    var previewScrollPosition: CGFloat {
+        contentViewController?.currentScrollPosition ?? 0
+    }
+
     func find(_ query: String,
               backwards: Bool = false,
               mode: SearchMode = .contains,

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -898,7 +898,7 @@ nonisolated enum MarkdownHTML {
                 const y = window.scrollY || document.documentElement.scrollTop || 0;
                 if (y !== lastScroll) {
                     lastScroll = y;
-                    post({ kind: 'scroll', value: y });
+                    post({ kind: 'scrollPosition', value: y });
                 }
             });
         }

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -887,6 +887,23 @@ nonisolated enum MarkdownHTML {
             });
         }
 
+        // Scroll bridge: with compositor-scrolled WKWebView (macOS 26 SDK)
+        // the host can't observe scrolling natively — the page reports it.
+        let lastScroll = -1;
+        let scrollRaf = 0;
+        function pushScroll() {
+            if (scrollRaf) return;
+            scrollRaf = requestAnimationFrame(() => {
+                scrollRaf = 0;
+                const y = window.scrollY || document.documentElement.scrollTop || 0;
+                if (y !== lastScroll) {
+                    lastScroll = y;
+                    post({ kind: 'scroll', value: y });
+                }
+            });
+        }
+        window.addEventListener('scroll', pushScroll, { passive: true });
+
         window.MdPreviewHost = { pushHeight, measureHeight };
 
         function elementForEventTarget(target) {

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -417,7 +417,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             let raw = ceil(CGFloat(truncating: value))
             lastReportedDocumentHeight = raw
             heightDidChange?(raw * webView.pageZoom)
-        case "scroll":
+        case "scrollPosition":
             guard let value = dict["value"] as? NSNumber else { return }
             lastReportedScrollY = CGFloat(truncating: value)
             // The native bounds observer fires this in the legacy path.
@@ -1088,7 +1088,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             return true
         }
 
-        guard let scrollView = webScrollView else { return false }
+        guard let scrollView = webScrollView else {
+            return performScrollActionViaPage(action)
+        }
         let clipView = scrollView.contentView
         let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
         let topInset = clipView.contentInsets.top
@@ -1123,6 +1125,42 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             return true
         }
         animateScroll(to: target, in: scrollView, duration: duration)
+        return true
+    }
+
+    /// Line/page/top/bottom scrolling for the JS path, mirroring the native
+    /// deltas above.
+    private func performScrollActionViaPage(_ action: ScrollAction) -> Bool {
+        let metrics = scrollMetrics
+        let maxY = max(metrics.documentHeight - metrics.viewportHeight, 0)
+        let pageDelta = max(metrics.viewportHeight * 0.9, 40)
+        let lineDelta: CGFloat = 40
+
+        let target: CGFloat
+        let duration: TimeInterval
+        switch action {
+        case .lineUp:
+            target = metrics.position - lineDelta
+            duration = 0.08
+        case .lineDown:
+            target = metrics.position + lineDelta
+            duration = 0.08
+        case .pageUp:
+            target = metrics.position - pageDelta
+            duration = 0.08
+        case .pageDown:
+            target = metrics.position + pageDelta
+            duration = 0.08
+        case .top:
+            target = 0
+            duration = 0.2
+        case .bottom:
+            target = maxY
+            duration = 0.2
+        case .previousHeading, .nextHeading:
+            return true
+        }
+        scrollDocument(to: max(0, min(target, maxY)), topMargin: 0, duration: duration)
         return true
     }
 

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -205,6 +205,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     // without waiting for JS to post a fresh value (it won't — scrollHeight
     // is invariant under pageZoom).
     private var lastReportedDocumentHeight: CGFloat = 1
+    // Last scroll offset reported by the page (CSS pixels) — the only scroll
+    // position visible to the host without `webScrollView`.
+    private var lastReportedScrollY: CGFloat = 0
     private var zoomDefaultsKey: String?
     private var magnificationStartZoom: CGFloat?
     private var accumulatedMagnification: CGFloat = 0
@@ -414,6 +417,11 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             let raw = ceil(CGFloat(truncating: value))
             lastReportedDocumentHeight = raw
             heightDidChange?(raw * webView.pageZoom)
+        case "scroll":
+            guard let value = dict["value"] as? NSNumber else { return }
+            lastReportedScrollY = CGFloat(truncating: value)
+            // The native bounds observer fires this in the legacy path.
+            if webScrollView == nil { scrollDidChange?() }
         case "log":
             // MdPreviewPerf.log() — debug-only; release builds never post.
             // Routed through os.Logger so `log stream --level=debug
@@ -824,10 +832,30 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         }
     }
 
+    /// Document-Y offset for a link fragment: literal `id` match first
+    /// (footnotes carry real ids), then GitHub-style heading slugs, since
+    /// headings only get synthetic `md-heading-N` ids.
     func elementOffset(id: String, completion: @escaping (CGFloat?) -> Void) {
         let script = """
         (() => {
-            const el = document.getElementById(\(javaScriptStringLiteral(id)));
+            const target = \(javaScriptStringLiteral(id));
+            let el = document.getElementById(target);
+            if (!el) {
+                const wanted = target.toLowerCase();
+                const slugify = (text) => text
+                    .toLowerCase()
+                    .trim()
+                    .replace(/[^\\p{L}\\p{N}\\s_-]/gu, '')
+                    .replace(/\\s/g, '-');
+                const seen = new Map();
+                for (const heading of document.querySelectorAll('h1,h2,h3,h4,h5,h6')) {
+                    let slug = slugify(heading.textContent || '');
+                    const count = seen.get(slug) || 0;
+                    seen.set(slug, count + 1);
+                    if (count > 0) slug = slug + '-' + count;
+                    if (slug === wanted) { el = heading; break; }
+                }
+            }
             if (!el) return null;
             const rect = el.getBoundingClientRect();
             return rect.top + (window.scrollY || document.documentElement.scrollTop || 0);
@@ -1015,10 +1043,23 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let documentHeight: CGFloat
     }
 
+    /// Whether the native scroll geometry has caught up with the height the
+    /// page last reported — WebKit resizes its document view a beat after a
+    /// content swap, and scrolling before then clamps against the stale
+    /// height. Always true on the JS path, which clamps in the web process.
+    var isScrollGeometrySynced: Bool {
+        guard let scrollView = webScrollView,
+              let documentView = scrollView.documentView else {
+            return webScrollView == nil
+        }
+        let expected = lastReportedDocumentHeight * webView.pageZoom
+        return abs(documentView.bounds.height - expected) < 2
+    }
+
     var scrollMetrics: ScrollMetrics {
         guard let scrollView = webScrollView else {
             return ScrollMetrics(
-                position: 0,
+                position: lastReportedScrollY * webView.pageZoom,
                 viewportHeight: bounds.height,
                 documentHeight: max(lastReportedDocumentHeight * webView.pageZoom, bounds.height)
             )
@@ -1036,6 +1077,17 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     /// the standard implementation).
     @discardableResult
     func performScrollAction(_ action: ScrollAction) -> Bool {
+        // Heading navigation doesn't need the native scroll view, and
+        // nothing downstream handles it — don't fall through.
+        if action == .previousHeading {
+            scrollToAdjacentHeading(forward: false)
+            return true
+        }
+        if action == .nextHeading {
+            scrollToAdjacentHeading(forward: true)
+            return true
+        }
+
         guard let scrollView = webScrollView else { return false }
         let clipView = scrollView.contentView
         let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
@@ -1045,15 +1097,6 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         let maxY = max(documentHeight - clipView.bounds.height + bottomInset, minY)
         let pageDelta = max(clipView.bounds.height * 0.9, 40)
         let lineDelta: CGFloat = 40
-
-        if action == .previousHeading {
-            scrollToAdjacentHeading(forward: false, in: scrollView)
-            return true
-        }
-        if action == .nextHeading {
-            scrollToAdjacentHeading(forward: true, in: scrollView)
-            return true
-        }
 
         let target: CGFloat
         let duration: TimeInterval
@@ -1086,7 +1129,15 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     func scrollDocument(to y: CGFloat,
                         topMargin: CGFloat = 12,
                         duration: TimeInterval = 0.25) {
-        guard let scrollView = webScrollView else { return }
+        guard let scrollView = webScrollView else {
+            let zoom = max(webView.pageZoom, 0.001)
+            let cssTop = max((y - topMargin) / zoom, 0)
+            let behavior = duration <= 0 ? "instant" : "smooth"
+            webView.evaluateJavaScript(
+                "window.scrollTo({ top: \(cssTop), behavior: '\(behavior)' });"
+            ) { _, _ in }
+            return
+        }
         let clipView = scrollView.contentView
         let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
         let minY = -clipView.contentInsets.top
@@ -1109,15 +1160,11 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         scrollView.flashScrollers()
     }
 
-    private func scrollToAdjacentHeading(forward: Bool, in scrollView: NSScrollView) {
-        let clipView = scrollView.contentView
-        let topInset = clipView.contentInsets.top
-        let bottomInset = clipView.contentInsets.bottom
-        let viewportTop = clipView.bounds.origin.y + topInset
+    private func scrollToAdjacentHeading(forward: Bool) {
+        let viewportTop = scrollMetrics.position
 
-        webView.evaluateJavaScript(Self.headingOffsetsScript) { [weak self, weak scrollView] result, _ in
+        webView.evaluateJavaScript(Self.headingOffsetsScript) { [weak self] result, _ in
             guard let self,
-                  let scrollView,
                   let raw = result as? [NSNumber] else { return }
             let offsets = raw.map { CGFloat(truncating: $0) }.sorted()
             // Headings we navigate to land at viewportTop + topMargin (12 pt).
@@ -1129,12 +1176,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                 ? offsets.first(where: { $0 > cssViewportTop + 16 })
                 : offsets.last(where: { $0 < cssViewportTop - 1 })
             guard let headingY = pick else { return }
-            let topMargin: CGFloat = 12
-            let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
-            let minY = -topInset
-            let maxY = max(documentHeight - clipView.bounds.height + bottomInset, minY)
-            let target = max(minY, min((headingY * zoom) - topInset - topMargin, maxY))
-            self.animateScroll(to: target, in: scrollView, duration: 0.2)
+            self.scrollDocument(to: headingY * zoom, topMargin: 12, duration: 0.2)
         }
     }
 
@@ -1151,6 +1193,56 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     @objc func mdScrollPreviousHeading(_ sender: Any?) { performScrollAction(.previousHeading) }
     @objc func mdScrollNextHeading(_ sender: Any?)     { performScrollAction(.nextHeading) }
 
+    /// With compositor scrolling an internal WebKit view is first responder:
+    /// `keyDown` on the WKWebView subclass never fires, and WebKit claims
+    /// ⌥arrows in the key-equivalent pass before the main menu sees them.
+    /// Claim heading navigation above WebKit, only while the preview owns
+    /// focus so text fields keep their option-arrow editing behavior.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let responder = window?.firstResponder as? NSView,
+           responder.isDescendant(of: self),
+           let action = Self.headingScrollAction(for: event) {
+            performScrollAction(action)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    private static func headingScrollAction(for event: NSEvent) -> ScrollAction? {
+        guard event.type == .keyDown,
+              event.modifierFlags.contains(.option),
+              !event.modifierFlags.contains(.command),
+              !event.modifierFlags.contains(.control),
+              !event.modifierFlags.contains(.shift),
+              let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first
+        else { return nil }
+        switch Int(scalar.value) {
+        case NSUpArrowFunctionKey: return .previousHeading
+        case NSDownArrowFunctionKey: return .nextHeading
+        default: return nil
+        }
+    }
+
+    /// Legacy path, slated for removal. Older WKWebView configurations
+    /// happen to embed an NSScrollView in the private subview tree; finding
+    /// and driving it was never API — an implementation detail this code
+    /// borrowed. Modern WebKit composites macOS web content in the UI
+    /// process (remote layer tree): the WKWebView hosts only a WKFlippedView
+    /// layer-hosting view and no NSScrollView exists — see
+    /// Source/WebKit/UIProcess/mac/WebViewImpl.mm
+    /// (ENABLE(REMOTE_LAYER_TREE_ON_MAC_BY_DEFAULT)) in
+    /// https://github.com/WebKit/WebKit. Observed here: builds with the
+    /// macOS 26 SDK get the new architecture, so `webScrollView` stays nil
+    /// and every branch guarded on it falls back to the supported route —
+    /// WKWebView exposes no scroll API on macOS (`scrollView` is available
+    /// on iOS/iPadOS/Catalyst/visionOS only,
+    /// https://developer.apple.com/documentation/webkit/wkwebview/scrollview),
+    /// so scrolling goes through `evaluateJavaScript` + `Window.scrollTo`
+    /// (https://developer.mozilla.org/docs/Web/API/Window/scrollTo) with the
+    /// page reporting scroll/height back via `WKScriptMessageHandler`
+    /// (https://developer.apple.com/documentation/webkit/wkscriptmessagehandler).
+    /// Once releases are built exclusively with the new SDK, `webScrollView`
+    /// and these branches can be deleted.
     private func configureWebKitScrollView() {
         guard let scrollView = webView.descendantViews.first(where: { $0 is NSScrollView })
                 as? NSScrollView else { return }
@@ -1202,7 +1294,8 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                let base = currentAssetBase,
                let resolved = MarkdownAssetScheme.resolve(url, against: base) {
                 if Self.isMarkdownDocument(resolved) {
-                    localMarkdownLinkActivated?(resolved)
+                    // resolve() works on the path alone and drops `#section`.
+                    localMarkdownLinkActivated?(Self.reattachingFragment(of: url, to: resolved))
                 } else {
                     NSWorkspace.shared.open(resolved)
                 }
@@ -1217,6 +1310,14 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     private static func isMarkdownDocument(_ url: URL) -> Bool {
         ["md", "markdown", "mdown", "mkdn", "mkd"].contains(url.pathExtension.lowercased())
+    }
+
+    private static func reattachingFragment(of source: URL, to target: URL) -> URL {
+        guard let fragment = source.fragment, !fragment.isEmpty,
+              var components = URLComponents(url: target, resolvingAgainstBaseURL: false)
+        else { return target }
+        components.fragment = fragment
+        return components.url ?? target
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {


### PR DESCRIPTION
Cross-document links like `[text](doc.md#some-header)` opened the target file but never scrolled to the section, and back/forward reopened documents at the top instead of where the user left them.

- Carry the link fragment through md-asset resolution (resolve() works on the path alone) and scroll to it once the target document renders.
- Resolve fragments against GitHub-style slugs of heading text — rendered headings only carry synthetic md-heading-N ids, so same- document anchors never matched anything either.
- Store a scroll offset with each back/forward history entry, captured on departure and restored on return; a history restore wins over the original link fragment.
- Retry the pending scroll target on a short timer: the file switch blanks the article first, and the earliest layout events describe a page where the target can't resolve yet.

Doing this surfaced that WKWebView built against the macOS 26 SDK no longer embeds the private NSScrollView the scroll layer drove — content is composited in the UI process (remote layer tree) and every native scroll branch silently no-oped. Programmatic scrolling now falls back to the supported route (evaluateJavaScript + window.scrollTo, with the page reporting scroll position over the existing host bridge), which also revives scrollspy, TOC clicks, and find-scroll in new-SDK builds. Keyboard heading navigation (⌥↑/⌥↓) additionally needed a performKeyEquivalent override above WebKit: an internal WebKit view is first responder in the new architecture and claims option-arrows before the main menu or keyDown ever see them. The legacy NSScrollView path remains for pre-macOS-26-SDK builds and is documented for removal.