### PR TITLE
Align keyboard shortcuts with macOS standards

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -963,15 +963,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let formatTitle = L("Format")
         let menu = NSMenu(title: formatTitle)
-        menu.addItem(item("Body", command: "h0"))
-        menu.addItem(item("Heading 1", command: "h1", key: "1", modifiers: [.shift, .command]))
-        menu.addItem(item("Heading 2", command: "h2", key: "2", modifiers: [.shift, .command]))
-        menu.addItem(item("Heading 3", command: "h3", key: "3", modifiers: [.shift, .command]))
+        // ⇧⌘3/4/5 are captured system-wide for screenshots and ⌘` cycles
+        // app windows (HIG), so headings live on ⌥⌘ and inline code on
+        // ⇧⌘M — Apple Notes' Monostyled shortcut.
+        menu.addItem(item("Body", command: "h0", key: "0", modifiers: [.option, .command]))
+        menu.addItem(item("Heading 1", command: "h1", key: "1", modifiers: [.option, .command]))
+        menu.addItem(item("Heading 2", command: "h2", key: "2", modifiers: [.option, .command]))
+        menu.addItem(item("Heading 3", command: "h3", key: "3", modifiers: [.option, .command]))
         menu.addItem(.separator())
         menu.addItem(item("Bold", command: "bold", key: "b"))
         menu.addItem(item("Italic", command: "italic", key: "i"))
         menu.addItem(item("Strikethrough", command: "strikethrough", key: "x", modifiers: [.shift, .command]))
-        menu.addItem(item("Inline Code", command: "code", key: "`"))
+        menu.addItem(item("Inline Code", command: "code", key: "m", modifiers: [.shift, .command]))
         menu.addItem(item("Link", command: "link", key: "k"))
         menu.addItem(.separator())
         menu.addItem(item("Bulleted List", command: "bulletList", key: "7", modifiers: [.shift, .command]))
@@ -997,7 +1000,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                          keyEquivalent: String,
                                          action: Selector) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
-        item.keyEquivalentModifierMask = [.option, .command]
+        // ⌃⌘ like Safari's sidebar panes; ⌥⌘1–3 belong to Format headings.
+        item.keyEquivalentModifierMask = [.control, .command]
         item.target = self
         if let image = NSImage(systemSymbolName: symbol, accessibilityDescription: title) {
             image.isTemplate = true


### PR DESCRIPTION
## Summary

Fixes #231 — `⌘\`` (Inline Code) shadowed the system's **cycle-through-windows** shortcut, while `⇧⌘\`` still cycled backwards, leaving window cycling working in only one direction. Auditing the rest of the app's bindings against the [HIG standard shortcuts](https://developer.apple.com/design/human-interface-guidelines/keyboards#Standard-keyboard-shortcuts) also turned up `⇧⌘3` (Heading 3), which macOS captures system-wide for screenshots — the shortcut was dead and pressing it took a screenshot instead.

## Changes

| Command | Before | After | Rationale |
|---|---|---|---|
| Inline Code | `⌘\`` | `⇧⌘M` | Apple Notes' Monostyled; the Format menu already mirrors Notes (`⇧⌘7`/`⇧⌘9`/`⇧⌘L`/`⌘'`) |
| Heading 1/2/3 | `⇧⌘1/2/3` | `⌥⌘1/2/3` | `⇧⌘3` is the system screenshot shortcut; `⌥⌘n` is the de-facto heading convention (Notion, Craft) |
| Body | — | `⌥⌘0` | Completes the heading group |
| Hide Sidebar / TOC / Project Navigator | `⌥⌘1/2/3` | `⌃⌘1/2/3` | Frees `⌥⌘n` for headings; matches Safari's sidebar panes (`⌃⌘1` Bookmarks, `⌃⌘2` Reading List) |

## Test plan

- [x] Reproduced the bug on the released 0.0.39: with multiple windows, `⌘\`` twice left focus unchanged while `⇧⌘\`` cycled backwards (scripted via System Events)
- [x] On this build: `⌘\`` and `⇧⌘\`` both cycle windows, in preview and edit mode
- [x] `⇧⌘M` in edit mode wraps the selection in backticks (verified via saved file contents)
- [x] `⌘↓` / arrow keys still move the caret normally in edit mode (Go menu doesn't intercept)
- [x] Debug build compiles clean

Note for reviewers: window cycling needs two separate **windows** — with System Settings "Prefer tabs: Always", documents open as tabs and `⌘\`` has nothing to cycle (use Window → Move Tab to New Window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)