### PR TITLE
Support Markdown-escaped math delimiters

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -673,6 +673,15 @@ nonisolated enum MarkdownHTML {
         try! NSRegularExpression(pattern: #"(?<!\\)\\\[([\s\S]+?)\\\]"#)
     }()
 
+    // Markdown authors sometimes double the delimiter backslashes so the
+    // Markdown parser emits the single-backslash form expected by MathJax.
+    // Math is extracted before Markdown parsing here, so accept that source
+    // form directly while still rejecting runs of three or more backslashes.
+    private static let markdownEscapedBracketedBlockMathRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"(?<!\\)\\\\\[([\s\S]+?)\\\\\]"#)
+    }()
+
     // Reject leading `\$` (escaped) and require non-whitespace adjacent to
     // delimiters so prose like "$5 and $10" doesn't match.
     private static let inlineMathRegex: NSRegularExpression = {
@@ -683,6 +692,11 @@ nonisolated enum MarkdownHTML {
     private static let parenthesizedInlineMathRegex: NSRegularExpression = {
         // swiftlint:disable:next force_try
         try! NSRegularExpression(pattern: #"(?<!\\)\\\(([^\n]+?)\\\)"#)
+    }()
+
+    private static let markdownEscapedParenthesizedInlineMathRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"(?<!\\)\\\\\(([^\n]+?)\\\\\)"#)
     }()
 
     // Fenced code block. Group 1 = backtick run, group 2 = info string, group 3 = body.
@@ -787,9 +801,13 @@ nonisolated enum MarkdownHTML {
         }
 
         let afterDollarBlockMath = extractBlocks(matching: blockMathRegex, from: afterInlineCode)
+        let afterMarkdownEscapedBlockMath = extractBlocks(
+            matching: markdownEscapedBracketedBlockMathRegex,
+            from: afterDollarBlockMath
+        )
         let afterBlockMath = extractBlocks(
             matching: bracketedBlockMathRegex,
-            from: afterDollarBlockMath
+            from: afterMarkdownEscapedBlockMath
         )
         let afterDollarInlineMath = replaceMatches(
             of: inlineMathRegex,
@@ -798,9 +816,16 @@ nonisolated enum MarkdownHTML {
             defer { inlines.append(capture) }
             return "MdPreviewMathInline\(inlines.count)Token"
         }
+        let afterMarkdownEscapedInlineMath = replaceMatches(
+            of: markdownEscapedParenthesizedInlineMathRegex,
+            in: afterDollarInlineMath
+        ) { capture in
+            defer { inlines.append(capture) }
+            return "MdPreviewMathInline\(inlines.count)Token"
+        }
         let afterInlineMath = replaceMatches(
             of: parenthesizedInlineMathRegex,
-            in: afterDollarInlineMath
+            in: afterMarkdownEscapedInlineMath
         ) { capture in
             defer { inlines.append(capture) }
             return "MdPreviewMathInline\(inlines.count)Token"

--- a/scripts/check-math-html.py
+++ b/scripts/check-math-html.py
@@ -9,6 +9,10 @@ checks = {
     "extracts block $$...$$ math": "blockMathRegex" in source,
     r"extracts inline \\(...\\) math": "parenthesizedInlineMathRegex" in source,
     r"extracts block \\[...\\] math": "bracketedBlockMathRegex" in source,
+    r"extracts Markdown-escaped inline \\\\(...\\\\) math":
+        "markdownEscapedParenthesizedInlineMathRegex" in source,
+    r"extracts Markdown-escaped block \\\\[...\\\\] math":
+        "markdownEscapedBracketedBlockMathRegex" in source,
     "detects ```math fences": "codeFenceRegex" in source and 'info.language == "math"' in source,
     "skips math inside code spans/fences": "inlineCodeRegex" in source and "MdPreviewProtect" in source,
     "loads bundled KaTeX renderer": "Vendor/KaTeX" in source and "katex.min" in source,

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -550,15 +550,46 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         ), rendered.articleHTML)
     }
 
+    func testMarkdownEscapedLatexDelimitersRenderAsMath() {
+        let rendered = MarkdownHTML.render(
+            markdown: #"""
+            Inline \\(\frac{\pi}{2}\\) expression.
+
+            \\[\int_0^1 f(t) \mathrm{d}t\\]
+
+            \\[\sum_j \gamma_j^2/d_j\\]
+            """#,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertTrue(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"<span class="math math-inline">\frac{\pi}{2}</span>"#
+        ), rendered.articleHTML)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"class="math math-display">\int_0^1 f(t) \mathrm{d}t</div>"#
+        ), rendered.articleHTML)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"class="math math-display">\sum_j \gamma_j^2/d_j</div>"#
+        ), rendered.articleHTML)
+        XCTAssertEqual(
+            rendered.articleHTML.components(separatedBy: "class=\"math ").count - 1,
+            3
+        )
+    }
+
     func testLatexDelimitersInsideCodeRemainLiteral() {
         let rendered = MarkdownHTML.render(
             markdown: #"""
             `\(inline\)`
+            `\\(markdown escaped inline\\)`
 
             ```latex
             \[
             \frac{a}{b}
             \]
+
+            \\[\sum_i x_i\\]
             ```
             """#,
             vendorLoading: .lazy
@@ -566,7 +597,9 @@ final class MarkdownHTMLRenderTests: XCTestCase {
 
         XCTAssertFalse(rendered.containsMath)
         XCTAssertTrue(rendered.articleHTML.contains(#"<code>\(inline\)</code>"#))
+        XCTAssertTrue(rendered.articleHTML.contains(#"<code>\\(markdown escaped inline\\)</code>"#))
         XCTAssertTrue(rendered.articleHTML.contains(#"\["#))
+        XCTAssertTrue(rendered.articleHTML.contains(#"\\[\sum_i x_i\\]"#))
         XCTAssertFalse(rendered.articleHTML.contains("class=\"math"))
     }
 


### PR DESCRIPTION
## Summary

- render Markdown-escaped `\\\\(...\\\\)` and `\\\\[...\\\\]` math delimiters
- keep escaped delimiter lookalikes inside code spans and fenced code literal
- extend the static math smoke checks and renderer regression coverage

## Root cause

Math extraction runs before the Markdown parser. The full sample doubles delimiter backslashes so Markdown would emit the single-backslash MathJax form, but the extractor only recognized the undoubled source form and intentionally rejected a preceding backslash.

## Validation

- `python3 scripts/check-math-html.py`
- `swift test --package-path tests/swift-tests` (87 tests)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-escaped-latex-build CODE_SIGNING_ALLOWED=NO build`
- Computer Use: opened `samples/full.md` in the exact Debug build and verified the inline fraction, Fourier transform, integral, and summation all render
