### PR TITLE
Fix shell option highlighting in read mode

### DIFF
--- a/md-preview/CodeFenceInfo.swift
+++ b/md-preview/CodeFenceInfo.swift
@@ -20,6 +20,21 @@ nonisolated struct CodeFenceInfo: Equatable {
     /// whitespace trimmed. Empty when there is no metadata.
     let metadata: String
 
+    /// Language identifier passed to the read-mode highlighter.
+    ///
+    /// CodeMirror treats these common shell fence names as one shell grammar,
+    /// while highlight.js reserves `shell` and `console` for transcript-style
+    /// input. Normalize them so read and edit mode parse the same source as
+    /// shell code.
+    var highlightLanguage: String {
+        switch language {
+        case "shell", "sh", "zsh", "console":
+            return "bash"
+        default:
+            return language
+        }
+    }
+
     init(rawInfoString: String?) {
         guard let raw = rawInfoString else {
             self.language = ""

--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -495,7 +495,7 @@ nonisolated struct EscapingHTMLFormatter: MarkupWalker {
         let info = CodeFenceInfo(rawInfoString: codeBlock.language)
         let languageAttr = info.language.isEmpty
             ? ""
-            : " class=\"language-\(escapeAttribute(info.language))\""
+            : " class=\"language-\(escapeAttribute(info.highlightLanguage))\""
         result += "<pre\(sourceLineAttribute(codeBlock))><code\(languageAttr)>\(escapeText(codeBlock.code))</code></pre>\n"
     }
 

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1778,6 +1778,8 @@ nonisolated enum MarkdownHTML {
 
     /// Yields via rAF every ~8 ms so the main thread is never pinned for
     /// more than one frame on docs with many code blocks.
+    /// Internal so the WebKit regression tests can exercise the exact script
+    /// shipped by the app with the bundled highlight.js runtime.
     static let highlightAllBody = """
     function decorateShellOptions(block) {
         if (!block.classList.contains('language-bash')) return;
@@ -1785,10 +1787,10 @@ nonisolated enum MarkdownHTML {
         const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
         while (walker.nextNode()) {
             const parent = walker.currentNode.parentElement;
-            if (!parent || parent.closest('.hljs-comment, .hljs-string, .hljs-attr')) continue;
+            if (!parent || parent.closest('.hljs-comment, .hljs-string, .hljs-meta, .hljs-attr')) continue;
             textNodes.push(walker.currentNode);
         }
-        const optionPattern = /(^|[\\s=])(-{1,2}[A-Za-z][A-Za-z0-9-]*)(?=$|[\\s;&|)])/g;
+        const optionPattern = /(^|[\\s=])(-{1,2}[A-Za-z][A-Za-z0-9-]*)(?=$|[=\\s;&|)])/g;
         textNodes.forEach((node) => {
             const source = node.nodeValue || '';
             let match;

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1778,7 +1778,41 @@ nonisolated enum MarkdownHTML {
 
     /// Yields via rAF every ~8 ms so the main thread is never pinned for
     /// more than one frame on docs with many code blocks.
-    private static let highlightAllBody = """
+    static let highlightAllBody = """
+    function decorateShellOptions(block) {
+        if (!block.classList.contains('language-bash')) return;
+        const textNodes = [];
+        const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+        while (walker.nextNode()) {
+            const parent = walker.currentNode.parentElement;
+            if (!parent || parent.closest('.hljs-comment, .hljs-string, .hljs-attr')) continue;
+            textNodes.push(walker.currentNode);
+        }
+        const optionPattern = /(^|[\\s=])(-{1,2}[A-Za-z][A-Za-z0-9-]*)(?=$|[\\s;&|)])/g;
+        textNodes.forEach((node) => {
+            const source = node.nodeValue || '';
+            let match;
+            let cursor = 0;
+            let changed = false;
+            const fragment = document.createDocumentFragment();
+            optionPattern.lastIndex = 0;
+            while ((match = optionPattern.exec(source)) !== null) {
+                const optionStart = match.index + match[1].length;
+                fragment.append(document.createTextNode(source.slice(cursor, optionStart)));
+                const span = document.createElement('span');
+                span.className = 'hljs-attr';
+                span.textContent = match[2];
+                fragment.append(span);
+                cursor = optionStart + match[2].length;
+                changed = true;
+            }
+            if (changed) {
+                fragment.append(document.createTextNode(source.slice(cursor)));
+                node.replaceWith(fragment);
+            }
+        });
+    }
+
     function highlightAll() {
         if (typeof hljs === 'undefined') return;
         if (!document.querySelector('pre code[class*="language-"]:not([data-hljs-done="1"])')) return;
@@ -1793,6 +1827,7 @@ nonisolated enum MarkdownHTML {
                 const block = blocks[i++];
                 try {
                     hljs.highlightElement(block);
+                    decorateShellOptions(block);
                 } catch (e) {
                     MdPreviewPerf.log('hljs threw', String(e && e.message || e));
                 }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/CodeFenceInfoTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/CodeFenceInfoTests.swift
@@ -58,4 +58,12 @@ final class CodeFenceInfoTests: XCTestCase {
         XCTAssertEqual(info.language, "")
         XCTAssertEqual(info.metadata, "")
     }
+
+    func testShellAliasesUseBashForReadModeHighlighting() {
+        for language in ["shell", "sh", "zsh", "console"] {
+            XCTAssertEqual(CodeFenceInfo(rawInfoString: language).highlightLanguage, "bash")
+        }
+        XCTAssertEqual(CodeFenceInfo(rawInfoString: "bash").highlightLanguage, "bash")
+        XCTAssertEqual(CodeFenceInfo(rawInfoString: "swift").highlightLanguage, "swift")
+    }
 }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -322,6 +322,79 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertTrue(codeRule.contains("display: block;"))
     }
 
+    func testShellFenceAliasesUseBashReadModeGrammar() {
+        for language in ["shell", "sh", "zsh", "console", "bash"] {
+            let rendered = MarkdownHTML.render(
+                markdown: """
+                ```\(language)
+                git status --short
+                ```
+                """,
+                vendorLoading: .lazy
+            )
+
+            XCTAssertTrue(
+                rendered.articleHTML.contains("<code class=\"language-bash\">"),
+                "\(language): \(rendered.articleHTML)"
+            )
+        }
+    }
+
+    @MainActor
+    func testReadModeHighlightsShellOptionsWithoutTouchingComments() async throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let highlightURL = repositoryRoot
+            .appendingPathComponent("md-preview/Vendor/Highlight/highlight.min.js")
+        let highlightJS = try String(contentsOf: highlightURL, encoding: .utf8)
+            .replacingOccurrences(of: "</script", with: "<\\/script")
+        let html = """
+        <!DOCTYPE html>
+        <html><body>
+        <pre><code class="language-bash">git status --short
+        npx serve-sim --list -q
+        # --ignored</code></pre>
+        <script>\(highlightJS)</script>
+        <script>
+        const MdPreviewPerf = { log() {}, now: () => performance.now() };
+        window.requestAnimationFrame = (callback) => callback();
+        \(MarkdownHTML.highlightAllBody)
+        highlightAll();
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 700, height: 300))
+
+        webView.loadHTMLString(html, baseURL: repositoryRoot)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        for _ in 0..<100 {
+            let done = try await webView.evaluateJavaScript(
+                "document.querySelector('code').dataset.hljsDone === '1'"
+            ) as? Bool
+            if done == true { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let result = try await webView.evaluateJavaScript("""
+        JSON.stringify({
+            options: Array.from(document.querySelectorAll('code > .hljs-attr')).map((node) => node.textContent),
+            commentOptions: Array.from(document.querySelectorAll('.hljs-comment .hljs-attr')).map((node) => node.textContent),
+            html: document.querySelector('code').innerHTML,
+        })
+        """)
+        let json = try XCTUnwrap(result as? String)
+        let values = try JSONDecoder().decode(ShellHighlightValues.self, from: Data(json.utf8))
+
+        XCTAssertEqual(values.options, ["--short", "--list", "-q"], values.html)
+        XCTAssertTrue(values.commentOptions.isEmpty)
+    }
+
     func testBlockMathKeepsValidWrapperAndSourceLine() {
         let rendered = MarkdownHTML.render(
             markdown: """
@@ -544,6 +617,12 @@ private struct LongDocumentScrollMetrics: Decodable {
     let rowCount: Int
     let overflowY: String
     let bodyOverflowY: String
+}
+
+private struct ShellHighlightValues: Decodable {
+    let options: [String]
+    let commentOptions: [String]
+    let html: String
 }
 
 private struct MermaidLayoutMetrics: Decodable {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -355,8 +355,11 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         let html = """
         <!DOCTYPE html>
         <html><body>
-        <pre><code class="language-bash">git status --short
-        npx serve-sim --list -q
+        <pre><code class="language-bash">#!/bin/bash -e
+        git status --short
+        git log --pretty=format:%h
+        xcodebuild --derivedDataPath=/tmp/build
+        npx serve-sim --list -q -a -b
         # --ignored</code></pre>
         <script>\(highlightJS)</script>
         <script>
@@ -385,14 +388,20 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         JSON.stringify({
             options: Array.from(document.querySelectorAll('code > .hljs-attr')).map((node) => node.textContent),
             commentOptions: Array.from(document.querySelectorAll('.hljs-comment .hljs-attr')).map((node) => node.textContent),
+            metaOptions: Array.from(document.querySelectorAll('.hljs-meta .hljs-attr')).map((node) => node.textContent),
             html: document.querySelector('code').innerHTML,
         })
         """)
         let json = try XCTUnwrap(result as? String)
         let values = try JSONDecoder().decode(ShellHighlightValues.self, from: Data(json.utf8))
 
-        XCTAssertEqual(values.options, ["--short", "--list", "-q"], values.html)
+        XCTAssertEqual(
+            values.options,
+            ["--short", "--pretty", "--derivedDataPath", "--list", "-q", "-a", "-b"],
+            values.html
+        )
         XCTAssertTrue(values.commentOptions.isEmpty)
+        XCTAssertTrue(values.metaOptions.isEmpty)
     }
 
     func testBlockMathKeepsValidWrapperAndSourceLine() {
@@ -622,6 +631,7 @@ private struct LongDocumentScrollMetrics: Decodable {
 private struct ShellHighlightValues: Decodable {
     let options: [String]
     let commentOptions: [String]
+    let metaOptions: [String]
     let html: String
 }
 


### PR DESCRIPTION
## Summary

- normalize `shell`, `sh`, `zsh`, and `console` fences to the Bash grammar in read mode, matching edit mode's language aliases
- preserve the editor's parameter styling for unclassified shell options such as `--short`, `--check`, and `-q`
- leave options inside shell comments and strings untouched

## Root cause

Read mode uses highlight.js while edit mode uses CodeMirror. highlight.js interprets `shell` as transcript-style “Shell Session” syntax and does not classify ordinary command options, whereas CodeMirror treats the reported fence aliases as shell code and highlights their options.

## Validation

- `swift test --package-path tests/swift-tests` (67 tests)
- WebKit DOM regression test covering shell aliases, long and short options, and comment exclusion
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-issue205-derived build`

Closes #205
