### PR TITLE
Restore native page scrollbar

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -963,15 +963,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let formatTitle = L("Format")
         let menu = NSMenu(title: formatTitle)
-        menu.addItem(item("Body", command: "h0"))
-        menu.addItem(item("Heading 1", command: "h1", key: "1", modifiers: [.shift, .command]))
-        menu.addItem(item("Heading 2", command: "h2", key: "2", modifiers: [.shift, .command]))
-        menu.addItem(item("Heading 3", command: "h3", key: "3", modifiers: [.shift, .command]))
+        // ⇧⌘3/4/5 are captured system-wide for screenshots and ⌘` cycles
+        // app windows (HIG), so headings live on ⌥⌘ and inline code on
+        // ⇧⌘M — Apple Notes' Monostyled shortcut.
+        menu.addItem(item("Body", command: "h0", key: "0", modifiers: [.option, .command]))
+        menu.addItem(item("Heading 1", command: "h1", key: "1", modifiers: [.option, .command]))
+        menu.addItem(item("Heading 2", command: "h2", key: "2", modifiers: [.option, .command]))
+        menu.addItem(item("Heading 3", command: "h3", key: "3", modifiers: [.option, .command]))
         menu.addItem(.separator())
         menu.addItem(item("Bold", command: "bold", key: "b"))
         menu.addItem(item("Italic", command: "italic", key: "i"))
         menu.addItem(item("Strikethrough", command: "strikethrough", key: "x", modifiers: [.shift, .command]))
-        menu.addItem(item("Inline Code", command: "code", key: "`"))
+        menu.addItem(item("Inline Code", command: "code", key: "m", modifiers: [.shift, .command]))
         menu.addItem(item("Link", command: "link", key: "k"))
         menu.addItem(.separator())
         menu.addItem(item("Bulleted List", command: "bulletList", key: "7", modifiers: [.shift, .command]))
@@ -997,7 +1000,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                          keyEquivalent: String,
                                          action: Selector) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
-        item.keyEquivalentModifierMask = [.option, .command]
+        // ⌃⌘ like Safari's sidebar panes; ⌥⌘1–3 belong to Format headings.
+        item.keyEquivalentModifierMask = [.control, .command]
         item.target = self
         if let image = NSImage(systemSymbolName: symbol, accessibilityDescription: title) {
             image.isTemplate = true

--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -17,7 +17,7 @@ final class ContentViewController: NSViewController {
     private static let pageZoomDefaultsKey = "MarkdownPreview.pageZoom"
 
     private var webView: MarkdownWebView!
-    private var webViewPageWidthConstraint: NSLayoutConstraint?
+    private var webViewCenteredLeadingConstraint: NSLayoutConstraint?
     private var webViewCenteredConstraints: [NSLayoutConstraint] = []
     private var webViewFullWidthConstraints: [NSLayoutConstraint] = []
     private var pendingFlashWork: DispatchWorkItem?
@@ -103,7 +103,8 @@ final class ContentViewController: NSViewController {
             self?.tableEditRequested?(request)
         }
         webView.zoomDidChange = { [weak self] zoom in
-            self?.webViewPageWidthConstraint?.constant = MarkdownHTML.preferredPageWidth * zoom
+            self?.webViewCenteredLeadingConstraint?.constant =
+                -MarkdownHTML.preferredPageWidth * zoom / 2
         }
         webView.scrollDidChange = { [weak self] in
             self?.evaluateActiveHeading()
@@ -112,30 +113,35 @@ final class ContentViewController: NSViewController {
 
         container.addSubview(webView)
 
-        // Normal (centered) mode caps the web view at the page width and
-        // centers it in AppKit rather than letting CSS auto-margins center
-        // the column inside a full-width web view. A sidebar/inspector
-        // reveal then only *moves* the web view — applied synchronously
-        // with each animation frame — instead of resizing it, which forces
-        // the web process to re-run layout asynchronously and made the
-        // column jitter for the duration of the animation (#162). The
-        // width constant tracks pageZoom (zoomDidChange above) so the
-        // column keeps its 820 CSS-px measure at every zoom level.
-        let pageWidth = webView.widthAnchor.constraint(
-            equalToConstant: MarkdownHTML.preferredPageWidth * webView.pageZoom)
+        // Normal (centered) mode positions the web view in AppKit rather
+        // than letting CSS auto-margins center the column inside the web
+        // view. A sidebar/inspector reveal then *moves* the column —
+        // applied synchronously with each animation frame — instead of
+        // re-centering it, which forces the web process to re-run layout
+        // asynchronously and made the column jitter for the duration of
+        // the animation (#162). Only the leading edge is placed at the
+        // centered column's position; the trailing edge always reaches the
+        // container so WebKit's native overlay scrollbar sits at the
+        // preview edge. The rendered article is leading-anchored
+        // (ContentWidth.hostCentered), so the width the web view gains on
+        // the trailing side is inert gutter and mid-animation width
+        // changes cannot move the text. The leading constant tracks
+        // pageZoom (zoomDidChange above) so the column keeps its 820
+        // CSS-px measure at every zoom level.
+        let centeredLeading = webView.leadingAnchor.constraint(
+            equalTo: container.centerXAnchor,
+            constant: -MarkdownHTML.preferredPageWidth * webView.pageZoom / 2)
         // Stay below the split items' holding priorities (content 250,
         // sidebar 260) so window resizing breaks this page-width preference
         // before AppKit changes the user's chosen sidebar width.
-        pageWidth.priority = .init(249)
-        webViewPageWidthConstraint = pageWidth
+        centeredLeading.priority = .init(249)
+        webViewCenteredLeadingConstraint = centeredLeading
         webViewCenteredConstraints = [
-            webView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            webView.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor),
-            pageWidth
+            centeredLeading,
+            webView.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor)
         ]
         webViewFullWidthConstraints = [
-            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor)
         ]
 
         // Keep the WKWebView viewport-sized and let WebKit own vertical
@@ -143,7 +149,8 @@ final class ContentViewController: NSViewController {
         // enormous backing surface that loses Retina resolution on long docs.
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: container.topAnchor),
-            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor)
         ])
         applyContentWidthMode()
     }

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -2715,7 +2715,12 @@ nonisolated enum MarkdownHTML {
         padding: 0;
         overflow: hidden;
     }
-    ::-webkit-scrollbar {
+    /* Hide inner scrollers' bars (tables, math) but never match the root:
+       any custom ::-webkit-scrollbar style on <html>/<body> — including a
+       later "restore" override — swaps the page's native macOS overlay
+       scrollbar for WebKit's legacy one. Zero specificity (:where) keeps
+       the pre::-webkit-scrollbar rules below winning for code blocks. */
+    :where(:not(html):not(body))::-webkit-scrollbar {
         display: none;
         width: 0;
         height: 0;

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -39,13 +39,20 @@ nonisolated enum MarkdownHTML {
     }
 
     /// Layout of the rendered article column.
-    /// - centered: capped at `contentColumnWidth` and centered, so wide
-    ///   windows read like a paged document. Matches Quick Look, whose
-    ///   `preferredPageWidth` panel minus the body gutters is exactly one
+    /// - centered: capped at `contentColumnWidth` and centered by CSS auto
+    ///   margins, so wide windows read like a paged document. Quick Look,
+    ///   whose full-bleed panel minus the body gutters is exactly one
     ///   column.
+    /// - hostCentered: capped at `contentColumnWidth` but anchored to the
+    ///   leading gutter; the app centers the column by *positioning* the
+    ///   web view (see ContentViewController.loadView). Anchoring keeps the
+    ///   column glued to the web view's leading edge so host-driven width
+    ///   changes never re-center it asynchronously (#162), while the web
+    ///   view's trailing edge reaches the window for the native scrollbar.
     /// - full: span the whole window.
     enum ContentWidth {
         case centered
+        case hostCentered
         case full
     }
 
@@ -145,11 +152,23 @@ nonisolated enum MarkdownHTML {
         body { overflow: visible !important; }
         </style>
         """ : ""
-        let contentWidthOverride = contentWidth == .full ? """
-        <style>
-        article.markdown-body { max-width: none; }
-        </style>
-        """ : ""
+        let contentWidthOverride: String
+        switch contentWidth {
+        case .centered:
+            contentWidthOverride = ""
+        case .hostCentered:
+            contentWidthOverride = """
+            <style>
+            article.markdown-body { margin-left: 0; }
+            </style>
+            """
+        case .full:
+            contentWidthOverride = """
+            <style>
+            article.markdown-body { max-width: none; }
+            </style>
+            """
+        }
         let baseTag = assetBaseHref.map { "<base href=\"\($0)\">" } ?? ""
         let sanitizerBlock = dompurifyBlock
         let morphBlock = morphdomBlock

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -175,7 +175,7 @@ enum ContentWidthSetting: String, CaseIterable {
 
     var renderWidth: MarkdownHTML.ContentWidth {
         switch self {
-        case .normal: return .centered
+        case .normal: return .hostCentered
         case .fullWidth: return .full
         }
     }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -165,6 +165,78 @@ final class MarkdownHTMLRenderTests: XCTestCase {
     }
 
     @MainActor
+    func testContentWidthModesLayOutDistinctArticleGeometry() async throws {
+        func articleRect(contentWidth: MarkdownHTML.ContentWidth) async throws -> (x: Double, width: Double) {
+            let rendered = MarkdownHTML.render(
+                markdown: "# Doc\n\n" + String(repeating: "word ", count: 400),
+                allowsScroll: true,
+                vendorLoading: .lazy,
+                contentWidth: contentWidth
+            )
+            let styleBlocks = rendered.html
+                .components(separatedBy: "<style>")
+                .dropFirst()
+                .compactMap { $0.components(separatedBy: "</style>").first }
+                .map { "<style>\($0)</style>" }
+                .joined(separator: "\n")
+            let html = """
+            <!DOCTYPE html>
+            <html><head>\(styleBlocks)</head>
+            <body><article class="markdown-body">\(rendered.articleHTML)</article></body></html>
+            """
+            let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 1700, height: 600))
+            webView.loadHTMLString(html, baseURL: nil)
+            while webView.isLoading {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            let result = try await webView.evaluateJavaScript("""
+            (() => {
+                const r = document.querySelector('article').getBoundingClientRect();
+                return JSON.stringify({ x: r.x, width: r.width });
+            })()
+            """)
+            let json = try XCTUnwrap(result as? String)
+            let rect = try JSONDecoder().decode([String: Double].self, from: Data(json.utf8))
+            return (try XCTUnwrap(rect["x"]), try XCTUnwrap(rect["width"]))
+        }
+
+        // The app positions the web view so the column lands centered in
+        // the window; inside the web view the column must hug the leading
+        // gutter and keep the page measure.
+        let hostCentered = try await articleRect(contentWidth: .hostCentered)
+        XCTAssertEqual(hostCentered.x, 40, accuracy: 1)
+        XCTAssertEqual(hostCentered.width, 820, accuracy: 1)
+
+        // Quick Look centers the same measure with CSS auto margins.
+        let centered = try await articleRect(contentWidth: .centered)
+        XCTAssertEqual(centered.x, (1700 - 820) / 2, accuracy: 1)
+        XCTAssertEqual(centered.width, 820, accuracy: 1)
+
+        // Full width spans the viewport minus the body gutters.
+        let full = try await articleRect(contentWidth: .full)
+        XCTAssertEqual(full.x, 40, accuracy: 1)
+        XCTAssertEqual(full.width, 1700 - 80, accuracy: 1)
+    }
+
+    func testContentWidthModesEmitExpectedArticleOverrides() {
+        let centered = MarkdownHTML.render(
+            markdown: "# Doc", vendorLoading: .lazy, contentWidth: .centered)
+        XCTAssertFalse(centered.html.contains("article.markdown-body { margin-left: 0; }"))
+        XCTAssertFalse(centered.html.contains("article.markdown-body { max-width: none; }"))
+
+        // The app centers the column by positioning the web view, so the
+        // article must stay glued to the leading gutter instead of
+        // re-centering when the web view's trailing edge tracks the window.
+        let hostCentered = MarkdownHTML.render(
+            markdown: "# Doc", vendorLoading: .lazy, contentWidth: .hostCentered)
+        XCTAssertTrue(hostCentered.html.contains("article.markdown-body { margin-left: 0; }"))
+
+        let full = MarkdownHTML.render(
+            markdown: "# Doc", vendorLoading: .lazy, contentWidth: .full)
+        XCTAssertTrue(full.html.contains("article.markdown-body { max-width: none; }"))
+    }
+
+    @MainActor
     func testLongInlineCodeInHeadingStaysWithinViewport() async throws {
         let rendered = MarkdownHTML.render(
             markdown: "## 1. New port — `src/features/imageUpload/application/repositoryInterfaces/imageProcessedPublisherInterface.ts`",

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -103,6 +103,11 @@ final class MarkdownHTMLRenderTests: XCTestCase {
             allowsScroll: true,
             vendorLoading: .lazy
         )
+        // The scrollbar hide must never match <html>/<body>: any custom
+        // ::-webkit-scrollbar style on the root replaces the native macOS
+        // overlay scrollbar with WebKit's legacy one.
+        XCTAssertFalse(rendered.html.contains("\n    ::-webkit-scrollbar {"))
+        XCTAssertTrue(rendered.html.contains(":where(:not(html):not(body))::-webkit-scrollbar"))
         let styleBlocks = rendered.html
             .components(separatedBy: "<style>")
             .dropFirst()
@@ -135,6 +140,9 @@ final class MarkdownHTMLRenderTests: XCTestCase {
                 rowCount: document.querySelectorAll('tbody tr').length,
                 overflowY: getComputedStyle(document.documentElement).overflowY,
                 bodyOverflowY: getComputedStyle(document.body).overflowY,
+                rootScrollbarDisplay: getComputedStyle(document.documentElement, '::-webkit-scrollbar').display,
+                rootScrollbarWidth: getComputedStyle(document.documentElement, '::-webkit-scrollbar').width,
+                tableScrollbarDisplay: getComputedStyle(document.querySelector('table'), '::-webkit-scrollbar').display,
             });
         })()
         """)
@@ -151,6 +159,9 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertGreaterThan(metrics.scrollPosition, metrics.viewportHeight, json)
         XCTAssertEqual(metrics.overflowY, "auto")
         XCTAssertEqual(metrics.bodyOverflowY, "visible")
+        XCTAssertNotEqual(metrics.rootScrollbarDisplay, "none", json)
+        XCTAssertNotEqual(metrics.rootScrollbarWidth, "0px", json)
+        XCTAssertEqual(metrics.tableScrollbarDisplay, "none", json)
     }
 
     @MainActor
@@ -880,6 +891,9 @@ private struct LongDocumentScrollMetrics: Decodable {
     let rowCount: Int
     let overflowY: String
     let bodyOverflowY: String
+    let rootScrollbarDisplay: String
+    let rootScrollbarWidth: String
+    let tableScrollbarDisplay: String
 }
 
 private struct ShellHighlightValues: Decodable {


### PR DESCRIPTION
## Summary

- Restore the native macOS overlay scrollbar for the page in both the app preview and Quick Look, drawn at the **window edge**.
- Scope the stylesheet's global `::-webkit-scrollbar` hide to `:where(:not(html):not(body))` so it never matches the root element.
- In the app's centered mode, pin the web view's trailing edge to the window and center the column by positioning the leading edge — keeping the #162 anti-jitter design intact.

## Root cause

The shared stylesheet globally hid all WebKit scrollbars. Originally the `allowsScroll` override restored the page scrollbar, but 7b40336 dropped that override claiming the base rule was removed too — it wasn't, so scrollable previews have had no scroll indicator since.

## Why this shape

- Any custom `::-webkit-scrollbar` style on `<html>`/`<body>` — including a "restore" override — makes WebKit render its legacy scrollbar instead of the native macOS overlay one. The hide rule must simply never match the root. `:where()` keeps it at zero specificity so the custom `pre` code-block scrollbar styling still wins, and tables/math keep their bars hidden.
- **Window-edge scrollbar without the #162 regression**: the web view's trailing edge is now always pinned to the container, so the native scrollbar sits at the preview edge. Only the leading edge is placed at the centered column's position (`centerX − pageWidth/2`, priority 249, tracking pageZoom). The new `ContentWidth.hostCentered` mode anchors the article to the leading gutter in CSS, so the column stays glued to the web view's leading edge: sidebar/inspector reveals still *translate* the column synchronously with AppKit, and mid-animation width changes on the trailing side are inert gutter.
- Quick Look keeps `ContentWidth.centered` (CSS auto-margin centering in its full-bleed panel), so both surfaces wrap lines identically as before.

## Validation

- `swift test --package-path tests/swift-tests` (90 tests, 0 failures) — includes new coverage: root scrollbar not hidden/zero-width at runtime, inner table bars still hidden, and a WebKit geometry test asserting the article rectangle in all three content-width modes at a 1700 px viewport.
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`
- Launched the Debug build with a long document: overlay scrollbar appears at the window edge while scrolling; column centered in Normal, spans in Full Width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)