### PR TITLE
Fix Mermaid dark mode in Quick Look

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -56,6 +56,13 @@ nonisolated enum MarkdownHTML {
         case full
     }
 
+    /// Native appearance supplied by hosts whose WebKit media-query result
+    /// can disagree with the surface they render into (notably Quick Look).
+    enum ColorScheme: String {
+        case light
+        case dark
+    }
+
     /// Width the Quick Look panel requests for its preview window.
     static let preferredPageWidth: CGFloat = 900
     /// The centered article measure: `preferredPageWidth` minus the 40px
@@ -137,11 +144,13 @@ nonisolated enum MarkdownHTML {
     static func makeHTML(from markdown: String,
                          allowsScroll: Bool = false,
                          assetBaseHref: String? = nil,
-                         vendorLoading: VendorLoading = .inline) -> String {
+                         vendorLoading: VendorLoading = .inline,
+                         colorScheme: ColorScheme? = nil) -> String {
         render(markdown: markdown,
                allowsScroll: allowsScroll,
                assetBaseHref: assetBaseHref,
-               vendorLoading: vendorLoading).html
+               vendorLoading: vendorLoading,
+               colorScheme: colorScheme).html
     }
 
     static func render(markdown: String,
@@ -149,6 +158,7 @@ nonisolated enum MarkdownHTML {
                        assetBaseHref: String? = nil,
                        vendorLoading: VendorLoading = .inline,
                        contentWidth: ContentWidth = .centered,
+                       colorScheme: ColorScheme? = nil,
                        warmup: Bool = false) -> RenderedHTML {
         let frontmatter = MarkdownFrontmatter.split(markdown)
         let body = frontmatter.body
@@ -260,9 +270,12 @@ nonisolated enum MarkdownHTML {
         // The bootstrap then reads template.innerHTML, runs it through
         // DOMPurify, and assigns the sanitized result to article.innerHTML.
         let safeBody = bodyHTML.replacingOccurrences(of: "</template", with: "<\\/template")
+        let colorSchemeAttribute = colorScheme.map {
+            " data-mdp-color-scheme=\"\($0.rawValue)\""
+        } ?? ""
         let html = """
         <!DOCTYPE html>
-        <html>
+        <html\(colorSchemeAttribute)>
         <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -2526,13 +2539,20 @@ nonisolated enum MarkdownHTML {
             let draining = false;
             let initialized = false;
 
+            function selectedTheme() {
+                const nativeScheme = document.documentElement.dataset.mdpColorScheme;
+                if (nativeScheme) return nativeScheme === 'dark' ? 'dark' : 'default';
+                const dark = window.matchMedia
+                    && window.matchMedia('(prefers-color-scheme: dark)').matches;
+                return dark ? 'dark' : 'default';
+            }
+
             function ensureInit() {
                 if (initialized) return;
                 initialized = true;
-                const dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
                 mermaid.initialize({
                     startOnLoad: false,
-                    theme: dark ? 'dark' : 'default',
+                    theme: selectedTheme(),
                     securityLevel: 'strict',
                     fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif'
                 });

--- a/quick-look/PreviewProvider.swift
+++ b/quick-look/PreviewProvider.swift
@@ -27,7 +27,17 @@ class PreviewProvider: QLPreviewProvider, QLPreviewingController {
         )
         #endif
         let text = try String(contentsOf: request.fileURL, encoding: .utf8)
-        let renderedHTML = MarkdownHTML.makeHTML(from: text, allowsScroll: true)
+        let colorScheme = await MainActor.run {
+            let appearance = NSApplication.shared.effectiveAppearance
+            return appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                ? MarkdownHTML.ColorScheme.dark
+                : MarkdownHTML.ColorScheme.light
+        }
+        let renderedHTML = MarkdownHTML.makeHTML(
+            from: text,
+            allowsScroll: true,
+            colorScheme: colorScheme
+        )
         let baseDirectory = request.fileURL.deletingLastPathComponent()
         let rewrite = InlineLocalAssets.rewriteRelativeImages(
             html: renderedHTML,

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -722,6 +722,18 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(rendered.articleHTML.contains("<code class=\"language-mermaid\""))
     }
 
+    func testExplicitColorSchemeIsExposedToRendererScripts() {
+        let dark = MarkdownHTML.render(
+            markdown: "# Dark",
+            colorScheme: .dark
+        )
+        let automatic = MarkdownHTML.render(markdown: "# Automatic")
+
+        XCTAssertTrue(dark.html.contains(#"<html data-mdp-color-scheme="dark">"#))
+        XCTAssertTrue(automatic.html.contains("<html>"))
+        XCTAssertFalse(automatic.html.contains("data-mdp-color-scheme"))
+    }
+
     func testMermaidPopupButtonIsEmitted() {
         let rendered = MarkdownHTML.render(
             markdown: """
@@ -899,6 +911,82 @@ final class MarkdownHTMLRenderTests: XCTestCase {
             "(window.__posted || []).some((m) => m && m.kind === 'mermaidPopup')"
         ) as? Bool
         XCTAssertEqual(postedPopupOnDoubleClick, false, "double-click must not post a mermaidPopup message")
+    }
+
+    @MainActor
+    func testMermaidNativeColorSchemeOverridesMatchMedia() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```mermaid
+            journey
+                title My working day
+                section Go to work
+                  Make tea: 5: Me
+            ```
+            """,
+            vendorLoading: .lazy,
+            colorScheme: .dark
+        )
+
+        let html = """
+        <!DOCTYPE html>
+        <html data-mdp-color-scheme="dark"><head>
+        <script>
+        window.__themes = [];
+        window.__runs = 0;
+        Object.defineProperty(window, 'matchMedia', {
+            value: () => ({ matches: false }),
+            configurable: true
+        });
+        window.IntersectionObserver = class {
+            constructor(callback) { this.callback = callback; }
+            observe(target) { this.callback([{ target, isIntersecting: true }]); }
+            unobserve() {}
+        };
+        window.ResizeObserver = class {
+            constructor() {}
+            observe() {}
+        };
+        window.mermaid = {
+            initialize(options) { window.__themes.push(options.theme); },
+            async run({ nodes }) {
+                window.__runs += 1;
+                const theme = window.__themes[window.__themes.length - 1];
+                for (const node of nodes) {
+                    node.innerHTML = '<svg viewBox="0 0 400 200" data-theme="' + theme + '"></svg>';
+                }
+            }
+        };
+        </script></head><body>
+        <article class="markdown-body">\(rendered.articleHTML)</article>
+        <script>
+        const __mdpMermaid = \(MarkdownHTML.mermaidInitWiring);
+        __mdpMermaid.bootstrap();
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        var darkRenderReady = false
+        for _ in 0..<100 {
+            let state = try await webView.evaluateJavaScript("""
+            JSON.stringify({
+                themes: window.__themes,
+                runs: window.__runs,
+                renderedTheme: document.querySelector('.mermaid svg')?.dataset.theme || ''
+            })
+            """) as? String
+            if state == #"{"themes":["dark"],"runs":1,"renderedTheme":"dark"}"# {
+                darkRenderReady = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTAssertTrue(darkRenderReady, "native dark appearance must win when matchMedia reports light")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- pass the Quick Look extension native AppKit appearance into rendered HTML
- make Mermaid prefer that explicit appearance over WebKit matchMedia
- cover the Quick Look mismatch with a WKWebView regression test

## Root cause

Quick Look can render the preview surface in dark mode while its HTML JavaScript context reports a light prefers-color-scheme value. Mermaid used that JavaScript result once during initialization, producing a static light-theme SVG against the dark preview.

## Validation

- swift test: 135 tests passed, 1 manual benchmark skipped
- xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build: succeeded
- verified NSApplication effectiveAppearance resolves DarkAqua while macOS is in dark mode

Closes #260