### PR TITLE
Add Buy Me a Coffee link to README and FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,2 @@
-# These are supported funding model platforms
-
-github: [mfauzaan] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
+github: [mfauzaan]
 buy_me_a_coffee: pluk
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -10,6 +10,6 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
 polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+buy_me_a_coffee: pluk
 thanks_dev: # Replace with a single thanks.dev username
 custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 <p align="center"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" />&nbsp;<img alt="Swift" src="https://img.shields.io/badge/swift-6.0-orange" />&nbsp;<img alt="License" src="https://img.shields.io/badge/license-MIT-green" />&nbsp;<img alt="Latest release" src="https://img.shields.io/github/v/release/pluk-inc/markdown-preview" />&nbsp;<img alt="Homebrew cask" src="https://img.shields.io/homebrew/cask/v/markdown-preview" /></p>
 
+<p align="center">
+  <a href="https://buymeacoffee.com/pluk">
+    <img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=pluk&button_colour=FFDD00&font_colour=000000&font_family=Inter&outline_colour=000000&coffee_colour=ffffff" height="42" alt="Buy Me a Coffee" />
+  </a>
+</p>
+
 ---
 
 > Drop a `.md` on the icon (or set Markdown Preview as your default handler) and get a clean, scrollable preview with a real document outline — no Electron, no browser tab.
@@ -142,6 +148,10 @@ Pull requests are welcome. For larger changes, please open an issue first to dis
     <img src="docs/sponsors/amore-logo.png" height="54" alt="Amore" />
   </a>
 </p>
+
+## Support
+
+Markdown Preview is free and MIT-licensed. If it saved you a browser tab, you can [buy us a coffee](https://buymeacoffee.com/pluk).
 
 ## Acknowledgments
 - [Amore](http://amore.computer/) — MacOS release automation (signing, notarization, DMG, hosting, appcast)


### PR DESCRIPTION
## Summary

Adds https://buymeacoffee.com/pluk as a support link in three places:

- `.github/FUNDING.yml` — fills in the previously empty `buy_me_a_coffee:` key with `pluk`, which is what drives GitHub's "Sponsor this project" sidebar section and the repo's Sponsor button (alongside the existing `github: [mfauzaan]` entry).
- `README.md` top — a centered Buy Me a Coffee button (official button API, yellow with the coffee-cup icon) directly under the badge row.
- `README.md` — a short `## Support` section just before Acknowledgments with the same link in prose.

No code or app changes.

## Test plan

- After merge to `main`, confirm Buy Me a Coffee appears in the repo's "Sponsor this project" sidebar section (requires Sponsorships enabled in repo Settings → General → Features).
- Render `README.md` on GitHub and confirm the button appears centered under the badges and links to https://buymeacoffee.com/pluk.
- Confirm the `## Support` section reads correctly and its link resolves.

Note: the README button image is fetched from `img.buymeacoffee.com` (proxied by GitHub camo). If we'd rather keep the README self-hosted like the sponsor logos, we can swap in a PNG under `docs/sponsors/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)