### PR TITLE
Fix Mermaid diagram HUD layout

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -2353,11 +2353,15 @@ nonisolated enum MarkdownHTML {
             \(diagram)
             </div></div>
             <div class="mermaid-hud" aria-hidden="true">
+            <div class="mermaid-hud-group mermaid-hud-zoom">
             <button type="button" class="mermaid-hud-btn" data-mm-act="out" tabindex="-1" aria-label="\(zoomOut)">−</button>
             <button type="button" class="mermaid-hud-btn mermaid-hud-level" data-mm-act="reset" tabindex="-1" aria-label="\(resetZoom)">100%</button>
             <button type="button" class="mermaid-hud-btn" data-mm-act="in" tabindex="-1" aria-label="\(zoomIn)">+</button>
-            <button type="button" class="mermaid-hud-btn mermaid-hud-width" data-mm-act="width" tabindex="-1" aria-label="\(fillWidth)" aria-pressed="false" title="\(fillWidth)">⤢</button>
+            </div>
+            <div class="mermaid-hud-group mermaid-hud-actions">
+            <button type="button" class="mermaid-hud-btn mermaid-hud-width" data-mm-act="width" tabindex="-1" aria-label="\(fillWidth)" aria-pressed="false" title="\(fillWidth)"><span class="mermaid-hud-width-symbol" aria-hidden="true">⤢</span></button>
             \(popupButton)
+            </div>
             </div>
             </figure>
             """
@@ -3136,12 +3140,10 @@ nonisolated enum MarkdownHTML {
         top: 8px;
         right: 8px;
         display: flex;
-        gap: 2px;
-        padding: 3px;
-        border-radius: 9px;
-        background: color-mix(in srgb, Canvas 75%, transparent);
-        backdrop-filter: blur(20px) saturate(160%);
-        -webkit-backdrop-filter: blur(20px) saturate(160%);
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px 8px;
+        max-width: calc(100% - 16px);
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.12s ease;
@@ -3149,6 +3151,15 @@ nonisolated enum MarkdownHTML {
         font-size: 12px;
         line-height: 1;
         color: var(--text);
+    }
+    .mermaid-hud-group {
+        display: flex;
+        gap: 2px;
+        padding: 3px;
+        border-radius: 9px;
+        background: color-mix(in srgb, Canvas 75%, transparent);
+        backdrop-filter: blur(20px) saturate(160%);
+        -webkit-backdrop-filter: blur(20px) saturate(160%);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
     }
     .mermaid-figure:hover .mermaid-hud,
@@ -3180,12 +3191,16 @@ nonisolated enum MarkdownHTML {
         font-variant-numeric: tabular-nums;
     }
     .mermaid-hud-width {
-        margin-left: 2px;
-        font-size: 14px;
+        line-height: 12px;
+    }
+    .mermaid-hud-width-symbol {
+        display: inline-block;
+        font-size: 22px;
+        font-weight: 600;
     }
     .mermaid-hud-popup {
-        margin-left: 2px;
-        font-size: 13px;
+        font-size: 16px;
+        line-height: 12px;
     }
     @media (prefers-reduced-motion: reduce) {
         .mermaid-hud { transition: none; }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -398,6 +398,18 @@ final class MarkdownHTMLRenderTests: XCTestCase {
             rendered.articleHTML.contains(#"class="mermaid-hud-btn mermaid-hud-popup""#),
             rendered.articleHTML
         )
+        XCTAssertTrue(
+            rendered.articleHTML.contains(#"class="mermaid-hud-group mermaid-hud-zoom""#),
+            rendered.articleHTML
+        )
+        XCTAssertTrue(
+            rendered.articleHTML.contains(#"class="mermaid-hud-group mermaid-hud-actions""#),
+            rendered.articleHTML
+        )
+        XCTAssertTrue(
+            rendered.articleHTML.contains(#"class="mermaid-hud-width-symbol" aria-hidden="true">⤢</span>"#),
+            rendered.articleHTML
+        )
         // SPM helper tests lack the Mermaid vendor bundle, so the page falls
         // back to the "renderer unavailable" stub — assert the real wiring
         // string (injected by the app when Vendor/Mermaid is present).
@@ -686,6 +698,70 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(restored.expanded)
         XCTAssertEqual(restored.buttonPressed, "false")
         XCTAssertEqual(restored.figureWidth, initial.figureWidth, accuracy: 1)
+    }
+
+    @MainActor
+    func testMermaidHUDWrapsInsideNarrowDiagram() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```mermaid
+            flowchart LR
+                A --> B
+            ```
+            """,
+            vendorLoading: .lazy
+        )
+        let stylesheet = try XCTUnwrap(
+            rendered.html
+                .components(separatedBy: "<style>")
+                .dropFirst()
+                .first?
+                .components(separatedBy: "</style>")
+                .first
+        )
+        let html = """
+        <!DOCTYPE html>
+        <html><head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>\(stylesheet)</style>
+        </head><body><article class="markdown-body">\(rendered.articleHTML)</article>
+        <script>
+        const figure = document.querySelector('.mermaid-figure');
+        figure.style.width = '200px';
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let result = try await webView.evaluateJavaScript("""
+        (() => {
+            const figure = document.querySelector('.mermaid-figure').getBoundingClientRect();
+            const hud = document.querySelector('.mermaid-hud').getBoundingClientRect();
+            const zoom = document.querySelector('.mermaid-hud-zoom').getBoundingClientRect();
+            const actions = document.querySelector('.mermaid-hud-actions').getBoundingClientRect();
+            return JSON.stringify({
+                figureLeft: figure.left,
+                figureRight: figure.right,
+                hudLeft: hud.left,
+                hudRight: hud.right,
+                zoomTop: zoom.top,
+                actionsTop: actions.top
+            });
+        })()
+        """)
+        let json = try XCTUnwrap(result as? String)
+        let metrics = try JSONDecoder().decode(
+            MermaidHUDMetrics.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertGreaterThanOrEqual(metrics.hudLeft, metrics.figureLeft + 7)
+        XCTAssertLessThanOrEqual(metrics.hudRight, metrics.figureRight - 7)
+        XCTAssertGreaterThan(metrics.actionsTop, metrics.zoomTop)
     }
 
     func testCodeBlockLayoutMatchesDeferredHighlightingFromFirstPaint() throws {
@@ -1273,6 +1349,15 @@ private struct MermaidLayoutMetrics: Decodable {
     let svgWidth: CGFloat
     let expanded: Bool
     let buttonPressed: String
+}
+
+private struct MermaidHUDMetrics: Decodable {
+    let figureLeft: CGFloat
+    let figureRight: CGFloat
+    let hudLeft: CGFloat
+    let hudRight: CGFloat
+    let zoomTop: CGFloat
+    let actionsTop: CGFloat
 }
 
 private struct MermaidPopupMessage: Decodable {


### PR DESCRIPTION
## Summary

- separate Mermaid zoom controls from the width and popup actions
- increase the optical size and weight of the width toggle icon
- keep the HUD inside narrow diagrams by wrapping control groups when needed
- add WebKit-backed regression coverage for the narrow layout

## Root cause

All five controls shared one pill, and after separating them the combined HUD could become wider than a narrow Mermaid figure. Paint containment then clipped the left side. The width-toggle Unicode glyph also rendered with less visual weight than the neighboring popup icon.

## Validation

- `swift test --package-path tests/swift-tests` — 116 tests passed
- Debug app and Quick Look extension build succeeded with `CODE_SIGNING_ALLOWED=NO`
- visually verified in the exact rebuilt app using `samples/mermaid-heavy.md`