### PR TITLE
Keep the Mermaid popup out of Quick Look and off other apps

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -2313,7 +2313,17 @@ nonisolated enum MarkdownHTML {
         let resetZoom = htmlEscape(NSLocalizedString("Reset zoom", comment: "Mermaid diagram control"))
         let zoomIn = htmlEscape(NSLocalizedString("Zoom In", comment: "Mermaid diagram control"))
         let fillWidth = htmlEscape(NSLocalizedString("Fill width", comment: "Mermaid diagram control"))
+        // The popup is app-only — `MarkdownWebView` compiles its `mermaidPopup`
+        // handler out of the Quick Look extension, so emitting the button there
+        // would leave a control that does nothing when clicked.
+        #if QUICK_LOOK_EXTENSION
+        let popupButton = ""
+        #else
         let openWindow = htmlEscape(NSLocalizedString("Open in Window", comment: "Mermaid diagram control"))
+        let popupButton = """
+        <button type="button" class="mermaid-hud-btn mermaid-hud-popup" data-mm-act="popup" tabindex="-1" aria-label="\(openWindow)" title="\(openWindow)">⛶</button>
+        """
+        #endif
         for match in matches {
             rendered += nsHTML.substring(with: NSRange(
                 location: cursor,
@@ -2331,7 +2341,7 @@ nonisolated enum MarkdownHTML {
             <button type="button" class="mermaid-hud-btn mermaid-hud-level" data-mm-act="reset" tabindex="-1" aria-label="\(resetZoom)">100%</button>
             <button type="button" class="mermaid-hud-btn" data-mm-act="in" tabindex="-1" aria-label="\(zoomIn)">+</button>
             <button type="button" class="mermaid-hud-btn mermaid-hud-width" data-mm-act="width" tabindex="-1" aria-label="\(fillWidth)" aria-pressed="false" title="\(fillWidth)">⤢</button>
-            <button type="button" class="mermaid-hud-btn mermaid-hud-popup" data-mm-act="popup" tabindex="-1" aria-label="\(openWindow)" title="\(openWindow)">⛶</button>
+            \(popupButton)
             </div>
             </figure>
             """

--- a/md-preview/MermaidDiagramPopup.swift
+++ b/md-preview/MermaidDiagramPopup.swift
@@ -99,7 +99,11 @@ final class MermaidDiagramPopup: NSObject {
             defer: false
         )
         panel.isFloatingPanel = true
-        panel.level = .floating
+        // `.normal`, not `.floating`: a floating level keeps the panel above
+        // every *other* application's windows too, which is why AppKit pairs
+        // that level with `hidesOnDeactivate`. Reading the diagram alongside
+        // the document only needs it to outlive losing key focus.
+        panel.level = .normal
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
         panel.minSize = NSSize(width: MermaidPopupSizing.minimumWidth, height: MermaidPopupSizing.minimumHeight)


### PR DESCRIPTION
## Summary

Two follow-ups to #237, found while testing that PR.

**The `⛶` button shipped into Quick Look, where it does nothing.** `MarkdownHTML.swift` is an additive member of the `quick-look` target (`project.pbxproj:97-105`), but `MarkdownWebView`'s handler is gated:

```swift
#if !QUICK_LOOK_EXTENSION
case "mermaidPopup":
    presentMermaidPopup(dict)
#endif
```

So a Quick Look preview grew a fourth HUD button that ran `openPopup`, posted `mermaidPopup`, and hit nothing. The button is now built behind the same `#if`, so it only exists where a window can open.

**The popup floated above every other application.** `.level = .floating` with `hidesOnDeactivate = false` keeps the diagram on top of Slack, Xcode, everything — AppKit pairs the floating level with `hidesOnDeactivate` precisely because of that. `.normal` delivers what the type's own header comment already promised: a window that survives losing key focus so the diagram can be read next to the document. `isFloatingPanel` (the panel *styling*) and `hidesOnDeactivate = false` are unchanged.

## Test plan

- `xcodebuild -scheme md-preview -configuration Debug build` — succeeds, no new warnings.
- `swift test` in `tests/swift-tests` — **104 tests, 0 failures**.
- `scripts/check-mermaid-html.py` — passes; the popup assertion still matches, since the button markup remains in source behind the `#else`.
- Button target membership verified against the built binaries rather than inferred:

  ```
  quick-look.appex/.../quick-look.debug.dylib   data-mm-act="popup" → 0
  Markdown Preview.app/.../*.debug.dylib        data-mm-act="popup" → 1
  ```

- Manually: `⛶` opens, resizes, and closes as before in the app; hovering a diagram in a Finder Quick Look preview shows three HUD buttons, not four; with the popup open, switching to another app now puts that app's window in front.

## Note

`scripts/check-mermaid-html.py` greps source only, so it can prove the button *is* emitted but can't catch it leaking into the wrong target again. The `strings` check above is the real guard and is currently manual — worth wiring into CI if this class of bug recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)