### PR TITLE
Avoid open panel for Finder-opened files

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -117,6 +117,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var documentPromptScheduleGeneration = 0
     private var didReceiveOpenURLsDuringLaunch = false
     private var hasFinishedLaunching = false
+    private var pendingOpenURLCount = 0
+    private weak var activeOpenPanel: NSOpenPanel?
     private var isTerminationSaveInProgress = false
     private var pendingTerminationSaveCount = 0
     private var terminationSaveFailed = false
@@ -170,10 +172,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 continue
             }
 
+            pendingOpenURLCount += 1
             NSDocumentController.shared.openDocument(withContentsOf: url,
-                                                     display: true) { _, _, error in
-                guard let error else { return }
-                NSAlert(error: error).runModal()
+                                                     display: true) { [weak self] _, _, error in
+                if let error {
+                    NSAlert(error: error).runModal()
+                }
+                guard let self else { return }
+                self.pendingOpenURLCount -= 1
+                if error != nil, self.pendingOpenURLCount == 0 {
+                    self.scheduleDocumentPrompt(requiresNoDocuments: true)
+                }
             }
         }
     }
@@ -330,6 +339,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         defer { isPromptingForDocument = false }
 
         let panel = makeOpenPanel()
+        activeOpenPanel = panel
+        defer { activeOpenPanel = nil }
         guard panel.runModal() == .OK, let url = panel.url else { return }
         if url.isExistingDirectory {
             openFolder(url)
@@ -363,6 +374,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func cancelScheduledDocumentPrompt() {
+        // Dismiss a prompt that already made it past the generation check and
+        // is sitting in runModal() when the open event arrives.
+        activeOpenPanel?.cancel(nil)
         guard isDocumentPromptScheduled else { return }
         documentPromptScheduleGeneration += 1
         isDocumentPromptScheduled = false

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -114,6 +114,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var isOpeningDocumentFromPrompt = false
     private var isPromptingForDocument = false
     private var isDocumentPromptScheduled = false
+    private var documentPromptScheduleGeneration = 0
+    private var didReceiveOpenURLsDuringLaunch = false
+    private var hasFinishedLaunching = false
     private var isTerminationSaveInProgress = false
     private var pendingTerminationSaveCount = 0
     private var terminationSaveFailed = false
@@ -132,7 +135,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         installGoMenu()
         installAppMenuItemIcons()
         installZoomMenuItemIcons()
-        scheduleDocumentPrompt(requiresNoDocuments: true)
+        hasFinishedLaunching = true
+        if !didReceiveOpenURLsDuringLaunch {
+            scheduleDocumentPrompt(requiresNoDocuments: true)
+        }
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
@@ -153,6 +159,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
+        if !hasFinishedLaunching {
+            didReceiveOpenURLsDuringLaunch = true
+        }
+        cancelScheduledDocumentPrompt()
+
         for url in urls {
             if url.isExistingDirectory {
                 openFolder(url)
@@ -339,13 +350,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               !isDocumentPromptScheduled else { return }
 
         isDocumentPromptScheduled = true
+        documentPromptScheduleGeneration += 1
+        let scheduleGeneration = documentPromptScheduleGeneration
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            guard self.documentPromptScheduleGeneration == scheduleGeneration else { return }
             self.isDocumentPromptScheduled = false
             guard !requiresNoDocuments || NSDocumentController.shared.documents.isEmpty else { return }
             NSApp.activate(ignoringOtherApps: true)
             self.promptForDocument()
         }
+    }
+
+    private func cancelScheduledDocumentPrompt() {
+        guard isDocumentPromptScheduled else { return }
+        documentPromptScheduleGeneration += 1
+        isDocumentPromptScheduled = false
     }
 
     private func openFolder(_ url: URL) {


### PR DESCRIPTION
## Summary

- suppress the initial file picker when Finder sends URLs during app launch
- cancel a queued picker if the external open event arrives immediately after launch
- preserve the normal Open dialog when Markdown Preview is launched without a file

## Root cause

The app queued its launch picker before `NSDocumentController` had finished opening the Finder-provided document. The queued check could still see an empty document list and present the picker alongside the document window.

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-issue-216 build`
- `swift test --package-path tests/swift-tests` (67 tests)
- launched an isolated copy of the exact built app with `CHANGELOG.md`: one document window, no picker or sheet
- launched the same isolated app without a file: Open dialog appeared as expected

Closes #216
