### PR TITLE
Match PDF exports to read-only preview

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -74,6 +74,33 @@ nonisolated enum MarkdownHTML {
     static let pagePaddingBottom: CGFloat = 48
     static let sourceLineHeight = bodyFontSize * bodyLineHeight
 
+    /// Exported PDFs opt out of the paper-specific restyling below so the
+    /// print pipeline paginates the same read-only page shown on screen.
+    static let previewPrintClass = "md-preview-print-fidelity"
+
+    /// The only export-specific print adjustments are mechanical: move the
+    /// read-only page padding into a real page margin so every PDF page gets
+    /// the same gutters, retain the same content measure, and paint the
+    /// otherwise-transparent WebKit page with the active Canvas color. The
+    /// print operation then fits that complete column to the selected paper
+    /// instead of reflowing it at the narrower print viewport.
+    static let previewPrintOverrideCSS = """
+    @media print {
+        @page {
+            margin: \(Int(pagePaddingTop))px \(Int(pagePaddingHorizontal))px \(Int(pagePaddingBottom))px;
+        }
+        html.\(previewPrintClass),
+        html.\(previewPrintClass) body {
+            background: Canvas;
+        }
+        html.\(previewPrintClass) body {
+            box-sizing: border-box;
+            width: \(contentColumnWidth)px;
+            padding: 0;
+        }
+    }
+    """
+
     /// Body size, in points, used by the print stylesheet when the app hasn't
     /// injected an explicit choice. CSS `pt` reaches paper 1:1, so this is the
     /// literal printed size. The on-screen 15px body prints at 15 × 0.75 =
@@ -3539,7 +3566,7 @@ nonisolated enum MarkdownHTML {
     [dir="rtl"] { text-align: right; }
 
     /* ---------------------------------------------------------------------
-       Print / PDF export.
+       Paper-optimized printing.
 
        WebKit lays print out at a viewport of the printable width in CSS px
        (96px per inch), and 1 CSS px maps to exactly 0.75pt on paper. Sizing
@@ -3547,12 +3574,13 @@ nonisolated enum MarkdownHTML {
        no scaling factor to compensate for. `md-print-size` (injected by the
        app at print time) overrides the default below.
 
-       The on-screen palette is dark-mode aware; paper is not, so the light
-       values are restored unconditionally — otherwise a user printing in
-       dark mode gets white text on a black background.
+       The on-screen palette is dark-mode aware; paper is not, so regular
+       printing restores the light values unconditionally. PDF export adds
+       `previewPrintClass` before entering WebKit's print pipeline, which
+       excludes these paper-only changes and preserves the read-only page.
        --------------------------------------------------------------------- */
     @media print {
-        :root {
+        :root:not(.\(previewPrintClass)) {
             color-scheme: light;
             --text: #1d1d1f;
             --secondary: #6e6e73;
@@ -3563,22 +3591,28 @@ nonisolated enum MarkdownHTML {
             --code-bg: #f5f5f7;
             --grid: #d2d2d7;
         }
-        html, body {
+        html,
+        body {
             overflow: visible;
+        }
+        :root:not(.\(previewPrintClass)),
+        :root:not(.\(previewPrintClass)) body {
             background: #fff;
         }
         @page {
             margin: \(printPageMarginTop) \(printPageMarginSide) \(printPageMarginBottom);
         }
         body {
-            font-size: \(defaultPrintPointSize)pt;
-            padding: 0;
             -webkit-print-color-adjust: exact;
             print-color-adjust: exact;
         }
+        :root:not(.\(previewPrintClass)) body {
+            font-size: \(defaultPrintPointSize)pt;
+            padding: 0;
+        }
         /* NSPrintInfo owns the page margins, and the print viewport is
            narrower than the on-screen measure, so the column just fills it. */
-        article.markdown-body {
+        :root:not(.\(previewPrintClass)) article.markdown-body {
             max-width: none;
             margin: 0;
         }
@@ -3593,21 +3627,36 @@ nonisolated enum MarkdownHTML {
         }
 
         /* Splitting these across a page break loses the reading order. */
-        pre, blockquote, table, figure, .md-frontmatter, .markdown-alert {
+        :root:not(.\(previewPrintClass)) pre,
+        :root:not(.\(previewPrintClass)) blockquote,
+        :root:not(.\(previewPrintClass)) table,
+        :root:not(.\(previewPrintClass)) figure,
+        :root:not(.\(previewPrintClass)) .md-frontmatter,
+        :root:not(.\(previewPrintClass)) .markdown-alert {
             break-inside: avoid;
         }
-        tr, li { break-inside: avoid; }
-        h1, h2, h3, h4, h5, h6 { break-after: avoid; }
-        pre {
+        :root:not(.\(previewPrintClass)) tr,
+        :root:not(.\(previewPrintClass)) li { break-inside: avoid; }
+        :root:not(.\(previewPrintClass)) h1,
+        :root:not(.\(previewPrintClass)) h2,
+        :root:not(.\(previewPrintClass)) h3,
+        :root:not(.\(previewPrintClass)) h4,
+        :root:not(.\(previewPrintClass)) h5,
+        :root:not(.\(previewPrintClass)) h6 { break-after: avoid; }
+        :root:not(.\(previewPrintClass)) pre {
             white-space: pre-wrap;
             word-wrap: break-word;
         }
         /* Inner scrollers can't scroll on paper — let them wrap instead of
            clipping their overflow. */
-        .md-code-wrap, .md-table-scroll, table, pre {
+        :root:not(.\(previewPrintClass)) .md-code-wrap,
+        :root:not(.\(previewPrintClass)) .md-table-scroll,
+        :root:not(.\(previewPrintClass)) table,
+        :root:not(.\(previewPrintClass)) pre {
             overflow: visible !important;
         }
-        img, svg {
+        :root:not(.\(previewPrintClass)) img,
+        :root:not(.\(previewPrintClass)) svg {
             max-width: 100% !important;
             height: auto;
         }
@@ -3615,10 +3664,12 @@ nonisolated enum MarkdownHTML {
            document to fit, which silently overrides the chosen point size — a
            request for 18pt came out at ~15pt. Keep every block inside the
            measure so the size stays honest. */
-        body { overflow-wrap: break-word; }
-        table { width: 100%; }
-        th, td { overflow-wrap: anywhere; }
-        pre, code { overflow-wrap: anywhere; }
+        :root:not(.\(previewPrintClass)) body { overflow-wrap: break-word; }
+        :root:not(.\(previewPrintClass)) table { width: 100%; }
+        :root:not(.\(previewPrintClass)) th,
+        :root:not(.\(previewPrintClass)) td { overflow-wrap: anywhere; }
+        :root:not(.\(previewPrintClass)) pre,
+        :root:not(.\(previewPrintClass)) code { overflow-wrap: anywhere; }
     }
 
     """

--- a/md-preview/MarkdownWebView+PDFExport.swift
+++ b/md-preview/MarkdownWebView+PDFExport.swift
@@ -13,6 +13,7 @@ import UniformTypeIdentifiers
 import WebKit
 
 private let printSizeStyleElementID = "md-print-size"
+private let previewPrintStyleElementID = "md-preview-print-style"
 
 private enum DocumentExportFormat: String, CaseIterable {
     case pdf
@@ -280,9 +281,11 @@ private final class PrintSizeAccessoryController: NSViewController, NSPrintPanel
 
     private var pointSize = PrintSizeOptions.pointSize
     private var exportFormat: DocumentExportFormat?
+    private let showsPrintSize: Bool
 
     init(exportFormat: DocumentExportFormat? = nil) {
         self.exportFormat = exportFormat
+        showsPrintSize = exportFormat == nil
         super.init(nibName: nil, bundle: nil)
         title = NSLocalizedString("Markdown Preview",
                                   comment: "Print panel accessory pane title")
@@ -291,18 +294,21 @@ private final class PrintSizeAccessoryController: NSViewController, NSPrintPanel
     required init?(coder: NSCoder) { fatalError() }
 
     override func loadView() {
-        let sizeRow = PrintSizeRowView(width: 620)
-        sizeRow.onChange = { [weak self] size in
-            guard let self else { return }
-            self.willChangeValue(forKey: "localizedSummaryItems")
-            self.pointSize = size
-            self.didChangeValue(forKey: "localizedSummaryItems")
-            self.applySize?(size) { [weak self] in
-                self?.previewRevision += 1
+        var rows: [NSView] = []
+        if showsPrintSize {
+            let sizeRow = PrintSizeRowView(width: 620)
+            sizeRow.onChange = { [weak self] size in
+                guard let self else { return }
+                self.willChangeValue(forKey: "localizedSummaryItems")
+                self.pointSize = size
+                self.didChangeValue(forKey: "localizedSummaryItems")
+                self.applySize?(size) { [weak self] in
+                    self?.previewRevision += 1
+                }
             }
+            rows.append(sizeRow)
         }
 
-        var rows: [NSView] = []
         if let exportFormat {
             let formatRow = ExportFormatRowView(
                 width: 620,
@@ -315,9 +321,8 @@ private final class PrintSizeAccessoryController: NSViewController, NSPrintPanel
                 self.didChangeValue(forKey: "localizedSummaryItems")
                 self.exportFormatDidChange?(format)
             }
-            rows.append(formatRow)
+            rows.insert(formatRow, at: 0)
         }
-        rows.append(sizeRow)
 
         let stack = NSStackView(views: rows)
         stack.orientation = .vertical
@@ -349,11 +354,14 @@ private final class PrintSizeAccessoryController: NSViewController, NSPrintPanel
     // MARK: NSPrintPanelAccessorizing
 
     func localizedSummaryItems() -> [[NSPrintPanel.AccessorySummaryKey: String]] {
-        var items: [[NSPrintPanel.AccessorySummaryKey: String]] = [[
-            .itemName: NSLocalizedString("Font Size",
-                                         comment: "Print panel summary item name"),
-            .itemDescription: PrintSizeOptions.localizedLabel(for: pointSize),
-        ]]
+        var items: [[NSPrintPanel.AccessorySummaryKey: String]] = []
+        if showsPrintSize {
+            items.append([
+                .itemName: NSLocalizedString(
+                    "Font Size", comment: "Print panel summary item name"),
+                .itemDescription: PrintSizeOptions.localizedLabel(for: pointSize),
+            ])
+        }
         if let exportFormat {
             items.insert([
                 .itemName: NSLocalizedString(
@@ -786,10 +794,10 @@ extension MarkdownWebView {
 
     private func runPrintOperation(
         _ operation: NSPrintOperation,
-        from window: NSWindow
+        from window: NSWindow,
+        matchesPreview: Bool = false
     ) {
-        // Seed the stylesheet before the first thumbnail is generated.
-        applyPrintPointSize(PrintSizeOptions.pointSize) {
+        let run = {
             operation.runModal(
                 for: window,
                 delegate: nil,
@@ -797,6 +805,79 @@ extension MarkdownWebView {
                 contextInfo: nil
             )
         }
+
+        // Export keeps the live read-only stylesheet intact. Regular Print
+        // retains its paper-oriented size and pagination controls.
+        if matchesPreview {
+            applyPreviewPrintMode(completion: run)
+        } else {
+            applyPaperPrintMode {
+                self.applyPrintPointSize(
+                    PrintSizeOptions.pointSize,
+                    completion: run
+                )
+            }
+        }
+    }
+
+    /// Marks the live page so its paper-only CSS does not replace the
+    /// read-only typography, width, spacing, wrapping, or active palette.
+    /// WebKit still paginates it, but the pixels sent into that pagination are
+    /// the same ones the preview renderer owns.
+    private func applyPreviewPrintMode(completion: (() -> Void)? = nil) {
+        let script = """
+        (() => {
+            document.documentElement.classList.add(
+                '\(MarkdownHTML.previewPrintClass)'
+            );
+            document.getElementById('\(printSizeStyleElementID)')?.remove();
+            let style = document.getElementById('\(previewPrintStyleElementID)');
+            if (!style) {
+                style = document.createElement('style');
+                style.id = '\(previewPrintStyleElementID)';
+                document.head.appendChild(style);
+            }
+            style.textContent = \(Self.javaScriptStringLiteral(
+                MarkdownHTML.previewPrintOverrideCSS
+            ));
+            return true;
+        })()
+        """
+        evaluatePrintSetupScript(script, label: "preview print mode", completion: completion)
+    }
+
+    private func applyPaperPrintMode(completion: (() -> Void)? = nil) {
+        let script = """
+        (() => {
+            document.documentElement.classList.remove(
+                '\(MarkdownHTML.previewPrintClass)'
+            );
+            document.getElementById('\(previewPrintStyleElementID)')?.remove();
+            return true;
+        })()
+        """
+        evaluatePrintSetupScript(script, label: "paper print mode", completion: completion)
+    }
+
+    private func evaluatePrintSetupScript(
+        _ script: String,
+        label: String,
+        completion: (() -> Void)?
+    ) {
+        webView.evaluateJavaScript(script) { _, error in
+            if let error {
+                Logger.perf.debug(
+                    "\(label, privacy: .public) setup failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            completion?()
+        }
+    }
+
+    private nonisolated static func javaScriptStringLiteral(_ value: String) -> String {
+        let data = try? JSONSerialization.data(withJSONObject: [value])
+        let array = data.flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
+        return String(array.dropFirst().dropLast())
     }
 
     /// Sets the printed body size by injecting a print-only rule into the
@@ -886,7 +967,7 @@ extension MarkdownWebView {
         )
         let operation = configuredPrintOperation(from: window, panel: panel)
         prepareForPanelDrivenExport(operation)
-        runPrintOperation(operation, from: window)
+        runPrintOperation(operation, from: window, matchesPreview: true)
     }
 
     /// Rasterises the document to a single tall PNG. `createPDF` captures the

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLPrintStyleTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLPrintStyleTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 @testable import MarkdownHelpers
 
-/// The print stylesheet ships inside the rendered page, and the app overrides
-/// only the body size at print time. These guard the parts the export path
-/// depends on: that a print block exists, that it is sized in `pt` (which
-/// reaches paper 1:1), and that the paper palette can't inherit dark mode.
+/// Regular Print keeps paper-oriented rules, while PDF export adds a class
+/// that leaves the read-only renderer in charge. These tests guard both sides
+/// of that contract.
 final class MarkdownHTMLPrintStyleTests: XCTestCase {
     private func printBlock() throws -> String {
         let html = MarkdownHTML.render(markdown: "text", vendorLoading: .lazy).html
@@ -30,11 +29,17 @@ final class MarkdownHTMLPrintStyleTests: XCTestCase {
             block.contains("font-size: \(MarkdownHTML.defaultPrintPointSize)pt"),
             "print body must be sized in pt so CSS maps 1:1 to paper points"
         )
+        XCTAssertTrue(block.contains(
+            ":root:not(.\(MarkdownHTML.previewPrintClass)) body"
+        ))
     }
 
     func testPrintForcesTheLightPaletteRegardlessOfSystemAppearance() throws {
         let block = try printBlock()
         XCTAssertTrue(block.contains("color-scheme: light"))
+        XCTAssertTrue(block.contains(
+            ":root:not(.\(MarkdownHTML.previewPrintClass))"
+        ))
         XCTAssertTrue(block.contains("--text: #1d1d1f"),
                       "dark mode must not carry into paper")
         XCTAssertTrue(block.contains("background: #fff"))
@@ -61,6 +66,27 @@ final class MarkdownHTMLPrintStyleTests: XCTestCase {
             html.range(of: "font-size: \(MarkdownHTML.bodyFontSize)px"))
         let printBlock = try XCTUnwrap(html.range(of: "@media print {"))
         XCTAssertLessThan(screenRule.lowerBound, printBlock.lowerBound)
+    }
+
+    func testPreviewFidelityExportUsesTheReadOnlyPageGeometry() {
+        let css = MarkdownHTML.previewPrintOverrideCSS
+        XCTAssertTrue(css.contains(
+            "margin: \(Int(MarkdownHTML.pagePaddingTop))px "
+                + "\(Int(MarkdownHTML.pagePaddingHorizontal))px "
+                + "\(Int(MarkdownHTML.pagePaddingBottom))px;"
+        ))
+        XCTAssertTrue(css.contains("html.\(MarkdownHTML.previewPrintClass)"))
+        XCTAssertTrue(css.contains("background: Canvas"))
+        XCTAssertTrue(css.contains(
+            "width: \(MarkdownHTML.contentColumnWidth)px"
+        ))
+        XCTAssertTrue(css.contains("box-sizing: border-box"))
+        XCTAssertTrue(css.contains("padding: 0"))
+
+        XCTAssertFalse(css.contains("font-size"))
+        XCTAssertFalse(css.contains("max-width"))
+        XCTAssertFalse(css.contains("overflow-wrap"))
+        XCTAssertFalse(css.contains("color-scheme"))
     }
 
 }


### PR DESCRIPTION
## Summary

- make PDF export preserve the read-only preview stylesheet and active appearance
- keep the same 820 px content measure and move the read-only 32/40/48 px padding into a real `@page` margin so every PDF page gets matching gutters
- keep regular Print on its existing paper-oriented font-size and pagination path
- hide the print-only font-size control from the export panel and cover the export/print CSS contract with tests

## Testing

- `swift test --package-path tests/swift-tests` - 133 tests passed, 1 skipped
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-user-test-20260801-v4 CODE_SIGNING_ALLOWED=NO build` - succeeded
- exported the repository README through the native PDF panel to an 8-page Letter PDF and rendered every page at 110 dpi
- visually inspected all pages and measured minimum rendered bounds of about 45 px horizontally, 38 px at the top, and 55 px at the bottom, matching the 40/32/48 CSS px page padding after print scaling
