### PR TITLE
Release 0.0.44 (48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.44] – 2026-08-02
+
+Exported PDFs now look like the document you were reading.
+
+### Changed
+
+- **PDF export matches the read-only preview.** Exports keep the preview stylesheet and the active light or dark appearance, hold the same 820 px content measure, and turn the reading view's 32/40/48 px padding into real page margins so every page gets matching gutters. The print-only font-size control is hidden from the export panel, while File ▸ Print… keeps its existing paper-oriented sizing and pagination ([#258](https://github.com/pluk-inc/markdown-preview/pull/258)).
+
 ## [0.0.43] – 2026-07-30
 
 Large documents open dramatically faster, reading mode is properly white in light mode, and the preview stays on the file you opened while you edit.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.43
-CURRENT_PROJECT_VERSION = 47
+MARKETING_VERSION = 0.0.44
+CURRENT_PROJECT_VERSION = 48


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` to `0.0.44` and `CURRENT_PROJECT_VERSION` to `48`
- Add the `CHANGELOG.md` entry for 0.0.44

## What's in 0.0.44

- **PDF export matches the read-only preview.** Exports keep the preview stylesheet and the active light or dark appearance, hold the same 820 px content measure, and turn the reading view's 32/40/48 px padding into real page margins so every page gets matching gutters. The print-only font-size control is hidden from the export panel, while File ▸ Print… keeps its existing paper-oriented sizing and pagination (#258).

## Test plan

- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` succeeds
- [ ] About window and Finder Get Info report version 0.0.44 (48) for both the app and the Quick Look extension
- [ ] `./scripts/release.sh` resolves the 0.0.44 changelog entry without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)