### PR TITLE
fix(navigation): navigating to files in parent folders

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 			membershipExceptions = (
 				CodeFenceInfo.swift,
 				EscapingHTMLFormatter.swift,
+				MarkdownAssetResolution.swift,
 				MarkdownAssetSchemeHandler.swift,
 				MarkdownFrontmatter.swift,
 				MarkdownHTML.swift,

--- a/md-preview/MarkdownAssetResolution.swift
+++ b/md-preview/MarkdownAssetResolution.swift
@@ -41,10 +41,13 @@ nonisolated enum MarkdownAssetResolution {
     }
 
     /// Maps an `md-asset://…` URL to the file it names. Returns `nil` for
-    /// other schemes and for paths that don't name a filesystem location
-    /// (empty, or the bare root).
+    /// other schemes, for URLs with a host (well-formed `md-asset` URLs have
+    /// none — this keeps protocol-relative references like `//host/pic.png`
+    /// from aliasing local files), and for paths that don't name a
+    /// filesystem location (empty, or the bare root).
     static func fileURL(for assetURL: URL) -> URL? {
         guard assetURL.scheme == scheme else { return nil }
+        if let host = assetURL.host, !host.isEmpty { return nil }
         let path = assetURL.path
         guard path.count > 1, path.hasPrefix("/") else { return nil }
         return URL(fileURLWithPath: path).standardizedFileURL

--- a/md-preview/MarkdownAssetResolution.swift
+++ b/md-preview/MarkdownAssetResolution.swift
@@ -1,0 +1,52 @@
+//
+//  MarkdownAssetResolution.swift
+//  md-preview
+//
+
+import Foundation
+
+/// Pure-Foundation path logic for the `md-asset` custom scheme, shared by
+/// the scheme handler (asset serving) and the web view's navigation
+/// delegate (link clicks). WebKit-free so it can be unit-tested in the
+/// SPM helper package.
+///
+/// The rendered page's `<base>` mirrors the document folder's absolute
+/// filesystem path, so WebKit resolves relative references — including
+/// `../` links into parent folders — before they ever reach the app. An
+/// `md-asset` URL's path therefore *is* the absolute path of the file it
+/// names. Reads outside the document folder are covered by the app's
+/// read-only absolute-path sandbox exception.
+nonisolated enum MarkdownAssetResolution {
+
+    static let scheme = "md-asset"
+
+    /// Base href used when the document has no file location (unsaved
+    /// documents, the vendor warmup page): relative references cannot
+    /// resolve to files, while vendor scripts — absolute
+    /// `md-asset:///__vendor/…` URLs — still load.
+    static let rootBaseHref = "\(scheme):///"
+
+    /// `<base href>` value for a document folder: an `md-asset` URL whose
+    /// percent-encoded path mirrors the folder's absolute path, with a
+    /// trailing slash so relative references resolve inside the folder and
+    /// `../` has room to climb before hitting the URL root.
+    static func baseHref(forFolder folder: URL) -> String {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = ""
+        var path = folder.standardizedFileURL.path
+        if !path.hasSuffix("/") { path.append("/") }
+        components.path = path
+        return components.string ?? rootBaseHref
+    }
+
+    /// Maps an `md-asset://…` URL to the file it names. Returns `nil` for
+    /// other schemes and for paths that don't name a filesystem location
+    /// (empty, or the bare root).
+    static func fileURL(for assetURL: URL) -> URL? {
+        guard assetURL.scheme == scheme else { return nil }
+        let path = assetURL.path
+        guard path.count > 1, path.hasPrefix("/") else { return nil }
+        return URL(fileURLWithPath: path).standardizedFileURL
+    }
+}

--- a/md-preview/MarkdownAssetSchemeHandler.swift
+++ b/md-preview/MarkdownAssetSchemeHandler.swift
@@ -7,13 +7,15 @@ import Foundation
 import UniformTypeIdentifiers
 import WebKit
 
-/// Custom URL scheme handler that serves files relative to the document's
-/// parent folder. The host process holds the security-scoped extension for
-/// the folder, so FileManager reads succeed even though the WKWebView's
+/// Custom URL scheme handler that serves local files to the preview page.
+/// Request URLs carry the file's absolute filesystem path (the page's
+/// `<base>` mirrors the document folder — see `MarkdownAssetResolution`),
+/// so links and images may reference parent folders. The host process has
+/// read access, so FileManager reads succeed even though the WKWebView's
 /// content process is sandboxed separately.
 nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
 
-    nonisolated static let scheme = "md-asset"
+    nonisolated static let scheme = MarkdownAssetResolution.scheme
     /// URL path prefix reserved for app-bundled vendor scripts (lazy-loaded).
     nonisolated static let vendorPathPrefix = "/__vendor/"
 
@@ -43,22 +45,6 @@ nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
     private func currentBaseURL() -> URL? {
         lock.lock(); defer { lock.unlock() }
         return _baseURL
-    }
-
-    /// Resolves an `md-asset://…` URL against `base`, rejecting path-traversal
-    /// that escapes the granted folder. Returns `nil` for malformed input.
-    nonisolated static func resolve(_ assetURL: URL, against base: URL) -> URL? {
-        var path = assetURL.path
-        while path.hasPrefix("/") { path.removeFirst() }
-        guard !path.isEmpty else { return nil }
-
-        let candidate = base.appendingPathComponent(path).standardizedFileURL
-        let basePath = base.standardizedFileURL.path
-        guard candidate.path == basePath
-                || candidate.path.hasPrefix(basePath + "/") else {
-            return nil
-        }
-        return candidate
     }
 
     /// Resolves a `/__vendor/<file>` URL to a file inside the app bundle's
@@ -116,8 +102,11 @@ nonisolated final class MarkdownAssetScheme: NSObject, WKURLSchemeHandler {
                 return
             }
 
-            guard let base,
-                  let resolved = Self.resolve(requestURL, against: base) else {
+            // User files are only served while a document with a real file
+            // location is loaded — the base is nil for unsaved documents
+            // and the warmup page.
+            guard base != nil,
+                  let resolved = MarkdownAssetResolution.fileURL(for: requestURL) else {
                 wrapper.fail(with: URLError(.badURL))
                 return
             }

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -186,7 +186,14 @@ nonisolated enum MarkdownHTML {
             </style>
             """
         }
-        let baseTag = assetBaseHref.map { "<base href=\"\($0)\">" } ?? ""
+        // The href may carry a real folder path (percent-encoded, but `&`
+        // and `'` survive URL path encoding) — escape it for the attribute.
+        let baseTag = assetBaseHref.map {
+            let escaped = $0
+                .replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "\"", with: "&quot;")
+            return "<base href=\"\(escaped)\">"
+        } ?? ""
         let sanitizerBlock = dompurifyBlock
         let morphBlock = morphdomBlock
         let mathBlock = containsMath ? katexHead(mode: vendorLoading) : VendorEmission()
@@ -1790,6 +1797,15 @@ nonisolated enum MarkdownHTML {
         // second update without the flag once the real document arrives,
         // which clears the inline style and reveals the article.
         window.MdPreview.update = (articleHTML, opts) => {
+            // Body swaps can carry a document from a different folder — move
+            // the page <base> first so the incoming content's relative URLs
+            // resolve against the right folder.
+            if (opts && opts.baseHref) {
+                const base = document.querySelector('base');
+                if (base && base.getAttribute('href') !== opts.baseHref) {
+                    base.setAttribute('href', opts.baseHref);
+                }
+            }
             const article = document.querySelector('.markdown-body');
             if (!article) return;
             const tStart = perfNow();

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -306,7 +306,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     private func warmupVendors() {
         guard !isPageReady, loadedFingerprint == nil else { return }
-        let baseHref = "\(MarkdownAssetScheme.scheme):///"
+        let baseHref = MarkdownAssetResolution.rootBaseHref
         let markdown = Self.warmupMarkdown
         let contentWidth = ContentWidthSetting.current.renderWidth
         Task { @concurrent [weak self] in
@@ -350,12 +350,20 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         webView.evaluateJavaScript("window.MdPreview && MdPreview.update('');") { _, _ in }
     }
 
+    /// The page `<base>` mirrors the document folder's absolute path so
+    /// WebKit can resolve relative links — including `../` into parent
+    /// folders — before they reach the scheme handler.
+    private var currentBaseHref: String {
+        currentAssetBase.map { MarkdownAssetResolution.baseHref(forFolder: $0) }
+            ?? MarkdownAssetResolution.rootBaseHref
+    }
+
     func display(markdown: String, assetBaseURL: URL? = nil) {
         currentMarkdown = markdown
         isPointerOverMermaidFigure = false
         assetScheme.setBaseURL(assetBaseURL)
         currentAssetBase = assetBaseURL
-        let baseHref = "\(MarkdownAssetScheme.scheme):///"
+        let baseHref = currentBaseHref
         renderGeneration &+= 1
         let generation = renderGeneration
         let contentWidth = ContentWidthSetting.current.renderWidth
@@ -411,7 +419,11 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         // subsequent file with any subset of renderers fast-paths into it.
         if isPageReady, let loaded = loadedFingerprint, loaded.covers(fingerprint) {
             let payload = javaScriptStringLiteral(rendered.articleHTML)
-            webView.evaluateJavaScript("window.MdPreview && MdPreview.update(\(payload));") { [weak self] _, _ in
+            // The loaded page keeps its original <base> across body swaps —
+            // pass the current document's base along so relative links keep
+            // resolving against the right folder after switching files.
+            let base = javaScriptStringLiteral(currentBaseHref)
+            webView.evaluateJavaScript("window.MdPreview && MdPreview.update(\(payload), { baseHref: \(base) });") { [weak self] _, _ in
                 self?.contentDidReplace?()
             }
             return
@@ -1345,10 +1357,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             if let fragment = sameDocumentFragmentID(from: url) {
                 fragmentLinkActivated?(fragment)
             } else if url.scheme == MarkdownAssetScheme.scheme,
-               let base = currentAssetBase,
-               let resolved = MarkdownAssetScheme.resolve(url, against: base) {
+               currentAssetBase != nil,
+               let resolved = MarkdownAssetResolution.fileURL(for: url) {
                 if Self.isMarkdownDocument(resolved) {
-                    // resolve() works on the path alone and drops `#section`.
+                    // fileURL(for:) works on the path alone and drops `#section`.
                     localMarkdownLinkActivated?(Self.reattachingFragment(of: url, to: resolved))
                 } else {
                     NSWorkspace.shared.open(resolved)
@@ -1392,11 +1404,25 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             return fragment
         }
         if url.scheme == MarkdownAssetScheme.scheme,
-           (url.host == nil || url.host == ""),
-           (url.path.isEmpty || url.path == "/") {
-            return fragment
+           (url.host == nil || url.host == "") {
+            // A fragment-only href resolves against the page <base>, which
+            // names the document folder — so a URL whose path is the folder
+            // itself (or the bare root when there is no folder) points back
+            // at this document.
+            if url.path.isEmpty || url.path == "/" {
+                return fragment
+            }
+            if let folder = currentAssetBase,
+               Self.droppingTrailingSlash(url.path)
+                == Self.droppingTrailingSlash(folder.standardizedFileURL.path) {
+                return fragment
+            }
         }
         return nil
+    }
+
+    private static func droppingTrailingSlash(_ path: String) -> String {
+        path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
     }
 }
 

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -1358,6 +1358,10 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                 fragmentLinkActivated?(fragment)
             } else if url.scheme == MarkdownAssetScheme.scheme,
                currentAssetBase != nil,
+               // `/__vendor/` is a reserved namespace served from the app
+               // bundle by the scheme handler — never a filesystem path, so
+               // clicks on authored vendor links stay inert.
+               !url.path.hasPrefix(MarkdownAssetScheme.vendorPathPrefix),
                let resolved = MarkdownAssetResolution.fileURL(for: url) {
                 if Self.isMarkdownDocument(resolved) {
                     // fileURL(for:) works on the path alone and drops `#section`.

--- a/tests/swift-tests/Sources/MarkdownHelpers/MarkdownAssetResolution.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/MarkdownAssetResolution.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/MarkdownAssetResolution.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownAssetResolutionTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownAssetResolutionTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import MarkdownHelpers
+
+final class MarkdownAssetResolutionTests: XCTestCase {
+
+    // MARK: baseHref(forFolder:)
+
+    func testBaseHrefMirrorsFolderPathWithTrailingSlash() {
+        let folder = URL(fileURLWithPath: "/Users/me/notes/sub", isDirectory: true)
+        XCTAssertEqual(
+            MarkdownAssetResolution.baseHref(forFolder: folder),
+            "md-asset:///Users/me/notes/sub/"
+        )
+    }
+
+    func testBaseHrefPercentEncodesSpecialCharacters() {
+        let folder = URL(fileURLWithPath: "/Users/me/My Notes", isDirectory: true)
+        XCTAssertEqual(
+            MarkdownAssetResolution.baseHref(forFolder: folder),
+            "md-asset:///Users/me/My%20Notes/"
+        )
+    }
+
+    // MARK: fileURL(for:)
+
+    func testFileURLMapsAssetPathToAbsoluteFilePath() {
+        let asset = URL(string: "md-asset:///Users/me/notes/img.png")!
+        XCTAssertEqual(
+            MarkdownAssetResolution.fileURL(for: asset)?.path,
+            "/Users/me/notes/img.png"
+        )
+    }
+
+    func testFileURLDecodesPercentEncoding() {
+        let asset = URL(string: "md-asset:///Users/me/My%20Notes/a%20b.md")!
+        XCTAssertEqual(
+            MarkdownAssetResolution.fileURL(for: asset)?.path,
+            "/Users/me/My Notes/a b.md"
+        )
+    }
+
+    func testFileURLStandardizesTraversalSegments() {
+        let asset = URL(string: "md-asset:///Users/me/notes/sub/../sibling.md")!
+        XCTAssertEqual(
+            MarkdownAssetResolution.fileURL(for: asset)?.path,
+            "/Users/me/notes/sibling.md"
+        )
+    }
+
+    func testFileURLRejectsRootAndEmptyPaths() {
+        XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "md-asset:///")!))
+        XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "md-asset://")!))
+    }
+
+    func testFileURLRejectsOtherSchemes() {
+        XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "file:///etc/hosts")!))
+        XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "https://example.com/a.md")!))
+    }
+
+    // MARK: End-to-end relative resolution
+
+    /// Mirrors what WebKit does with a relative href against the page
+    /// `<base>`: a `../` link climbs into the parent folder and maps back to
+    /// the right file — the behaviour the base-href design exists to enable.
+    func testParentRelativeLinkResolvesAgainstBaseHref() {
+        let folder = URL(fileURLWithPath: "/Users/me/notes/sub", isDirectory: true)
+        let base = URL(string: MarkdownAssetResolution.baseHref(forFolder: folder))!
+        let clicked = URL(string: "../sibling.md", relativeTo: base)!.absoluteURL
+        XCTAssertEqual(
+            MarkdownAssetResolution.fileURL(for: clicked)?.path,
+            "/Users/me/notes/sibling.md"
+        )
+    }
+
+    func testSameFolderRelativeLinkResolvesAgainstBaseHref() {
+        let folder = URL(fileURLWithPath: "/Users/me/notes/sub", isDirectory: true)
+        let base = URL(string: MarkdownAssetResolution.baseHref(forFolder: folder))!
+        let clicked = URL(string: "images/pic.png", relativeTo: base)!.absoluteURL
+        XCTAssertEqual(
+            MarkdownAssetResolution.fileURL(for: clicked)?.path,
+            "/Users/me/notes/sub/images/pic.png"
+        )
+    }
+}

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownAssetResolutionTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownAssetResolutionTests.swift
@@ -52,6 +52,11 @@ final class MarkdownAssetResolutionTests: XCTestCase {
         XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "md-asset://")!))
     }
 
+    func testFileURLRejectsNonEmptyHost() {
+        XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "md-asset://example.com/etc/hosts")!))
+        XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "md-asset://__vendor/katex.min.js")!))
+    }
+
     func testFileURLRejectsOtherSchemes() {
         XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "file:///etc/hosts")!))
         XCTAssertNil(MarkdownAssetResolution.fileURL(for: URL(string: "https://example.com/a.md")!))


### PR DESCRIPTION
## Summary

Relative links that climb into parent folders (`[up](../other.md)`, `![img](../pic.png)`) previously dead-ended: the preview page's `<base>` was the bare `md-asset:///` root, so WebKit clamped `../` segments before the app ever saw them, and the scheme handler additionally rejected anything escaping the document folder.

The page `<base>` now mirrors the document folder's absolute filesystem path, so WebKit resolves relative references — including `../` — natively, and an `md-asset` URL's path *is* the absolute path of the file it names. Reads outside the document folder were already covered by the app's read-only absolute-path sandbox exception.

- New `MarkdownAssetResolution` (pure Foundation, WebKit-free): builds the folder-mirroring base href and maps `md-asset` URLs back to file URLs; shared by the scheme handler and the navigation delegate, and symlinked into the SPM test package.
- `MdPreview.update` accepts an optional `baseHref` and moves the page `<base>` before swapping content, so the JS fast path stays correct when switching between documents in different folders (including off the warmup page).
- Fragment-only links are still detected as same-document now that they resolve to the folder-shaped base URL.
- Base href is HTML-escaped when emitted (`&` survives URL path encoding).

Behaviour notes: absolute-path references like `/img.png` now resolve against the filesystem root rather than the document folder, and a crafted markdown file can now *display* any file readable under the existing read-only `/` sandbox exception (no script execution — DOMPurify still strips scripts and styles).

## Test plan

- [x] `swift test --package-path tests/swift-tests` — 103 tests pass, including 8 new `MarkdownAssetResolutionTests` covering percent-encoding, traversal standardisation, scheme/root rejection, and round-trip resolution of `../sibling.md` against the generated base href
- [x] Debug build of both targets (`md-preview` + `quick-look`)
- [x] Manual: clicking `[Go to parent](../parent.md)` from a subfolder document opens the parent document; a parent-folder image (`../pic.png`) renders; same-document `#anchor` links still scroll in place; verified on additional real-world files


Made with Claude Code.