### PR TITLE
Fix stale content-width layout with a runtime root class

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -294,7 +294,8 @@ final class ContentViewController: NSViewController {
     /// full-bleed layout. See the loadView comment for why centering lives
     /// at the constraint layer instead of CSS.
     private func applyContentWidthMode() {
-        switch ContentWidthSetting.current {
+        let setting = ContentWidthSetting.current
+        switch setting {
         case .normal:
             NSLayoutConstraint.deactivate(webViewFullWidthConstraints)
             NSLayoutConstraint.activate(webViewCenteredConstraints)
@@ -302,6 +303,11 @@ final class ContentViewController: NSViewController {
             NSLayoutConstraint.deactivate(webViewCenteredConstraints)
             NSLayoutConstraint.activate(webViewFullWidthConstraints)
         }
+        // Flip the column CSS in the same breath as the constraints so the
+        // loaded page can never keep the other mode's layout (stale heads
+        // happen when the setting changes without this web view reloading,
+        // e.g. from another app instance sharing the defaults).
+        webView.applyContentWidth(setting.renderWidth)
     }
 
     func scrollToHeading(index: Int) {

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -56,6 +56,17 @@ nonisolated enum MarkdownHTML {
         case full
     }
 
+    /// Root (`<html>`) class carrying the content-width mode. The matching
+    /// rules live in the base stylesheet, so flipping the class at runtime
+    /// re-lays-out an already-loaded page without a reload.
+    static func rootClass(for contentWidth: ContentWidth) -> String {
+        switch contentWidth {
+        case .centered: return ""
+        case .hostCentered: return "md-host-centered"
+        case .full: return "md-full-width"
+        }
+    }
+
     /// Width the Quick Look panel requests for its preview window.
     static let preferredPageWidth: CGFloat = 900
     /// The centered article measure: `preferredPageWidth` minus the 40px
@@ -152,23 +163,16 @@ nonisolated enum MarkdownHTML {
         body { overflow: visible !important; }
         </style>
         """ : ""
-        let contentWidthOverride: String
-        switch contentWidth {
-        case .centered:
-            contentWidthOverride = ""
-        case .hostCentered:
-            contentWidthOverride = """
-            <style>
-            article.markdown-body { margin-left: 0; }
-            </style>
-            """
-        case .full:
-            contentWidthOverride = """
-            <style>
-            article.markdown-body { max-width: none; }
-            </style>
-            """
-        }
+        // The width mode rides on a root class (rules live in the base
+        // stylesheet) rather than a baked-in override <style>. The class set
+        // here gives first paint the right layout; the app re-asserts it at
+        // runtime (MarkdownWebView.applyContentWidth) from the same code
+        // path that owns the AppKit constraints, so a page whose head was
+        // rendered under an older setting can never keep a stale layout.
+        let contentWidthClass = Self.rootClass(for: contentWidth)
+        let htmlClassAttr = contentWidthClass.isEmpty
+            ? ""
+            : " class=\"\(contentWidthClass)\""
         let baseTag = assetBaseHref.map { "<base href=\"\($0)\">" } ?? ""
         let sanitizerBlock = dompurifyBlock
         let morphBlock = morphdomBlock
@@ -206,14 +210,13 @@ nonisolated enum MarkdownHTML {
         let safeBody = bodyHTML.replacingOccurrences(of: "</template", with: "<\\/template")
         let html = """
         <!DOCTYPE html>
-        <html>
+        <html\(htmlClassAttr)>
         <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         \(baseTag)
         <style>\(stylesheet)</style>
         \(scrollOverride)
-        \(contentWidthOverride)
         \(sanitizerBlock)
         \(morphBlock)
         \(hostBridgeScript)
@@ -2759,6 +2762,14 @@ nonisolated enum MarkdownHTML {
         margin-left: auto;
         margin-right: auto;
     }
+    /* Content-width modes, keyed off the root class so the app can flip
+       them at runtime (see MarkdownWebView.applyContentWidth).
+       - md-host-centered: the app centers the column by positioning the
+         web view; the article must hug the leading gutter so host-driven
+         width changes never re-center it asynchronously (#162).
+       - md-full-width: span the window. */
+    html.md-host-centered article.markdown-body { margin-left: 0; }
+    html.md-full-width article.markdown-body { max-width: none; }
     article.markdown-body > *:first-child { margin-top: 0 !important; }
 
     /* Frontmatter properties — Obsidian-style metadata panel. Deliberately

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -410,6 +410,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         // bundles). The launch-time warmup loads both vendors, so any
         // subsequent file with any subset of renderers fast-paths into it.
         if isPageReady, let loaded = loadedFingerprint, loaded.covers(fingerprint) {
+            // The kept page head may predate the current content-width
+            // setting (e.g. it changed in another instance sharing the
+            // defaults) — re-assert the root class alongside the swap.
+            applyContentWidth(ContentWidthSetting.current.renderWidth)
             let payload = javaScriptStringLiteral(rendered.articleHTML)
             webView.evaluateJavaScript("window.MdPreview && MdPreview.update(\(payload));") { [weak self] _, _ in
                 self?.contentDidReplace?()
@@ -420,6 +424,21 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         webView.loadHTMLString(rendered.html, baseURL: nil)
         loadedFingerprint = fingerprint
         isPageReady = false
+    }
+
+    /// Sets the content-width root class on the loaded page. The class is
+    /// part of the rendered HTML for first paint; this runtime flip keeps
+    /// an already-loaded page in sync with the live setting so constraints
+    /// (AppKit) and column CSS (WebKit) can never disagree.
+    func applyContentWidth(_ width: MarkdownHTML.ContentWidth) {
+        let hostCentered = width == .hostCentered
+        let fullWidth = width == .full
+        let js = """
+        (() => { const c = document.documentElement.classList;
+            c.toggle('md-host-centered', \(hostCentered));
+            c.toggle('md-full-width', \(fullWidth)); })();
+        """
+        webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
     func reloadPreview() {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -179,9 +179,12 @@ final class MarkdownHTMLRenderTests: XCTestCase {
                 .compactMap { $0.components(separatedBy: "</style>").first }
                 .map { "<style>\($0)</style>" }
                 .joined(separator: "\n")
+            let rootClass = MarkdownHTML.rootClass(for: contentWidth)
+            let classAttr = rootClass.isEmpty ? "" : " class=\"\(rootClass)\""
+            XCTAssertTrue(rendered.html.contains("<html\(classAttr)>"))
             let html = """
             <!DOCTYPE html>
-            <html><head>\(styleBlocks)</head>
+            <html\(classAttr)><head>\(styleBlocks)</head>
             <body><article class="markdown-body">\(rendered.articleHTML)</article></body></html>
             """
             let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 1700, height: 600))
@@ -218,22 +221,68 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertEqual(full.width, 1700 - 80, accuracy: 1)
     }
 
-    func testContentWidthModesEmitExpectedArticleOverrides() {
+    @MainActor
+    func testRuntimeRootClassFlipRelaysOutStaleHead() async throws {
+        // A page whose head was rendered under hostCentered (column hugs the
+        // leading gutter) must re-lay-out to full width when the app flips
+        // the root class at runtime — the fix for stale-head windows that
+        // missed a content-width toggle.
+        let rendered = MarkdownHTML.render(
+            markdown: "# Doc\n\n" + String(repeating: "word ", count: 400),
+            allowsScroll: true,
+            vendorLoading: .lazy,
+            contentWidth: .hostCentered
+        )
+        let styleBlocks = rendered.html
+            .components(separatedBy: "<style>")
+            .dropFirst()
+            .compactMap { $0.components(separatedBy: "</style>").first }
+            .map { "<style>\($0)</style>" }
+            .joined(separator: "\n")
+        let html = """
+        <!DOCTYPE html>
+        <html class="md-host-centered"><head>\(styleBlocks)</head>
+        <body><article class="markdown-body">\(rendered.articleHTML)</article></body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 1700, height: 600))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        // Same script MarkdownWebView.applyContentWidth emits for .full.
+        let result = try await webView.evaluateJavaScript("""
+        (() => {
+            const c = document.documentElement.classList;
+            c.toggle('md-host-centered', false);
+            c.toggle('md-full-width', true);
+            const r = document.querySelector('article').getBoundingClientRect();
+            return JSON.stringify({ x: r.x, width: r.width });
+        })()
+        """)
+        let json = try XCTUnwrap(result as? String)
+        let rect = try JSONDecoder().decode([String: Double].self, from: Data(json.utf8))
+        XCTAssertEqual(try XCTUnwrap(rect["x"]), 40, accuracy: 1)
+        XCTAssertEqual(try XCTUnwrap(rect["width"]), 1700 - 80, accuracy: 1)
+    }
+
+    func testContentWidthModesEmitExpectedRootClass() {
+        // The mode rides on the <html> class; the rules for both classes are
+        // always in the base stylesheet so the app can flip modes at runtime
+        // without reloading (and a stale head can be corrected in place).
         let centered = MarkdownHTML.render(
             markdown: "# Doc", vendorLoading: .lazy, contentWidth: .centered)
-        XCTAssertFalse(centered.html.contains("article.markdown-body { margin-left: 0; }"))
-        XCTAssertFalse(centered.html.contains("article.markdown-body { max-width: none; }"))
+        XCTAssertTrue(centered.html.contains("<html>"))
+        XCTAssertTrue(centered.html.contains("html.md-host-centered article.markdown-body { margin-left: 0; }"))
+        XCTAssertTrue(centered.html.contains("html.md-full-width article.markdown-body { max-width: none; }"))
 
-        // The app centers the column by positioning the web view, so the
-        // article must stay glued to the leading gutter instead of
-        // re-centering when the web view's trailing edge tracks the window.
         let hostCentered = MarkdownHTML.render(
             markdown: "# Doc", vendorLoading: .lazy, contentWidth: .hostCentered)
-        XCTAssertTrue(hostCentered.html.contains("article.markdown-body { margin-left: 0; }"))
+        XCTAssertTrue(hostCentered.html.contains("<html class=\"md-host-centered\">"))
 
         let full = MarkdownHTML.render(
             markdown: "# Doc", vendorLoading: .lazy, contentWidth: .full)
-        XCTAssertTrue(full.html.contains("article.markdown-body { max-width: none; }"))
+        XCTAssertTrue(full.html.contains("<html class=\"md-full-width\">"))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Follow-up to #228. Full Width windows could show the centered-mode column pinned to the leading gutter (see screenshot in the report): a loaded page's `<head>` kept the *other* mode's column CSS while the AppKit constraints were in the current mode.

## Root cause

The content-width mode was baked into the rendered `<head>` as an override `<style>`, while constraints are applied separately at the AppKit layer. Any path where a loaded page outlives a setting change without reloading desynchronizes them — a second app instance sharing the same user defaults, a restored session, or a window that misses the toggle reload. With `hostCentered`'s `margin-left: 0` in a full-width web view, the column lands left-pinned at the 820 px measure.

## Fix

- Both mode rules now live in the base stylesheet, keyed off an `<html>` class: `html.md-host-centered article { margin-left: 0 }`, `html.md-full-width article { max-width: none }`.
- The render stamps the class for a correct first paint (`MarkdownHTML.rootClass(for:)`).
- The app re-asserts the class at runtime from the same code path that owns the constraints — in `applyContentWidthMode()` on every toggle, and on every fast-path article swap — so constraints and column CSS can never disagree again.
- Side benefit: width toggles re-lay-out instantly (CSS reflow) instead of flashing through a full reload.

Quick Look is unaffected (`.centered`, no class, CSS auto-margin centering as before).

## Validation

- `swift test --package-path tests/swift-tests` — 90 tests, 0 failures, including a new WebKit regression test that loads a page with a stale `md-host-centered` head and verifies the runtime class flip (same script the app emits) re-lays-out to full width.
- Debug `xcodebuild` + manual check with three tabbed documents: Full Width fills edge to edge on every tab, Normal centers the 820 px column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)