### PR TITLE
Release 0.0.45 (49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.45] – 2026-08-05
+
+Mermaid diagrams in Quick Look now match the system appearance.
+
+### Fixed
+
+- **Mermaid diagrams respect dark mode in Quick Look.** Quick Look now passes its native macOS appearance into the rendered preview, so diagrams use a readable dark theme instead of light colors against a dark background ([#261](https://github.com/pluk-inc/markdown-preview/pull/261), [#260](https://github.com/pluk-inc/markdown-preview/issues/260)).
+
+### Contributors
+
+Thanks to the external reporter who helped improve this release:
+
+- [@GloryAlex](https://github.com/GloryAlex) — reported the Mermaid dark-mode mismatch in Quick Look ([#260](https://github.com/pluk-inc/markdown-preview/issues/260))
+
 ## [0.0.44] – 2026-08-02
 
 Exported PDFs now look like the document you were reading.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.44
-CURRENT_PROJECT_VERSION = 48
+MARKETING_VERSION = 0.0.45
+CURRENT_PROJECT_VERSION = 49


### PR DESCRIPTION
## Summary

- bump `MARKETING_VERSION` to `0.0.45` and `CURRENT_PROJECT_VERSION` to `49`
- add the `CHANGELOG.md` entry for 0.0.45
- credit @GloryAlex for reporting the Quick Look dark-mode issue

## What's in 0.0.45

- **Mermaid diagrams respect dark mode in Quick Look.** Quick Look now passes its native macOS appearance into the rendered preview, so diagrams use a readable dark theme instead of light colors against a dark background (#261, closes #260).

## Impact

Quick Look previews now render Mermaid diagrams consistently with the main app when macOS is using dark mode.

## Validation

- `git diff --check` passes
- Xcode build settings resolve `MARKETING_VERSION = 0.0.45`
- Xcode build settings resolve `CURRENT_PROJECT_VERSION = 49`

After merge, `./scripts/release.sh` will archive, sign, notarize, package, and publish the release through Amore.
