### PR TITLE
Keep preview on original path during editor backup saves

### DIFF
--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -3078,6 +3078,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 }
 
 private final class FileWatcher {
+    private static let moveResolutionDelay: TimeInterval = 0.20
+
     private let url: URL
     private let onChange: () -> Void
     /// Fired when the watched file is renamed or moved (in Finder, by an
@@ -3088,6 +3090,7 @@ private final class FileWatcher {
     private var source: DispatchSourceFileSystemObject?
     private var fileDescriptor: Int32 = -1
     private var debounce: DispatchWorkItem?
+    private var moveResolution: DispatchWorkItem?
 
     init(url: URL, onChange: @escaping () -> Void) {
         self.url = url
@@ -3113,12 +3116,8 @@ private final class FileWatcher {
             // For an actual user-visible rename, the FD's resolved path
             // differs from the watcher's URL — surface that to the host.
             if !event.intersection([.delete, .rename, .revoke]).isEmpty {
-                if let newURL = self.currentPath(),
-                   newURL.standardizedFileURL != self.url.standardizedFileURL,
-                   !FileManager.default.fileExists(atPath: self.url.path) {
-                    self.onRename?(newURL)
-                }
-                self.reopen()
+                self.resolveMove(afterSettlingAt: self.currentPath())
+                return
             }
             self.scheduleChange()
         }
@@ -3131,6 +3130,37 @@ private final class FileWatcher {
         }
         self.source = source
         source.resume()
+    }
+
+    private func resolveMove(afterSettlingAt movedURL: URL?) {
+        moveResolution?.cancel()
+        debounce?.cancel()
+        source?.cancel()
+        source = nil
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.moveResolution = nil
+            let resolution = FileWatcherMoveResolution.resolve(
+                originalURL: self.url,
+                movedURL: movedURL,
+                fileExists: { FileManager.default.fileExists(atPath: $0.path) }
+            )
+            switch resolution {
+            case .reloadOriginal:
+                self.open()
+                self.scheduleChange()
+            case .followRename(let newURL):
+                self.onRename?(newURL)
+            case .unavailable:
+                self.reopen()
+            }
+        }
+        moveResolution = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.moveResolutionDelay,
+            execute: work
+        )
     }
 
     private func reopen() {
@@ -3159,6 +3189,7 @@ private final class FileWatcher {
 
     func cancel() {
         debounce?.cancel()
+        moveResolution?.cancel()
         source?.cancel()
         source = nil
     }

--- a/md-preview/FileWatcherMoveResolution.swift
+++ b/md-preview/FileWatcherMoveResolution.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum FileWatcherMoveResolution: Equatable {
+    case reloadOriginal
+    case followRename(URL)
+    case unavailable
+
+    static func resolve(
+        originalURL: URL,
+        movedURL: URL?,
+        fileExists: (URL) -> Bool
+    ) -> FileWatcherMoveResolution {
+        // Editors commonly move the old inode aside before creating the new
+        // file at the original path. Prefer that path once the save settles.
+        if fileExists(originalURL) {
+            return .reloadOriginal
+        }
+
+        if let movedURL,
+           movedURL.standardizedFileURL != originalURL.standardizedFileURL,
+           fileExists(movedURL) {
+            return .followRename(movedURL)
+        }
+
+        return .unavailable
+    }
+}

--- a/tests/swift-tests/Sources/MarkdownHelpers/FileWatcherMoveResolution.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/FileWatcherMoveResolution.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/FileWatcherMoveResolution.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/FileWatcherMoveResolutionTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/FileWatcherMoveResolutionTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import MarkdownHelpers
+
+final class FileWatcherMoveResolutionTests: XCTestCase {
+    private let originalURL = URL(fileURLWithPath: "/tmp/README.md")
+    private let backupURL = URL(fileURLWithPath: "/tmp/README.md~")
+
+    func testReplacementAtOriginalPathWinsOverMovedInode() {
+        let existing = Set([originalURL, backupURL])
+
+        XCTAssertEqual(
+            FileWatcherMoveResolution.resolve(
+                originalURL: originalURL,
+                movedURL: backupURL,
+                fileExists: { existing.contains($0) }
+            ),
+            .reloadOriginal
+        )
+    }
+
+    func testRenameIsFollowedWhenOriginalPathStaysAbsent() {
+        XCTAssertEqual(
+            FileWatcherMoveResolution.resolve(
+                originalURL: originalURL,
+                movedURL: backupURL,
+                fileExists: { $0 == self.backupURL }
+            ),
+            .followRename(backupURL)
+        )
+    }
+
+    func testDeleteWithoutMovedFileRemainsUnavailable() {
+        XCTAssertEqual(
+            FileWatcherMoveResolution.resolve(
+                originalURL: originalURL,
+                movedURL: nil,
+                fileExists: { _ in false }
+            ),
+            .unavailable
+        )
+    }
+
+    func testOriginalDescriptorPathIsNotTreatedAsRename() {
+        XCTAssertEqual(
+            FileWatcherMoveResolution.resolve(
+                originalURL: originalURL,
+                movedURL: originalURL,
+                fileExists: { _ in false }
+            ),
+            .unavailable
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- defer destructive file-event classification for 200 ms so editor backup saves can settle
- keep watching and reload the original path when it reappears
- preserve genuine rename handling when the original path stays absent
- add deterministic coverage for replacement, rename, and unavailable-file decisions

## Root cause

Editors such as Emacs can move the watched inode to `README.md~` immediately before recreating `README.md`. The watcher checked whether the original path existed during that transient gap and treated the backup move as a genuine rename, permanently rebinding the document to the backup.

## User impact

Markdown Preview now continues following the file the user opened across backup-style and atomic saves, while Finder renames still update the document URL, title, sidebar, inspector, and watcher.

## Validation

- `swift test --package-path tests/swift-tests` — 132 passed, 1 optional benchmark skipped
- isolated Debug `xcodebuild` — succeeded
- exact built-app reproduction: backup-style save stayed on the original path and reloaded new contents
- atomic replacement stayed on the same path and reloaded
- genuine rename updated the title and URL; later edits to the renamed file continued reloading
- multiple documents still opened in one app process

Closes #119
