### PR TITLE
Fix broken Buy Me a Coffee button image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://buymeacoffee.com/pluk">
-    <img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=pluk&button_colour=FFDD00&font_colour=000000&font_family=Inter&outline_colour=000000&coffee_colour=ffffff" height="42" alt="Buy Me a Coffee" />
+    <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" height="42" alt="Buy Me a Coffee" />
   </a>
 </p>
 


### PR DESCRIPTION
## Summary

The Buy Me a Coffee button added in #249 renders as a broken image on GitHub.

The `img.buymeacoffee.com/button-api/` endpoint returns a ~32 KB SVG with embedded fonts, which GitHub's camo image proxy fails to serve. The URL also contained unescaped spaces in the `text=` parameter.

Swapped it for the static PNG button asset (`cdn.buymeacoffee.com/buttons/v2/default-yellow.png`), which camo proxies fine.

## Test plan

- [ ] Button renders on the rendered README on GitHub
- [ ] Clicking it still goes to https://buymeacoffee.com/pluk

🤖 Generated with [Claude Code](https://claude.com/claude-code)