### PR TITLE
Optimize initial rendering for large Markdown files

### DIFF
--- a/md-preview/EscapingHTMLFormatter.swift
+++ b/md-preview/EscapingHTMLFormatter.swift
@@ -562,6 +562,15 @@ nonisolated struct EscapingHTMLFormatter: MarkupWalker {
 
     mutating func visitParagraph(_ paragraph: Paragraph) {
         result += "<p\(sourceLineAttribute(paragraph))>"
+        // Source-indented pseudo-list lines only exist inside a parsed list.
+        // Keep the overwhelmingly common top-level paragraph path on the
+        // walker's direct traversal instead of materializing all children.
+        guard listDepth > 0 else {
+            descendInto(paragraph)
+            result += "</p>\n"
+            return
+        }
+
         let children = Array(paragraph.children)
         var sourceListLineOpen = false
         var sourceListIndentWrappers = 0

--- a/md-preview/MarkdownFrontmatter.swift
+++ b/md-preview/MarkdownFrontmatter.swift
@@ -35,12 +35,12 @@ nonisolated enum MarkdownFrontmatter {
 
     static func split(_ markdown: String) -> (raw: String?, format: Format?, body: String) {
         let stripped = markdown.first == "\u{FEFF}" ? String(markdown.dropFirst()) : markdown
+        let firstLineEnd = stripped.firstIndex(where: \.isNewline) ?? stripped.endIndex
+        guard let delimiter = Delimiter(openingLine: String(stripped[..<firstLineEnd]))
+        else { return (nil, nil, markdown) }
+
         var lines: [String] = []
         stripped.enumerateLines { line, _ in lines.append(line) }
-
-        guard let first = lines.first,
-              let delimiter = Delimiter(openingLine: first)
-        else { return (nil, nil, markdown) }
 
         guard let close = lines.dropFirst().firstIndex(where: {
             delimiter.closes($0)

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -392,7 +392,6 @@ nonisolated enum MarkdownHTML {
     }
 
     private struct FootnoteReference {
-        let token: String
         let number: Int
         let ordinal: Int
     }
@@ -414,6 +413,10 @@ nonisolated enum MarkdownHTML {
     }()
 
     private static func extractFootnotes(from markdown: String) -> FootnoteExtraction {
+        guard markdown.contains("[^") else {
+            return FootnoteExtraction(markdown: markdown, definitions: [], references: [])
+        }
+
         let split = splitFootnoteDefinitions(from: markdown)
         var protected: [String] = []
 
@@ -451,17 +454,16 @@ nonisolated enum MarkdownHTML {
             let ordinal = (referenceOrdinalsByNumber[definition.number] ?? 0) + 1
             referenceOrdinalsByNumber[definition.number] = ordinal
             let token = "MdPreviewFootnoteRef\(references.count)Token"
-            references.append(FootnoteReference(token: token, number: definition.number, ordinal: ordinal))
+            references.append(FootnoteReference(number: definition.number, ordinal: ordinal))
             return token
         }
 
-        var restored = replacedReferences
-        for (i, original) in protected.enumerated() {
-            restored = restored.replacingOccurrences(
-                of: "MdPreviewFootnoteProtect\(i)Token",
-                with: original
-            )
-        }
+        let restored = restoreIndexedTokens(
+            in: replacedReferences,
+            prefix: "MdPreviewFootnoteProtect",
+            suffix: "Token",
+            replacements: protected
+        )
 
         return FootnoteExtraction(
             markdown: restored,
@@ -581,8 +583,7 @@ nonisolated enum MarkdownHTML {
     private static func renderFootnoteReferences(in html: String,
                                                  with footnotes: FootnoteExtraction) -> String {
         guard !footnotes.references.isEmpty else { return html }
-        var rendered = html
-        for reference in footnotes.references {
+        let replacements = footnotes.references.map { reference in
             let refID = footnoteReferenceID(number: reference.number, ordinal: reference.ordinal)
             let footnoteID = footnoteDefinitionID(number: reference.number)
             let accessibilityLabel = htmlEscape(String(
@@ -592,9 +593,14 @@ nonisolated enum MarkdownHTML {
             let replacement = """
             <sup class="footnote-ref"><a id="\(refID)" href="#\(footnoteID)" aria-label="\(accessibilityLabel)">\(reference.number)</a></sup>
             """
-            rendered = rendered.replacingOccurrences(of: reference.token, with: replacement)
+            return replacement
         }
-        return rendered
+        return restoreIndexedTokens(
+            in: html,
+            prefix: "MdPreviewFootnoteRef",
+            suffix: "Token",
+            replacements: replacements
+        )
     }
 
     private static func renderFootnoteDefinitions(
@@ -874,13 +880,12 @@ nonisolated enum MarkdownHTML {
             return "MdPreviewMathInline\(inlines.count)Token"
         }
 
-        var processed = afterInlineMath
-        for (i, original) in protected.enumerated() {
-            processed = processed.replacingOccurrences(
-                of: "MdPreviewProtect\(i)Token",
-                with: original
-            )
-        }
+        let processed = restoreIndexedTokens(
+            in: afterInlineMath,
+            prefix: "MdPreviewProtect",
+            suffix: "Token",
+            replacements: protected
+        )
 
         return MathExtraction(
             processedMarkdown: processed,
@@ -1652,7 +1657,6 @@ nonisolated enum MarkdownHTML {
             ADD_ATTR: ['target'],
             ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix|md-asset):|[^a-z]|[a-z+.\\-]+(?:[^a-z+.\\-:]|$))/i
         };
-
         function sanitize(html) {
             if (typeof html !== 'string') return '';
             if (typeof DOMPurify === 'undefined' || !DOMPurify.sanitize) {
@@ -2093,6 +2097,51 @@ nonisolated enum MarkdownHTML {
             cursor = match.range.location + match.range.length
         }
         result += nsSource.substring(from: cursor)
+        return result
+    }
+
+    /// Replaces generated `prefix + decimal index + suffix` placeholders in a
+    /// single forward pass. Re-running `replacingOccurrences` once per token
+    /// made documents with many code spans, code fences, or footnotes scale
+    /// quadratically because each restoration rescanned the whole document.
+    private static func restoreIndexedTokens(in source: String,
+                                             prefix: String,
+                                             suffix: String,
+                                             replacements: [String]) -> String {
+        guard !replacements.isEmpty, source.contains(prefix) else { return source }
+
+        var result = ""
+        result.reserveCapacity(source.count)
+        var cursor = source.startIndex
+
+        while let tokenStart = source.range(
+            of: prefix,
+            range: cursor..<source.endIndex
+        ) {
+            result.append(contentsOf: source[cursor..<tokenStart.lowerBound])
+
+            var digitsEnd = tokenStart.upperBound
+            while digitsEnd < source.endIndex, source[digitsEnd].isNumber {
+                source.formIndex(after: &digitsEnd)
+            }
+
+            guard digitsEnd > tokenStart.upperBound,
+                  source[digitsEnd...].hasPrefix(suffix),
+                  let index = Int(source[tokenStart.upperBound..<digitsEnd]),
+                  replacements.indices.contains(index) else {
+                // This prefix can appear in authored Markdown. Preserve it and
+                // continue searching after the prefix instead of consuming an
+                // unrelated suffix later in the document.
+                result.append(contentsOf: source[tokenStart.lowerBound..<tokenStart.upperBound])
+                cursor = tokenStart.upperBound
+                continue
+            }
+
+            result.append(replacements[index])
+            cursor = source.index(digitsEnd, offsetBy: suffix.count)
+        }
+
+        result.append(contentsOf: source[cursor...])
         return result
     }
 

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1437,16 +1437,29 @@ nonisolated enum MarkdownHTML {
                     const column = Number(cell.dataset.tableColumn);
                     const placeholder = `Column ${column + 1}`;
                     cell.dataset.placeholder = placeholder;
-                    if (!(cell.innerText || '').trim()) cell.textContent = '';
-                    const updateAccessibilityLabel = () => {
-                        if ((cell.innerText || '').trim()) cell.removeAttribute('aria-label');
-                        else cell.setAttribute('aria-label', placeholder);
-                    };
-                    updateAccessibilityLabel();
-                    cell.addEventListener('input', updateAccessibilityLabel);
+                    // `innerText` forces layout when the table is already in
+                    // the live document. Header emptiness only depends on the
+                    // authored content, so `textContent` is sufficient here.
+                    if (!(cell.textContent || '').trim()) cell.textContent = '';
+                    updateTableHeaderAccessibilityLabel(cell);
                 });
             });
         }
+
+        function updateTableHeaderAccessibilityLabel(cell) {
+            const placeholder = cell.dataset.placeholder;
+            if (!placeholder) return;
+            if ((cell.textContent || '').trim()) cell.removeAttribute('aria-label');
+            else cell.setAttribute('aria-label', placeholder);
+        }
+
+        // One delegated listener covers both initial and morphed tables.
+        document.addEventListener('input', (event) => {
+            const cell = event.target.closest?.(
+                '.md-table-editor th[data-table-column]'
+            );
+            if (cell) updateTableHeaderAccessibilityLabel(cell);
+        });
 
         document.addEventListener('mousedown', (event) => {
             if (event.button !== 0) return;

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -1453,13 +1453,15 @@ nonisolated enum MarkdownHTML {
             else cell.setAttribute('aria-label', placeholder);
         }
 
-        // One delegated listener covers both initial and morphed tables.
-        document.addEventListener('input', (event) => {
-            const cell = event.target.closest?.(
-                '.md-table-editor th[data-table-column]'
-            );
-            if (cell) updateTableHeaderAccessibilityLabel(cell);
-        });
+        if (hasHostBridge) {
+            // One delegated listener covers both initial and morphed tables.
+            document.addEventListener('input', (event) => {
+                const cell = event.target.closest?.(
+                    '.md-table-editor th[data-table-column]'
+                );
+                if (cell) updateTableHeaderAccessibilityLabel(cell);
+            });
+        }
 
         document.addEventListener('mousedown', (event) => {
             if (event.button !== 0) return;

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -147,7 +147,12 @@ nonisolated enum MarkdownHTML {
             sourceLineOffset: sourceLineOffset
         )
         let headingsHTML = injectHeadingIDs(in: footnoteReferenceHTML + footnoteDefinitions.html)
-        let renderedBodyHTML = injectRTLDirection(in: headingsHTML)
+        // Direction inference scans every rendered block. Most documents
+        // contain no RTL text, so avoid walking the much larger generated
+        // HTML unless the Markdown could produce an RTL first character.
+        let renderedBodyHTML = sourceMayNeedRTLDirection(body)
+            ? injectRTLDirection(in: headingsHTML)
+            : headingsHTML
         let frontmatterHTML: String
         if let raw = frontmatter.raw,
            let format = frontmatter.format {
@@ -316,6 +321,26 @@ nonisolated enum MarkdownHTML {
         0x08A0...0x08FF, 0xFB50...0xFDFF, 0xFE70...0xFEFF
     ]
 
+    /// Over-inclusive by design: CommonMark decodes numeric character
+    /// references before formatting, so any `&#` might become RTL text.
+    /// False positives only take the existing slow path; false negatives
+    /// would skip direction inference.
+    private static func sourceMayNeedRTLDirection(_ source: String) -> Bool {
+        var previousWasAmpersand = false
+        for scalar in source.unicodeScalars {
+            if scalar.value >= 0x0590,
+               scalar.value <= 0xFEFF,
+               isRTL(scalar) {
+                return true
+            }
+            if previousWasAmpersand, scalar.value == 0x23 {
+                return true
+            }
+            previousWasAmpersand = scalar.value == 0x26
+        }
+        return false
+    }
+
     private static func injectRTLDirection(in html: String) -> String {
         let nsHtml = html as NSString
         let matches = rtlTagRegex.matches(in: html, range: NSRange(location: 0, length: nsHtml.length))
@@ -372,6 +397,10 @@ nonisolated enum MarkdownHTML {
 
     private static func isRTL(_ char: Character) -> Bool {
         guard let scalar = char.unicodeScalars.first else { return false }
+        return isRTL(scalar)
+    }
+
+    private static func isRTL(_ scalar: Unicode.Scalar) -> Bool {
         return rtlRanges.contains { $0.contains(scalar.value) }
     }
 

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -294,10 +294,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     private static let warmupMarkdown = ""
 
     private func warmupVendors() {
-        // Opening a real document during launch takes priority over speculative
-        // vendor warmup. Large documents otherwise give this tiny render enough
-        // time to win the race and make WebKit parse Mermaid + KaTeX +
-        // highlight.js before it can show the actual text.
+        // Opening a real document during launch takes priority over
+        // speculative WebKit work, which otherwise competes with the first
+        // Markdown render on cold open.
         guard renderGeneration == 0,
               !isPageReady,
               loadedFingerprint == nil else { return }
@@ -316,7 +315,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     private func applyWarmup(_ rendered: MarkdownHTML.RenderedHTML) {
         // Another display() may have arrived during the off-main render and
-        // already swapped the page in — don't stomp it with the warmup doc.
+        // taken priority over the speculative shell.
         guard renderGeneration == 0,
               !isPageReady,
               loadedFingerprint == nil else { return }
@@ -369,7 +368,16 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
                                             markdown: markdown,
                                             assetBaseHref: baseHref,
                                             contentWidth: contentWidth)
+            #if DEBUG
+            let renderFinishedAt = DispatchTime.now().uptimeNanoseconds
+            await self?.applyDisplayDebug(
+                rendered,
+                generation: generation,
+                renderFinishedAt: renderFinishedAt
+            )
+            #else
             await self?.applyDisplay(rendered, generation: generation)
+            #endif
         }
     }
 
@@ -397,6 +405,22 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         )
         return rendered
     }
+
+    #if DEBUG
+    private func applyDisplayDebug(_ rendered: MarkdownHTML.RenderedHTML,
+                                   generation: UInt64,
+                                   renderFinishedAt: UInt64) {
+        let enteredAt = DispatchTime.now().uptimeNanoseconds
+        Logger.perf.debug(
+            "[mdp-perf-swift] render finish -> MainActor +\(Self.debugMilliseconds(from: renderFinishedAt, to: enteredAt), privacy: .public)ms"
+        )
+        applyDisplay(rendered, generation: generation)
+        let returnedAt = DispatchTime.now().uptimeNanoseconds
+        Logger.perf.debug(
+            "[mdp-perf-swift] applyDisplay sync +\(Self.debugMilliseconds(from: enteredAt, to: returnedAt), privacy: .public)ms"
+        )
+    }
+    #endif
 
     private func applyDisplay(_ rendered: MarkdownHTML.RenderedHTML,
                               generation: UInt64) {
@@ -435,7 +459,16 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             return
         }
 
+        #if DEBUG
+        let loadStartedAt = DispatchTime.now().uptimeNanoseconds
         webView.loadHTMLString(rendered.html, baseURL: nil)
+        let loadReturnedAt = DispatchTime.now().uptimeNanoseconds
+        Logger.perf.debug(
+            "[mdp-perf-swift] loadHTMLString call +\(Self.debugMilliseconds(from: loadStartedAt, to: loadReturnedAt), privacy: .public)ms"
+        )
+        #else
+        webView.loadHTMLString(rendered.html, baseURL: nil)
+        #endif
         loadedFingerprint = fingerprint
         isPageReady = false
     }
@@ -454,6 +487,13 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         isPageReady = false
         reloadPreview()
     }
+
+    #if DEBUG
+    private nonisolated static func debugMilliseconds(from start: UInt64,
+                                                      to end: UInt64) -> Int {
+        Int((Double(end - start) / 1_000_000).rounded())
+    }
+    #endif
 
     fileprivate func didReceiveHostMessage(_ body: Any) {
         guard let dict = body as? [String: Any],

--- a/md-preview/MarkdownWebView.swift
+++ b/md-preview/MarkdownWebView.swift
@@ -287,25 +287,20 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         forMainFrameOnly: true
     )
 
-    /// Synthetic markdown that flips every renderer flag (math + mermaid +
-    /// code). Loaded into the WebView at launch so the heavy vendor JS is
-    /// parsed and executed before the user picks a real file. Every later
-    /// `display()` call then hits the fast-path (innerHTML swap + reapplier
-    /// sweep) instead of paying for a full reload.
-    private static let warmupMarkdown = """
-    $x$
-
-    ```mermaid
-    graph TD; A-->B
-    ```
-
-    ```typescript
-    let x: string = 'warmup';
-    ```
-    """
+    /// Warm only the stable preview shell. Plain documents can populate this
+    /// ready page immediately, while rich documents deliberately take a fresh
+    /// lazy-vendor load so their text paints before KaTeX, Mermaid, or
+    /// highlight.js work and the idle page does not retain those runtimes.
+    private static let warmupMarkdown = ""
 
     private func warmupVendors() {
-        guard !isPageReady, loadedFingerprint == nil else { return }
+        // Opening a real document during launch takes priority over speculative
+        // vendor warmup. Large documents otherwise give this tiny render enough
+        // time to win the race and make WebKit parse Mermaid + KaTeX +
+        // highlight.js before it can show the actual text.
+        guard renderGeneration == 0,
+              !isPageReady,
+              loadedFingerprint == nil else { return }
         let baseHref = MarkdownAssetResolution.rootBaseHref
         let markdown = Self.warmupMarkdown
         let contentWidth = ContentWidthSetting.current.renderWidth
@@ -322,7 +317,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     private func applyWarmup(_ rendered: MarkdownHTML.RenderedHTML) {
         // Another display() may have arrived during the off-main render and
         // already swapped the page in — don't stomp it with the warmup doc.
-        guard !isPageReady, loadedFingerprint == nil else { return }
+        guard renderGeneration == 0,
+              !isPageReady,
+              loadedFingerprint == nil else { return }
         loadedFingerprint = RendererFingerprint(
             math: rendered.containsMath,
             mermaid: rendered.containsMermaid,
@@ -414,16 +411,25 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
         // Fast path: the loaded page already has every renderer the new doc
         // needs — swap the article body via JS instead of reloading the
-        // WKWebView (which would re-parse and re-execute the multi-MB vendor
-        // bundles). The launch-time warmup loads both vendors, so any
-        // subsequent file with any subset of renderers fast-paths into it.
+        // WKWebView. The launch-time shell intentionally has no rich renderers,
+        // so a first math/Mermaid/code document gets a progressive lazy load.
         if isPageReady, let loaded = loadedFingerprint, loaded.covers(fingerprint) {
-            let payload = javaScriptStringLiteral(rendered.articleHTML)
             // The loaded page keeps its original <base> across body swaps —
             // pass the current document's base along so relative links keep
             // resolving against the right folder after switching files.
-            let base = javaScriptStringLiteral(currentBaseHref)
-            webView.evaluateJavaScript("window.MdPreview && MdPreview.update(\(payload), { baseHref: \(base) });") { [weak self] _, _ in
+            webView.callAsyncJavaScript(
+                """
+                if (!window.MdPreview) return false;
+                window.MdPreview.update(articleHTML, { baseHref });
+                return true;
+                """,
+                arguments: [
+                    "articleHTML": rendered.articleHTML,
+                    "baseHref": currentBaseHref,
+                ],
+                in: nil,
+                in: .page
+            ) { [weak self] _ in
                 self?.contentDidReplace?()
             }
             return

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -38,7 +38,7 @@ positional args to override. `--duration` (default 20 s) controls the
 sampling window per sample.
 
 CSV rows are `label,sample,metric,value` with metrics:
-`fcp_ms`, `render_ms`, `update_ms` (mean), `update_count`,
+`fcp_ms`, `render_ms`, `update_last_ms`, `update_ms` (mean), `update_count`,
 `rss_peak_kb_app`, `rss_mean_kb_app`, `rss_peak_kb_webcontent`,
 `rss_mean_kb_webcontent`, `cpu_mean_app`, `cpu_mean_webcontent`.
 
@@ -101,15 +101,19 @@ Measures the innerHTML-swap (or morphdom) update path under repeated edits:
   the launch-time vendor warmup and any restored windows emit earlier ones,
   and the freshly opened sample always renders after them. Don't interact
   with the app during timed opens.
-- `bench-app.sh` deletes the app's saved window state (in its sandbox
-  container) before each launch so macOS window restoration doesn't reopen
-  the previous sample and pollute RSS/CPU and update timings.
+- `bench-app.sh` launches with `open -F` and deletes the app's saved window
+  state (in its sandbox container) before each run so macOS window restoration
+  doesn't reopen previous samples and pollute RSS/CPU and update timings.
+- App log capture matches the built app's exact bundle id. Prefix matching
+  (`subsystem BEGINSWITH "doc.md-preview"`) can accidentally ingest Quick
+  Actions or extensions and assign their timings to the document under test.
 - `footprint` snapshots usually need sudo; the script degrades to ps-only
   RSS when unavailable.
 - `update_ms` blends in one small launch-warmup `MdPreview.update` that the
   log can't distinguish from the sample's own updates. On cold-open runs
-  (update_count ≈ 2) treat it as indicative only; edit-cycle runs dilute the
-  warmup to noise. Always compare `update_count` between baseline and
+  (update_count ≈ 2) use `update_last_ms`, which represents the displayed
+  document. `update_ms` remains useful for edit-cycle runs, where many updates
+  dilute warmup to noise. Always compare `update_count` between baseline and
   candidate to make sure you're averaging the same population.
 - `ps pcpu` is a decaying average, not an instantaneous reading — treat
   `cpu_mean_*` as relative between runs, not absolute utilization.

--- a/scripts/bench/bench-app.sh
+++ b/scripts/bench/bench-app.sh
@@ -3,7 +3,7 @@
 # bench-app.sh — CPU/memory/first-paint benchmark for the Markdown Preview app.
 #
 # For each sample file it launches the built app cold, captures the debug
-# perf log lines (subsystem doc.md-preview*, category perf), samples RSS/CPU
+# perf log lines from the app's exact bundle-id subsystem, samples RSS/CPU
 # of the app process and its WebKit WebContent process(es) every 500 ms, and
 # writes one CSV of metrics per run.
 #
@@ -80,6 +80,9 @@ echo "==> Output: $OUT_DIR"
 
 APP_PROC_NAME="Markdown Preview"
 BUNDLE_ID="$(defaults read "$APP_PATH/Contents/Info" CFBundleIdentifier 2>/dev/null || true)"
+[[ -n "$BUNDLE_ID" ]] || { echo "bundle id not found in app: $APP_PATH" >&2; exit 1; }
+[[ "$BUNDLE_ID" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]] \
+    || { echo "invalid bundle id in app: $BUNDLE_ID" >&2; exit 1; }
 
 # Window restoration reopens documents from the previous run, polluting both
 # the perf log and RSS/CPU attribution — wipe saved state for a clean cold open.
@@ -106,7 +109,7 @@ webcontent_pids() {
 # Extract metrics from a captured `log stream` file and the raw ps samples,
 # append CSV rows. Args: sample-name, logfile, psfile.
 emit_metrics() {
-    local name="$1" logfile="$2" psfile="$3" v
+    local name="$1" logfile="$2" psfile="$3" v update_values
 
     # FCP: last occurrence wins — the launch warmup page can also emit one,
     # and the real document's paint always comes after it.
@@ -128,15 +131,20 @@ emit_metrics() {
     # counted the same as plain builds. The sed capture pulls only the
     # timing digits — a bare [0-9.]+ grep would also match the dot in
     # "MdPreview.update" and double-count every line.
-    # Caveat: the launch-time warmup page fires one small update of its own
-    # that can't be told apart in the log, so cold-open means blend it in —
-    # compare update_count between runs and prefer edit-cycle runs (many
-    # updates) when update_ms is the metric under test.
-    sed -nE 's/.*MdPreview\.update( \([a-z]+\))? \(\+([0-9.]+)ms\).*/\2/p' "$logfile" \
-        | awk -v L="$LABEL" -v S="$name" '
-            { sum += $1; n++ }
-            END { if (n) printf "%s,%s,update_ms,%.1f\n%s,%s,update_count,%d\n",
-                          L, S, sum/n, L, S, n }' >> "$CSV"
+    # Caveat: when the launch-time shell wins the race, it fires one small
+    # update that can't be told apart in the log. update_last_ms identifies the
+    # displayed document; update_ms remains useful for repeated edit cycles.
+    update_values="$(sed -nE \
+        's/.*MdPreview\.update( \([a-z]+\))? \(\+([0-9.]+)ms\).*/\2/p' \
+        "$logfile")"
+    if [[ -n "$update_values" ]]; then
+        v="$(printf '%s\n' "$update_values" | tail -1)"
+        echo "$LABEL,$name,update_last_ms,$v" >> "$CSV"
+        printf '%s\n' "$update_values" | awk -v L="$LABEL" -v S="$name" '
+                { sum += $1; n++ }
+                END { if (n) printf "%s,%s,update_ms,%.1f\n%s,%s,update_count,%d\n",
+                              L, S, sum/n, L, S, n }' >> "$CSV"
+    fi
 
     # RSS / CPU stats from the ps samples (columns: role rss_kb pcpu).
     awk -v L="$LABEL" -v S="$name" '
@@ -170,12 +178,14 @@ run_sample() {
 
     # Start the log capture before launch so early perf lines aren't missed.
     log stream --level debug --style compact \
-        --predicate 'subsystem BEGINSWITH "doc.md-preview"' \
+        --predicate "subsystem == \"$BUNDLE_ID\"" \
         > "$logfile" 2>/dev/null &
     local log_pid=$!
     sleep 1
 
-    open -a "$APP_PATH" "$sample"
+    # -F asks AppKit for a fresh launch, preventing restored document windows
+    # from adding unrelated renders and WebContent processes to this sample.
+    open -F -a "$APP_PATH" "$sample"
 
     local app_pid=""
     for _ in $(seq 1 20); do

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/InitialRenderProbeTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/InitialRenderProbeTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import XCTest
+@testable import MarkdownHelpers
+
+/// Manual scaling probe used while tuning the app's first document render.
+/// Run in Release so Swift's optimizer matches the distributed app:
+///
+///     RUN_INITIAL_RENDER_PROBE=1 swift test -c release --package-path tests/swift-tests \
+///       --filter InitialRenderProbeTests/testRenderScaling
+final class InitialRenderProbeTests: XCTestCase {
+    func testRenderScaling() throws {
+        guard ProcessInfo.processInfo.environment["RUN_INITIAL_RENDER_PROBE"] == "1" else {
+            throw XCTSkip("Set RUN_INITIAL_RENDER_PROBE=1 to run the manual scaling benchmark")
+        }
+        _ = MarkdownHTML.render(markdown: "warmup", vendorLoading: .lazy)
+
+        let cases = [
+            ("prose-100k", makeDocument(targetBytes: 100_000, block: proseBlock)),
+            ("prose-500k", makeDocument(targetBytes: 500_000, block: proseBlock)),
+            ("prose-1m", makeDocument(targetBytes: 1_000_000, block: proseBlock)),
+            ("headings-500k", makeDocument(targetBytes: 500_000, block: headingBlock)),
+            ("code-500k", makeDocument(targetBytes: 500_000, block: codeBlock)),
+            ("mixed-500k", makeDocument(targetBytes: 500_000, block: mixedBlock)),
+        ]
+
+        for (name, markdown) in cases {
+            var samples: [Double] = []
+            var outputBytes = 0
+            for _ in 0..<3 {
+                let start = ContinuousClock.now
+                let rendered = MarkdownHTML.render(markdown: markdown, vendorLoading: .lazy)
+                samples.append(milliseconds(since: start))
+                outputBytes = rendered.articleHTML.utf8.count
+            }
+            let mean = samples.reduce(0, +) / Double(samples.count)
+            print(
+                "INITIAL_RENDER_PROBE name=\(name)"
+                    + " input_bytes=\(markdown.utf8.count)"
+                    + " output_bytes=\(outputBytes)"
+                    + " mean_ms=\(String(format: "%.1f", mean))"
+                    + " samples_ms=\(samples.map { String(format: "%.1f", $0) }.joined(separator: ","))"
+            )
+        }
+    }
+
+    private func makeDocument(targetBytes: Int, block: String) -> String {
+        let count = max(1, targetBytes / block.utf8.count)
+        return String(repeating: block, count: count)
+    }
+
+    private func milliseconds(since start: ContinuousClock.Instant) -> Double {
+        let duration = start.duration(to: .now)
+        return Double(duration.components.seconds) * 1_000
+            + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+    }
+
+    private var proseBlock: String {
+        """
+        ## A representative section
+
+        Markdown Preview should show useful text quickly, even when a document contains
+        many paragraphs, **emphasis**, [links](https://example.com), and ordinary lists.
+
+        - First item with enough prose to wrap across a normal preview column.
+        - Second item with `inline code` and a little more explanatory text.
+        - Third item that keeps the source structurally realistic.
+
+        """
+    }
+
+    private var headingBlock: String {
+        """
+        ## Section heading
+
+        A short paragraph under the section.
+
+        ### Nested heading
+
+        Another short paragraph with [a link](https://example.com).
+
+        """
+    }
+
+    private var codeBlock: String {
+        """
+        ## Code example
+
+        ```swift
+        struct Record {
+            let identifier: Int
+            let title: String
+        }
+
+        let records = (0..<100).map { Record(identifier: $0, title: "Item \\($0)") }
+        ```
+
+        A paragraph after the code block.
+
+        """
+    }
+
+    private var mixedBlock: String {
+        """
+        ## Mixed content
+
+        A paragraph with inline math $x^2 + y^2$, a footnote reference[^note], and `code`.
+
+        | Name | Value | Notes |
+        | --- | ---: | --- |
+        | Alpha | 42 | A representative row |
+        | Beta | 84 | Another representative row |
+
+        > [!NOTE]
+        > Large files can combine several Markdown features.
+
+        [^note]: A compact footnote definition.
+
+        """
+    }
+}

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -1363,6 +1363,24 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(rendered.articleHTML.contains("class=\"math"))
     }
 
+    func testProtectedCodeTokensRestoreInOnePassWithoutChangingContent() {
+        let codeSpans = (0..<100)
+            .map { "`literal-\($0)-$not-math$`" }
+            .joined(separator: " ")
+        let rendered = MarkdownHTML.render(
+            markdown: "MdPreviewProtectNotAToken \(codeSpans)",
+            vendorLoading: .lazy
+        )
+
+        XCTAssertFalse(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains("MdPreviewProtectNotAToken"))
+        XCTAssertTrue(rendered.articleHTML.contains("<code>literal-0-$not-math$</code>"))
+        XCTAssertTrue(rendered.articleHTML.contains("<code>literal-50-$not-math$</code>"))
+        XCTAssertTrue(rendered.articleHTML.contains("<code>literal-99-$not-math$</code>"))
+        XCTAssertFalse(rendered.articleHTML.contains("MdPreviewProtect0Token"))
+        XCTAssertFalse(rendered.articleHTML.contains("MdPreviewFootnoteProtect0Token"))
+    }
+
     @MainActor
     func testReportedLatexStructuresRenderWithBundledKatex() async throws {
         let rendered = MarkdownHTML.render(
@@ -1477,6 +1495,25 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertTrue(rendered.articleHTML.contains(
             "<p data-source-line=\"8\" data-source-start=\"8\" data-source-end=\"9\">First definition line."
         ))
+    }
+
+    func testMultipleFootnoteReferencesRestoreInSourceOrder() {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            First[^one], repeated[^one], and second[^two]. Literal `[^one]`.
+
+            [^one]: First note.
+            [^two]: Second note.
+            """,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertTrue(rendered.articleHTML.contains("id=\"fnref-1\" href=\"#fn-1\""))
+        XCTAssertTrue(rendered.articleHTML.contains("id=\"fnref-1-2\" href=\"#fn-1\""))
+        XCTAssertTrue(rendered.articleHTML.contains("id=\"fnref-2\" href=\"#fn-2\""))
+        XCTAssertTrue(rendered.articleHTML.contains("<code>[^one]</code>"))
+        XCTAssertFalse(rendered.articleHTML.contains("MdPreviewFootnoteRef"))
+        XCTAssertFalse(rendered.articleHTML.contains("MdPreviewFootnoteProtect"))
     }
 
     func testTablesExposeSourceRangeAndStableCellCoordinates() {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -331,6 +331,27 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         ))
     }
 
+    func testRTLDirectionRecognizesHebrewAndNumericCharacterReferences() {
+        let samples = [
+            "שלום עולם.",
+            "&#1513;&#1500;&#1493;&#1501;",
+            "&#x05E9;&#x05DC;&#x05D5;&#x05DD;",
+            "&#X05E9;&#X05DC;&#X05D5;&#X05DD;",
+        ]
+
+        for markdown in samples {
+            let rendered = MarkdownHTML.render(
+                markdown: markdown,
+                vendorLoading: .lazy
+            )
+
+            XCTAssertTrue(
+                rendered.articleHTML.contains(#" dir="rtl">"#),
+                "Expected RTL direction for \(markdown)"
+            )
+        }
+    }
+
     func testReadOnlyRenderingPreservesEveryBlankSourceLine() {
         let rendered = MarkdownHTML.render(
             markdown: "First paragraph.\n\n\n## Heading\n\nSecond paragraph.",

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MdPreviewUpdateTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MdPreviewUpdateTests.swift
@@ -177,7 +177,10 @@ final class MdPreviewUpdateTests: XCTestCase {
 
     @MainActor
     func testTableHeaderPlaceholderAccessibilityUsesDelegatedUpdates() async throws {
-        let webView = try await loadHarness(articleAttributes: "", installsHostBridge: true)
+        let webView = try await loadHarness(
+            articleAttributes: "",
+            stubsWebKitMessageHandler: true
+        )
         let article = MarkdownHTML.render(
             markdown: """
             | | Name |
@@ -187,6 +190,49 @@ final class MdPreviewUpdateTests: XCTestCase {
             vendorLoading: .lazy
         ).articleHTML
         let document = MarkdownHTML.javaScriptStringLiteral(article)
+
+        // Instrument the WebKit APIs that caused the regression. Unlike a
+        // source-string assertion, these counters remain valid if functions
+        // or event-handler registration are reordered.
+        _ = try await webView.evaluateJavaScript("""
+        (() => {
+            window.__tableHeaderInnerTextReads = 0;
+            window.__tableCellInputListenerRegistrations = 0;
+
+            const innerText = Object.getOwnPropertyDescriptor(
+                HTMLElement.prototype,
+                'innerText'
+            );
+            if (!innerText || typeof innerText.get !== 'function') {
+                throw new Error('HTMLElement.innerText getter unavailable');
+            }
+            const patchedInnerText = {
+                configurable: innerText.configurable,
+                enumerable: innerText.enumerable,
+                get() {
+                    if (this.matches?.('th[data-table-column]')) {
+                        window.__tableHeaderInnerTextReads += 1;
+                    }
+                    return innerText.get.call(this);
+                }
+            };
+            if (innerText.set) {
+                patchedInnerText.set = function (value) {
+                    return innerText.set.call(this, value);
+                };
+            }
+            Object.defineProperty(HTMLElement.prototype, 'innerText', patchedInnerText);
+
+            const addEventListener = EventTarget.prototype.addEventListener;
+            EventTarget.prototype.addEventListener = function (type, listener, options) {
+                if (type === 'input' && this instanceof HTMLTableCellElement) {
+                    window.__tableCellInputListenerRegistrations += 1;
+                }
+                return addEventListener.call(this, type, listener, options);
+            };
+            return true;
+        })()
+        """)
 
         // Exercise both the initial populate and the morph path. Table setup
         // must stay idempotent and the delegated input handler must keep the
@@ -220,6 +266,9 @@ final class MdPreviewUpdateTests: XCTestCase {
                 editorCount: document.querySelectorAll('.md-table-editor').length,
                 scrollCount: document.querySelectorAll('.md-table-scroll').length,
                 headerCount: headers.length,
+                headerInnerTextReads: window.__tableHeaderInnerTextReads,
+                tableCellInputListenerRegistrations:
+                    window.__tableCellInputListenerRegistrations,
                 placeholder: empty.dataset.placeholder || '',
                 initialEmptyLabel,
                 initialNamedLabel,
@@ -234,26 +283,13 @@ final class MdPreviewUpdateTests: XCTestCase {
         XCTAssertEqual(state.editorCount, 1, json)
         XCTAssertEqual(state.scrollCount, 1, json)
         XCTAssertEqual(state.headerCount, 2, json)
+        XCTAssertEqual(state.headerInnerTextReads, 0, json)
+        XCTAssertEqual(state.tableCellInputListenerRegistrations, 0, json)
         XCTAssertEqual(state.placeholder, "Column 1", json)
         XCTAssertEqual(state.initialEmptyLabel, "Column 1", json)
         XCTAssertNil(state.initialNamedLabel, json)
         XCTAssertNil(state.renamedLabel, json)
         XCTAssertEqual(state.restoredLabel, "Column 1", json)
-    }
-
-    func testTableSetupAvoidsPerHeaderLayoutReadsAndListeners() throws {
-        let script = MarkdownHTML.hostBridgeScript
-        let start = try XCTUnwrap(script.range(of: "function enableTableEditing"))
-        let tableSetupTail = script[start.lowerBound...]
-        let end = try XCTUnwrap(
-            tableSetupTail.range(of: "document.addEventListener('mousedown'")
-        )
-        let tableSetup = tableSetupTail[..<end.lowerBound]
-
-        XCTAssertTrue(tableSetup.contains("cell.textContent"))
-        XCTAssertTrue(tableSetup.contains("document.addEventListener('input'"))
-        XCTAssertFalse(tableSetup.contains("cell.innerText"))
-        XCTAssertFalse(tableSetup.contains("cell.addEventListener('input'"))
     }
 
     /// Builds the harness page — bundled DOMPurify + morphdom, the shipped
@@ -264,11 +300,11 @@ final class MdPreviewUpdateTests: XCTestCase {
     @MainActor
     private func loadHarness(
         articleAttributes: String,
-        installsHostBridge: Bool = false
+        stubsWebKitMessageHandler: Bool = false
     ) async throws -> WKWebView {
         let purifyJS = try TestVendor.script("md-preview/Vendor/DOMPurify/purify.min.js")
         let morphdomJS = try TestVendor.script("md-preview/Vendor/Morphdom/morphdom.min.js")
-        let hostBridgeStub = installsHostBridge
+        let webKitMessageHandlerStub = stubsWebKitMessageHandler
             ? """
               <script>
               window.webkit = {
@@ -312,7 +348,7 @@ final class MdPreviewUpdateTests: XCTestCase {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script>\(purifyJS)</script>
         <script>\(morphdomJS)</script>
-        \(hostBridgeStub)
+        \(webKitMessageHandlerStub)
         \(MarkdownHTML.hostBridgeScript)
         \(fakeRenderers)
         </head><body>
@@ -393,6 +429,8 @@ private struct TableHeaderPlaceholderState: Decodable {
     let editorCount: Int
     let scrollCount: Int
     let headerCount: Int
+    let headerInnerTextReads: Int
+    let tableCellInputListenerRegistrations: Int
     let placeholder: String
     let initialEmptyLabel: String?
     let initialNamedLabel: String?

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MdPreviewUpdateTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MdPreviewUpdateTests.swift
@@ -175,15 +175,110 @@ final class MdPreviewUpdateTests: XCTestCase {
         XCTAssertEqual(codeSurvived, true)
     }
 
+    @MainActor
+    func testTableHeaderPlaceholderAccessibilityUsesDelegatedUpdates() async throws {
+        let webView = try await loadHarness(articleAttributes: "", installsHostBridge: true)
+        let article = MarkdownHTML.render(
+            markdown: """
+            | | Name |
+            | --- | --- |
+            | First | Ada |
+            """,
+            vendorLoading: .lazy
+        ).articleHTML
+        let document = MarkdownHTML.javaScriptStringLiteral(article)
+
+        // Exercise both the initial populate and the morph path. Table setup
+        // must stay idempotent and the delegated input handler must keep the
+        // placeholder's accessibility label in sync.
+        _ = try await webView.evaluateJavaScript(
+            "window.MdPreview.update(\(document)); true"
+        )
+        _ = try await webView.evaluateJavaScript(
+            "window.MdPreview.update(\(document)); true"
+        )
+
+        let result = try await webView.evaluateJavaScript("""
+        (() => {
+            const headers = document.querySelectorAll(
+                '.md-table-editor th[data-table-column]'
+            );
+            const empty = headers[0];
+            const named = headers[1];
+            const initialEmptyLabel = empty.getAttribute('aria-label');
+            const initialNamedLabel = named.getAttribute('aria-label');
+
+            empty.textContent = 'Renamed';
+            empty.dispatchEvent(new Event('input', { bubbles: true }));
+            const renamedLabel = empty.getAttribute('aria-label');
+
+            empty.textContent = '';
+            empty.dispatchEvent(new Event('input', { bubbles: true }));
+            const restoredLabel = empty.getAttribute('aria-label');
+
+            return JSON.stringify({
+                editorCount: document.querySelectorAll('.md-table-editor').length,
+                scrollCount: document.querySelectorAll('.md-table-scroll').length,
+                headerCount: headers.length,
+                placeholder: empty.dataset.placeholder || '',
+                initialEmptyLabel,
+                initialNamedLabel,
+                renamedLabel,
+                restoredLabel,
+            });
+        })()
+        """)
+        let json = try XCTUnwrap(result as? String)
+        let state = try JSONDecoder().decode(TableHeaderPlaceholderState.self, from: Data(json.utf8))
+
+        XCTAssertEqual(state.editorCount, 1, json)
+        XCTAssertEqual(state.scrollCount, 1, json)
+        XCTAssertEqual(state.headerCount, 2, json)
+        XCTAssertEqual(state.placeholder, "Column 1", json)
+        XCTAssertEqual(state.initialEmptyLabel, "Column 1", json)
+        XCTAssertNil(state.initialNamedLabel, json)
+        XCTAssertNil(state.renamedLabel, json)
+        XCTAssertEqual(state.restoredLabel, "Column 1", json)
+    }
+
+    func testTableSetupAvoidsPerHeaderLayoutReadsAndListeners() throws {
+        let script = MarkdownHTML.hostBridgeScript
+        let start = try XCTUnwrap(script.range(of: "function enableTableEditing"))
+        let tableSetupTail = script[start.lowerBound...]
+        let end = try XCTUnwrap(
+            tableSetupTail.range(of: "document.addEventListener('mousedown'")
+        )
+        let tableSetup = tableSetupTail[..<end.lowerBound]
+
+        XCTAssertTrue(tableSetup.contains("cell.textContent"))
+        XCTAssertTrue(tableSetup.contains("document.addEventListener('input'"))
+        XCTAssertFalse(tableSetup.contains("cell.innerText"))
+        XCTAssertFalse(tableSetup.contains("cell.addEventListener('input'"))
+    }
+
     /// Builds the harness page — bundled DOMPurify + morphdom, the shipped
     /// host bridge, and fake renderers that mimic the real markers: stash
     /// `__mdSrc`, set the done flag, replace the children with a sentinel,
     /// and count runs so a destructive re-render (fresh node, count reset)
     /// is detectable.
     @MainActor
-    private func loadHarness(articleAttributes: String) async throws -> WKWebView {
+    private func loadHarness(
+        articleAttributes: String,
+        installsHostBridge: Bool = false
+    ) async throws -> WKWebView {
         let purifyJS = try TestVendor.script("md-preview/Vendor/DOMPurify/purify.min.js")
         let morphdomJS = try TestVendor.script("md-preview/Vendor/Morphdom/morphdom.min.js")
+        let hostBridgeStub = installsHostBridge
+            ? """
+              <script>
+              window.webkit = {
+                  messageHandlers: {
+                      mdPreviewHost: { postMessage() {} }
+                  }
+              };
+              </script>
+              """
+            : ""
         let fakeRenderers = """
         <script>
         (() => {
@@ -217,6 +312,7 @@ final class MdPreviewUpdateTests: XCTestCase {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script>\(purifyJS)</script>
         <script>\(morphdomJS)</script>
+        \(hostBridgeStub)
         \(MarkdownHTML.hostBridgeScript)
         \(fakeRenderers)
         </head><body>
@@ -291,4 +387,15 @@ private struct WarmupArticleState: Decodable {
     private enum CodingKeys: String, CodingKey {
         case warmup, opacity, keyedBlocks, paragraphText
     }
+}
+
+private struct TableHeaderPlaceholderState: Decodable {
+    let editorCount: Int
+    let scrollCount: Int
+    let headerCount: Int
+    let placeholder: String
+    let initialEmptyLabel: String?
+    let initialNamedLabel: String?
+    let renamedLabel: String?
+    let restoredLabel: String?
 }


### PR DESCRIPTION
## Summary

- replace quadratic code/math/footnote placeholder restoration with a single forward pass
- skip unnecessary frontmatter, footnote, top-level paragraph, and generated-HTML RTL work
- warm a lightweight preview shell while letting a real document win the startup race
- pass large DOM updates through WebKit arguments instead of serializing them into JavaScript source
- avoid table-initialization layout thrash and replace per-header input listeners with one delegated handler
- add a reusable opt-in Release scaling probe, WebKit regressions, a hardened cold-open benchmark harness, and Debug-only render-to-WebKit phase markers

## Root cause

Large documents with many protected code spans or fences restored each placeholder with a separate whole-document scan. That made the Swift render path scale quadratically. Startup could also race the real document with a synthetic warmup that eagerly loaded every vendor runtime.

After removing those costs, profiling showed that RTL inference was the largest remaining standalone Swift post-processing pass for plain files. It regex-scanned the much larger generated HTML and stripped tags block by block even when the Markdown contained no RTL text.

Table editing had a separate WebKit bottleneck: initialization mutated every live table and then read each header through `innerText` twice. Those layout-sensitive reads repeatedly forced WebKit to resolve the growing document, while every header also received its own input listener.

## Performance

| Fixture | Before | After |
| --- | ---: | ---: |
| Plain 250 KB | 1.31 s | 0.17 s |
| Feature-dense 250 KB | 1.30 s | 0.30 s |
| 8,534 code fences, 250 KB | 15.95 s | 0.16 s |
| Structured 1 MB | 19.70 s | 0.98 s |
| 600 tables, 213 KB — DOM update | 565 ms | 105 ms |
| Mixed 250 KB, 642 tables — DOM update | 2.59 s | 115 ms |
| Mixed 250 KB, 642 tables — first contentful paint | 2.62 s | 236 ms |

The final RTL gate reduced the current branch's exact Debug 250 KB plain render from a 248.0 ms mean to 168.7 ms, a 32.0% improvement. In the Release scaling probe it improved every measured family: 100 KB prose 46.5 → 33.1 ms, 500 KB prose 230.9 → 170.1 ms, 1 MB prose 489.3 → 356.8 ms, 500 KB headings 300.2 → 197.5 ms, 500 KB code 154.0 → 119.7 ms, and mixed 500 KB 438.5 → 382.8 ms.

Overall, the Release renderer probe reduced generated 1 MB prose from 17.5 seconds on the original baseline to 0.36 seconds. Table results are means from three clean cold launches of exact Debug binaries; the mixed fixture's DOM update improved 95.5% and first contentful paint improved 91.0%, with peak app and WebContent memory flat to slightly lower.

Debug-only phase markers now separate the render-to-main-actor hop and synchronous `loadHTMLString` call from the existing WebKit-local timings. Cold runs show `loadHTMLString` itself takes about 2 ms; the dominant remaining variable delay is WebKit starting the navigation after that call returns.

## Validation

- `swift test --package-path tests/swift-tests` — 127 tests passed, 1 opt-in benchmark skipped
- Debug and Release `xcodebuild` app builds
- `RUN_INITIAL_RENDER_PROBE=1 swift test -c release --package-path tests/swift-tests --filter InitialRenderProbeTests/testRenderScaling`
- three exact-app cold-launch repeats for the 250 KB plain fixture
- cold-launch matrix across 10 KB plain, 250 KB plain/headings/code/mixed, and 1 MB plain fixtures
- WebKit regression coverage for table placeholder behavior, morph idempotence, delegated accessibility updates, and the no-layout-read performance invariant
- RTL regression coverage for Arabic, Hebrew, and decimal/lowercase-hex/uppercase-hex numeric character references
