### PR TITLE
Paint the preview page white in light mode

### DIFF
--- a/md-preview/ContentViewController.swift
+++ b/md-preview/ContentViewController.swift
@@ -75,7 +75,7 @@ final class ContentViewController: NSViewController {
     var pendingAnchorRestored: (() -> Void)?
 
     override func loadView() {
-        let container = NSView()
+        let container = DocumentBackgroundView(frame: .zero)
         container.translatesAutoresizingMaskIntoConstraints = false
         view = container
 
@@ -525,5 +525,38 @@ final class ContentViewController: NSViewController {
             if offset <= activationLine { active = index } else { break }
         }
         return active
+    }
+}
+
+/// The light-mode page white. The preview web view is non-opaque and the
+/// rendered page paints no background of its own, so the whole reading surface
+/// composites onto whatever sits behind it — and that used to be the window,
+/// whose `windowBackgroundColor` is grey on macOS 15 and white on 26, leaving
+/// code blocks barely distinguishable from the page on the older systems
+/// (#251). Painting it here covers the page and, in centered mode, the gutter
+/// the web view's leading edge leaves beside the column.
+///
+/// Dark mode paints nothing and keeps the window background, which already
+/// reads as a page.
+private final class DocumentBackgroundView: NSView {
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+    }
+
+    /// Layer-backed so the fill costs a compositor rect rather than a
+    /// full-window CPU redraw on every resize frame. AppKit re-invokes
+    /// `updateLayer` when the effective appearance changes.
+    override var wantsUpdateLayer: Bool { true }
+
+    override func updateLayer() {
+        let isDark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        layer?.backgroundColor = isDark ? nil : NSColor.white.cgColor
     }
 }


### PR DESCRIPTION
## Summary

Reading mode showed a grey page on macOS 15 (Sequoia) instead of white, which left code blocks barely distinguishable from the surrounding text. Fixes #251.

The preview `WKWebView` is non-opaque (`drawsBackground = false`) and the rendered page paints no background of its own, so the whole reading surface composited onto whatever sat behind it — the window, whose `NSColor.windowBackgroundColor` is grey on macOS 15 and white on 26. That's why Quick Look and edit mode looked correct: both supply their own white.

## What changed

One file. `ContentViewController`'s container is now a layer-backed `DocumentBackgroundView` that paints white in light mode. That covers the page (the transparent web view composites onto it) and, in centered mode, the gutter the web view's leading edge leaves beside the column — `#162` moved column centering into the AppKit constraint, so that gutter is host-painted by design.

Dark mode paints nothing and keeps the window background, which already reads as a page — its appearance is untouched by this PR. The stylesheet is unchanged; pinning a page background in CSS as well turned out to be redundant, since the transparent web view already composites onto the host fill.

## Test plan

Verified on macOS 26, which can't reproduce the grey itself but confirms the surface is now painted deterministically rather than inherited from the system:

- [x] Light mode — page and gutter both scan pure `#ffffff` across the full content width, no seam at the web view's leading edge; code blocks read at `#f5f5f7`.
- [x] Dark mode — unchanged (the layer color is `nil` there and no CSS moved, so the dark path is identical to `main`).
- [x] Preview ↔ edit mode toggle shows no background shift in either appearance.
- [x] Debug build compiles clean; app launches and renders `samples/codeblocks.md`.

Worth a look on macOS 15 before release, since that's the system that showed the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)