### PR TITLE
Support standard LaTeX math delimiters

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -677,11 +677,21 @@ nonisolated enum MarkdownHTML {
         try! NSRegularExpression(pattern: #"\$\$([\s\S]+?)\$\$"#)
     }()
 
+    private static let bracketedBlockMathRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"(?<!\\)\\\[([\s\S]+?)\\\]"#)
+    }()
+
     // Reject leading `\$` (escaped) and require non-whitespace adjacent to
     // delimiters so prose like "$5 and $10" doesn't match.
     private static let inlineMathRegex: NSRegularExpression = {
         // swiftlint:disable:next force_try
         try! NSRegularExpression(pattern: #"(?<!\\)\$(?=\S)([^\$\n]+?)(?<=\S)\$"#)
+    }()
+
+    private static let parenthesizedInlineMathRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"(?<!\\)\\\(([^\n]+?)\\\)"#)
     }()
 
     // Fenced code block. Group 1 = backtick run, group 2 = info string, group 3 = body.
@@ -758,32 +768,49 @@ nonisolated enum MarkdownHTML {
             return "MdPreviewProtect\(protected.count - 1)Token"
         }
 
-        let nsAfterInlineCode = afterInlineCode as NSString
-        let blockMatches = blockMathRegex.matches(
-            in: afterInlineCode,
-            range: NSRange(location: 0, length: nsAfterInlineCode.length)
-        )
-        var afterBlockMath = ""
-        afterBlockMath.reserveCapacity(afterInlineCode.count)
-        var blockCursor = 0
-        for match in blockMatches {
-            afterBlockMath += nsAfterInlineCode.substring(with: NSRange(
-                location: blockCursor,
-                length: match.range.location - blockCursor
-            ))
-            let capture = nsAfterInlineCode.substring(with: match.range(at: 1))
-            let fullMatch = nsAfterInlineCode.substring(with: match.range)
-            blockLineCounts.append(fullMatch.count(where: \.isNewline) + 1)
-            afterBlockMath += "MdPreviewMathBlock\(blocks.count)Token"
-            afterBlockMath += String(
-                repeating: "\n",
-                count: fullMatch.count(where: \.isNewline)
+        func extractBlocks(matching regex: NSRegularExpression, from source: String) -> String {
+            let nsSource = source as NSString
+            let matches = regex.matches(
+                in: source,
+                range: NSRange(location: 0, length: nsSource.length)
             )
-            blocks.append(capture)
-            blockCursor = match.range.location + match.range.length
+            var result = ""
+            result.reserveCapacity(source.count)
+            var cursor = 0
+            for match in matches {
+                result += nsSource.substring(with: NSRange(
+                    location: cursor,
+                    length: match.range.location - cursor
+                ))
+                let capture = nsSource.substring(with: match.range(at: 1))
+                let fullMatch = nsSource.substring(with: match.range)
+                let newlineCount = fullMatch.count(where: \.isNewline)
+                blockLineCounts.append(newlineCount + 1)
+                result += "MdPreviewMathBlock\(blocks.count)Token"
+                result += String(repeating: "\n", count: newlineCount)
+                blocks.append(capture)
+                cursor = match.range.location + match.range.length
+            }
+            result += nsSource.substring(from: cursor)
+            return result
         }
-        afterBlockMath += nsAfterInlineCode.substring(from: blockCursor)
-        let afterInlineMath = replaceMatches(of: inlineMathRegex, in: afterBlockMath) { capture in
+
+        let afterDollarBlockMath = extractBlocks(matching: blockMathRegex, from: afterInlineCode)
+        let afterBlockMath = extractBlocks(
+            matching: bracketedBlockMathRegex,
+            from: afterDollarBlockMath
+        )
+        let afterDollarInlineMath = replaceMatches(
+            of: inlineMathRegex,
+            in: afterBlockMath
+        ) { capture in
+            defer { inlines.append(capture) }
+            return "MdPreviewMathInline\(inlines.count)Token"
+        }
+        let afterInlineMath = replaceMatches(
+            of: parenthesizedInlineMathRegex,
+            in: afterDollarInlineMath
+        ) { capture in
             defer { inlines.append(capture) }
             return "MdPreviewMathInline\(inlines.count)Token"
         }

--- a/scripts/check-math-html.py
+++ b/scripts/check-math-html.py
@@ -7,7 +7,9 @@ source = Path("md-preview/MarkdownHTML.swift").read_text()
 checks = {
     "extracts inline $...$ math": "inlineMathRegex" in source,
     "extracts block $$...$$ math": "blockMathRegex" in source,
-    "detects ```math fences": "codeFenceRegex" in source and 'info == "math"' in source,
+    r"extracts inline \\(...\\) math": "parenthesizedInlineMathRegex" in source,
+    r"extracts block \\[...\\] math": "bracketedBlockMathRegex" in source,
+    "detects ```math fences": "codeFenceRegex" in source and 'info.language == "math"' in source,
     "skips math inside code spans/fences": "inlineCodeRegex" in source and "MdPreviewProtect" in source,
     "loads bundled KaTeX renderer": "Vendor/KaTeX" in source and "katex.min" in source,
     "does not load KaTeX from a CDN": "cdn.jsdelivr.net/npm/katex" not in source,
@@ -15,7 +17,7 @@ checks = {
     "loads copy-tex extension": "copy-tex.min" in source,
     "styles math containers": ".math-display" in source,
     "renders inline math wrapper": 'class=\\"math math-inline\\"' in source,
-    "unwraps block math from <p>": "<p>MdPreviewMath" in source,
+    "unwraps block math from <p>": "mathTokenRegex" in source and "paragraph-wrapped block token" in source,
 }
 failed = [name for name, ok in checks.items() if not ok]
 if failed:

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -520,6 +520,127 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(rendered.articleHTML.contains("<p data-source-line=\"1\" data-source-start=\"1\" data-source-end=\"3\"><div"))
     }
 
+    func testLatexDelimitersRenderAsMath() {
+        let rendered = MarkdownHTML.render(
+            markdown: #"""
+            Inline \( E=mc^2 \) expression.
+
+            \[
+            \begin{equation}
+            E=mc^2
+            \end{equation}
+            \]
+            """#,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertTrue(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"<span class="math math-inline"> E=mc^2 </span>"#
+        ), rendered.articleHTML)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"data-source-line="3" data-source-start="3" data-source-end="7" class="math math-display""#
+        ), rendered.articleHTML)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"""
+            \begin{equation}
+            E=mc^2
+            \end{equation}
+            """#
+        ), rendered.articleHTML)
+    }
+
+    func testLatexDelimitersInsideCodeRemainLiteral() {
+        let rendered = MarkdownHTML.render(
+            markdown: #"""
+            `\(inline\)`
+
+            ```latex
+            \[
+            \frac{a}{b}
+            \]
+            ```
+            """#,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertFalse(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains(#"<code>\(inline\)</code>"#))
+        XCTAssertTrue(rendered.articleHTML.contains(#"\["#))
+        XCTAssertFalse(rendered.articleHTML.contains("class=\"math"))
+    }
+
+    @MainActor
+    func testReportedLatexStructuresRenderWithBundledKatex() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: #"""
+            \[
+            \begin{equation}
+            E=mc^2
+            \end{equation}
+            \]
+
+            $$
+            \begin{aligned}
+            a &= b+c\\
+            d &= e+f
+            \end{aligned}
+            $$
+
+            $$\frac{a}{b}$$
+            $$\int_0^\infty e^{-x}dx$$
+            $$\sum_{i=1}^{N}x_i$$
+            $$A=\begin{bmatrix}1&0\\0&1\end{bmatrix}$$
+            """#,
+            vendorLoading: .lazy
+        )
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let katexURL = repositoryRoot
+            .appendingPathComponent("md-preview/Vendor/KaTeX/katex.min.js")
+        let katexJS = try String(contentsOf: katexURL, encoding: .utf8)
+            .replacingOccurrences(of: "</script", with: "<\\/script")
+        let html = """
+        <!DOCTYPE html>
+        <html><body><article>\(rendered.articleHTML)</article>
+        <script>\(katexJS)</script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+
+        webView.loadHTMLString(html, baseURL: repositoryRoot)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try await webView.evaluateJavaScript("""
+        document.querySelectorAll('.math').forEach((element) => {
+            katex.render(element.textContent, element, {
+                displayMode: element.classList.contains('math-display'),
+                throwOnError: false,
+                output: 'htmlAndMathml'
+            });
+        });
+        """)
+
+        let mathCount = try await webView.evaluateJavaScript(
+            "document.querySelectorAll('.math').length"
+        ) as? Int
+        let renderedCount = try await webView.evaluateJavaScript(
+            "document.querySelectorAll('.math .katex').length"
+        ) as? Int
+        let errorCount = try await webView.evaluateJavaScript(
+            "document.querySelectorAll('.katex-error').length"
+        ) as? Int
+
+        XCTAssertEqual(mathCount, 6)
+        XCTAssertEqual(renderedCount, 6)
+        XCTAssertEqual(errorCount, 0)
+    }
+
     func testFootnoteRemovalDoesNotShiftFollowingSourceLines() {
         let rendered = MarkdownHTML.render(
             markdown: """


### PR DESCRIPTION
## Summary

- recognize `\(...\)` inline math and `\[…\]` display math before Markdown parsing
- preserve source-line mapping and keep delimiter-like text inside code spans and fences literal
- verify the reported equation, aligned, fraction, integral, summation, and matrix structures against the bundled KaTeX runtime

## Root cause

KaTeX already supports the reported commands and environments, but the Markdown math extractor only forwarded dollar-delimited and fenced math to KaTeX. Backslash-delimited LaTeX was left as plain Markdown text.

## Validation

- `swift test --package-path tests/swift-tests` (86 tests)
- `./scripts/check-math-html.py`
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-issue-222-build CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Fixes #222