### PR TITLE
Add an Always on Top window toggle

### DIFF
--- a/md-preview/AlwaysOnTopPolicy.swift
+++ b/md-preview/AlwaysOnTopPolicy.swift
@@ -20,8 +20,20 @@ enum AlwaysOnTopPolicy {
     /// belongs to. Both choices are intentional: the diagram popup follows the
     /// document, whereas this window is one the reader has explicitly asked to
     /// keep in sight while working in something else.
-    static func windowLevel(isPinned: Bool) -> Int {
-        Int(CGWindowLevelForKey(isPinned ? .floatingWindow : .normalWindow))
+    /// - Parameters:
+    ///   - isPinned: Whether the reader has asked to keep this window in sight.
+    ///   - isFullScreen: Whether the window is currently full screen. AppKit
+    ///     will not let a window above the normal level go full screen, so a
+    ///     pinned window loses Enter Full Screen and its green traffic light.
+    ///     A full-screen window owns its own Space, where floating above other
+    ///     applications means nothing, so the pin is suspended for the duration
+    ///     rather than fought with. It is kept as *intent* by the controller and
+    ///     reapplied on the way out. Required rather than defaulted: a caller
+    ///     that forgets it reintroduces exactly the bug this parameter exists
+    ///     to prevent.
+    static func windowLevel(isPinned: Bool, isFullScreen: Bool) -> Int {
+        let floats = isPinned && !isFullScreen
+        return Int(CGWindowLevelForKey(floats ? .floatingWindow : .normalWindow))
     }
 
     /// The windows a single toggle applies to.

--- a/md-preview/AlwaysOnTopPolicy.swift
+++ b/md-preview/AlwaysOnTopPolicy.swift
@@ -1,0 +1,45 @@
+//
+//  AlwaysOnTopPolicy.swift
+//  md-preview
+//
+//  Pure decision logic behind the "Always on Top" window toggle. Kept free of
+//  AppKit so the SPM helper tests can exercise it without a GUI host.
+//
+
+import CoreGraphics
+import Foundation
+
+enum AlwaysOnTopPolicy {
+    /// Raw `NSWindow.Level` value a document window takes for a given pinned
+    /// state.
+    ///
+    /// Pinned windows sit at the floating level, which keeps them above the
+    /// windows of *other* applications. That is the entire point here, and it
+    /// is deliberately the opposite of `MermaidDiagramPopup`, whose panel
+    /// stays at the normal level so a diagram never escapes the app it
+    /// belongs to. Both choices are intentional: the diagram popup follows the
+    /// document, whereas this window is one the reader has explicitly asked to
+    /// keep in sight while working in something else.
+    static func windowLevel(isPinned: Bool) -> Int {
+        Int(CGWindowLevelForKey(isPinned ? .floatingWindow : .normalWindow))
+    }
+
+    /// The windows a single toggle applies to.
+    ///
+    /// A tab group presents as one on-screen window, so pinning an individual
+    /// tab would be ambiguous — whichever tab happened to be frontmost would
+    /// decide whether the group floats, and the menu check mark would flip as
+    /// the reader switched tabs. Toggling therefore pins the whole group and
+    /// every tab reports the same state back.
+    ///
+    /// - Parameters:
+    ///   - window: The window whose toggle the reader used.
+    ///   - tabGroup: The windows sharing that window's tab group, or `nil`
+    ///     when the window is not tabbed.
+    /// - Returns: Every window that should take the new level.
+    static func affectedWindows<Window>(toggling window: Window,
+                                        tabGroup: [Window]?) -> [Window] {
+        guard let tabGroup, !tabGroup.isEmpty else { return [window] }
+        return tabGroup
+    }
+}

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -118,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         installFileExportMenuItems()
         installGoMenu()
         installAppMenuItemIcons()
-        installZoomMenuItemIcons()
+        installViewMenuItemIcons()
         hasFinishedLaunching = true
         if !didReceiveOpenURLsDuringLaunch {
             scheduleDocumentPrompt(requiresNoDocuments: true)
@@ -766,12 +766,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mainMenu.insertItem(goItem, at: insertIndex)
     }
 
-    private func installZoomMenuItemIcons() {
+    private func installViewMenuItemIcons() {
         guard let viewMenu = topLevelSubmenu(matching: Self.viewMenuTitles) else { return }
         let icons: [(titles: Set<String>, symbol: String)] = [
             (["Actual Size", "实际大小"], "magnifyingglass"),
             (["Zoom In", "放大"], "plus.magnifyingglass"),
-            (["Zoom Out", "缩小"], "minus.magnifyingglass")
+            (["Zoom Out", "缩小"], "minus.magnifyingglass"),
+            (["Always on Top", "始终置顶"], "pin")
         ]
         for (titles, symbol) in icons {
             guard let item = viewMenu.items.first(where: { titles.contains($0.title) }),

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -400,6 +400,13 @@
                                     <action selector="toggleSidebar:" target="-1" id="iwa-gc-5KM"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="mdp-aot-sep"/>
+                            <menuItem title="Always on Top" keyEquivalent="t" id="mdp-aot-itm">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleAlwaysOnTop:" target="-1" id="mdp-aot-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -772,12 +772,28 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         alwaysOnTopButton?.state = pinned ? .on : .off
     }
 
+    /// The pin icon doubles as the state indicator. An `NSMenuItem` draws its
+    /// image and its check mark in the same leading slot, so beside an icon the
+    /// tick is easy to miss and the item reads as neither on nor off. Filling
+    /// the pin makes the state legible at a glance; `state` is still set, so
+    /// VoiceOver and the menu's own semantics stay correct.
+    private static func alwaysOnTopMenuImage(isPinned: Bool) -> NSImage? {
+        let image = NSImage(
+            systemSymbolName: isPinned ? "pin.fill" : "pin",
+            accessibilityDescription: NSLocalizedString("Always on Top",
+                                                        comment: "Always on Top menu item")
+        )
+        image?.isTemplate = true
+        return image
+    }
+
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(saveDocument(_:)) {
             return isEditing
         }
         if menuItem.action == #selector(toggleAlwaysOnTop(_:)) {
             menuItem.state = isAlwaysOnTop ? .on : .off
+            menuItem.image = Self.alwaysOnTopMenuImage(isPinned: isAlwaysOnTop)
             return true
         }
         syncSidebarMenuState()

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -23,6 +23,7 @@ extension NSToolbarItem.Identifier {
     static let zoom = NSToolbarItem.Identifier("Zoom")
     static let editDocument = NSToolbarItem.Identifier("EditDocument")
     static let navigation = NSToolbarItem.Identifier("Navigation")
+    static let alwaysOnTop = NSToolbarItem.Identifier("AlwaysOnTop")
 }
 
 private extension Array where Element == NSToolbarItem.Identifier {
@@ -81,6 +82,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private weak var openInLLMItem: NSMenuToolbarItem?
     private weak var inspectorItem: NSToolbarItem?
     private weak var inspectorButton: NSButton?
+    private var isAlwaysOnTop = false
+    private weak var alwaysOnTopButton: NSButton?
     private weak var editItem: NSToolbarItem?
     private weak var editButton: NSButton?
     private var editorChangeRevision = 0
@@ -495,7 +498,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             .exportPDF,
             .exportDocument,
             .copyMarkdown,
-            .zoom
+            .zoom,
+            .alwaysOnTop
         ]
         if hasLLMTargetsAvailable {
             identifiers.insertAfterOpenActions(.openInLLM)
@@ -516,6 +520,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             return makeOpenInLLMItem()
         case .editDocument: return makeEditItem()
         case .inspector: return makeInspectorItem()
+        case .alwaysOnTop: return makeAlwaysOnTopItem()
         case .share: return makeShareItem()
         case .search: return makeSearchItem()
         case .printDocument: return makePrintItem()
@@ -716,9 +721,34 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         syncSidebarMenuState()
     }
 
+    @objc func toggleAlwaysOnTop(_ sender: Any?) {
+        setAlwaysOnTop(!isAlwaysOnTop)
+    }
+
+    private func setAlwaysOnTop(_ pinned: Bool) {
+        let level = NSWindow.Level(rawValue: AlwaysOnTopPolicy.windowLevel(isPinned: pinned))
+        let windows = AlwaysOnTopPolicy.affectedWindows(toggling: documentWindow,
+                                                        tabGroup: documentWindow.tabbedWindows)
+        for window in windows {
+            window.level = level
+            (window.windowController as? DocumentWindowController)?.recordAlwaysOnTop(pinned)
+        }
+    }
+
+    /// Stores the pinned state and refreshes the toolbar toggle. Applied to
+    /// every window in the tab group so each tab agrees with the group's level.
+    private func recordAlwaysOnTop(_ pinned: Bool) {
+        isAlwaysOnTop = pinned
+        alwaysOnTopButton?.state = pinned ? .on : .off
+    }
+
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(saveDocument(_:)) {
             return isEditing
+        }
+        if menuItem.action == #selector(toggleAlwaysOnTop(_:)) {
+            menuItem.state = isAlwaysOnTop ? .on : .off
+            return true
         }
         syncSidebarMenuState()
         return true
@@ -755,6 +785,47 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         inspectorItem = item
         refreshInspectorToggleItem()
         return item
+    }
+
+    private func makeAlwaysOnTopItem() -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: .alwaysOnTop)
+        let alwaysOnTop = NSLocalizedString("Always on Top", comment: "Always on Top toolbar item label")
+        item.label = alwaysOnTop
+        item.paletteLabel = alwaysOnTop
+        item.toolTip = NSLocalizedString("Keep this window in front of other apps",
+                                         comment: "Always on Top toolbar item tooltip")
+
+        let button = NSButton(image: alwaysOnTopImage(),
+                              target: self,
+                              action: #selector(toggleAlwaysOnTop(_:)))
+        button.setButtonType(.pushOnPushOff)
+        button.state = isAlwaysOnTop ? .on : .off
+        button.toolTip = item.toolTip
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 2),
+            button.topAnchor.constraint(equalTo: container.topAnchor),
+            button.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -2),
+            button.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            button.heightAnchor.constraint(equalToConstant: 32),
+            container.widthAnchor.constraint(equalToConstant: 36),
+            container.heightAnchor.constraint(equalToConstant: 32)
+        ])
+
+        item.view = container
+        alwaysOnTopButton = button
+        return item
+    }
+
+    private func alwaysOnTopImage() -> NSImage {
+        let image = NSImage(systemSymbolName: "pin",
+                            accessibilityDescription: NSLocalizedString("Always on Top", comment: "Always on Top toolbar image")) ?? NSImage()
+        image.isTemplate = true
+        return image
     }
 
     private func makeShareItem() -> NSToolbarItem {

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -173,6 +173,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func setupWindow() {
         documentWindow.styleMask.insert(.fullSizeContentView)
+        // Declared explicitly rather than left to AppKit's implicit default,
+        // because Always on Top raises the window above the normal level and a
+        // window that has not stated its full-screen capability is the first
+        // thing AppKit stops offering Enter Full Screen to.
+        documentWindow.collectionBehavior.insert(.fullScreenPrimary)
         documentWindow.delegate = self
         documentWindow.tabbingIdentifier = "MarkdownDocumentWindow"
         documentWindow.tabbingMode = Self.nextWindowDeclinesTabbing ? .disallowed : .automatic
@@ -255,6 +260,14 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     func windowWillClose(_ notification: Notification) {
         fileWatcher?.cancel()
         fileWatcher = nil
+    }
+
+    func windowWillEnterFullScreen(_ notification: Notification) {
+        reapplyAlwaysOnTopLevel(isFullScreen: true)
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification) {
+        reapplyAlwaysOnTopLevel(isFullScreen: false)
     }
 
     func windowWillReturnUndoManager(_ window: NSWindow) -> UndoManager? {
@@ -726,13 +739,30 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     }
 
     private func setAlwaysOnTop(_ pinned: Bool) {
-        let level = NSWindow.Level(rawValue: AlwaysOnTopPolicy.windowLevel(isPinned: pinned))
         let windows = AlwaysOnTopPolicy.affectedWindows(toggling: documentWindow,
                                                         tabGroup: documentWindow.tabbedWindows)
         for window in windows {
-            window.level = level
+            // Read each window's live full-screen state rather than assuming the
+            // reader pinned from a normal window: pinning while already in full
+            // screen must light the toggle without dropping out of full screen.
+            window.level = NSWindow.Level(
+                rawValue: AlwaysOnTopPolicy.windowLevel(
+                    isPinned: pinned,
+                    isFullScreen: window.styleMask.contains(.fullScreen)
+                )
+            )
             (window.windowController as? DocumentWindowController)?.recordAlwaysOnTop(pinned)
         }
+    }
+
+    /// Reapplies the level for a full-screen transition. `isAlwaysOnTop` is the
+    /// reader's intent and is deliberately left untouched, so the toolbar toggle
+    /// stays lit across the transition and the window floats again on the way out.
+    private func reapplyAlwaysOnTopLevel(isFullScreen: Bool) {
+        documentWindow.level = NSWindow.Level(
+            rawValue: AlwaysOnTopPolicy.windowLevel(isPinned: isAlwaysOnTop,
+                                                    isFullScreen: isFullScreen)
+        )
     }
 
     /// Stores the pinned state and refreshes the toolbar toggle. Applied to

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -36,7 +36,11 @@ private extension Array where Element == NSToolbarItem.Identifier {
     }
 }
 
-final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate, NSSearchFieldDelegate, NSMenuDelegate {
+// `NSMenuItemValidation` is load-bearing, not tidiness. `validateMenuItem` is only
+// reachable from AppKit through an @objc entry point, and `NSWindowController` has
+// no such method to override, so without this conformance the implementation below
+// is never called: no menu item ever gets its state, and the failure is silent.
+final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate, NSSearchFieldDelegate, NSMenuDelegate, NSMenuItemValidation {
 
     private enum NavigationIntent {
         case normal

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -73,6 +73,8 @@
 "Sidebar options" = "Sidebar options";
 "Inspector" = "Inspector";
 "Get Info" = "Get Info";
+"Always on Top" = "Always on Top";
+"Keep this window in front of other apps" = "Keep this window in front of other apps";
 "Show the inspector" = "Show the inspector";
 "Share" = "Share";
 "Share document" = "Share document";

--- a/md-preview/en.lproj/MainMenu.strings
+++ b/md-preview/en.lproj/MainMenu.strings
@@ -132,6 +132,8 @@
 	<string>Show Sidebar</string>
 	<key>mK6-2p-4JG.title</key>
 	<string>Check Grammar With Spelling</string>
+	<key>mdp-aot-itm.title</key>
+	<string>Always on Top</string>
 	<key>mdp-zi-itm.title</key>
 	<string>Zoom In</string>
 	<key>mdp-zo-itm.title</key>

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -73,6 +73,8 @@
 "Sidebar options" = "边栏选项";
 "Inspector" = "检查器";
 "Get Info" = "显示简介";
+"Always on Top" = "始终置顶";
+"Keep this window in front of other apps" = "让此窗口始终显示在其他 App 前面";
 "Show the inspector" = "显示检查器";
 "Share" = "共享";
 "Share document" = "共享文稿";

--- a/md-preview/zh-Hans.lproj/MainMenu.strings
+++ b/md-preview/zh-Hans.lproj/MainMenu.strings
@@ -193,6 +193,9 @@
 /* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "mK6-2p-4JG"; */
 "mK6-2p-4JG.title" = "检查拼写和语法";
 
+/* Class = "NSMenuItem"; title = "Always on Top"; ObjectID = "mdp-aot-itm"; */
+"mdp-aot-itm.title" = "始终置顶";
+
 /* Class = "NSMenuItem"; title = "Zoom In"; ObjectID = "mdp-zi-itm"; */
 "mdp-zi-itm.title" = "放大";
 

--- a/tests/swift-tests/Sources/MarkdownHelpers/AlwaysOnTopPolicy.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/AlwaysOnTopPolicy.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/AlwaysOnTopPolicy.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/AlwaysOnTopPolicyTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/AlwaysOnTopPolicyTests.swift
@@ -4,18 +4,37 @@ import XCTest
 
 final class AlwaysOnTopPolicyTests: XCTestCase {
     func testPinnedWindowSitsAtTheFloatingLevel() {
-        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: true),
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: true, isFullScreen: false),
                        Int(CGWindowLevelForKey(.floatingWindow)))
     }
 
     func testUnpinnedWindowReturnsToTheNormalLevel() {
-        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: false),
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: false, isFullScreen: false),
                        Int(CGWindowLevelForKey(.normalWindow)))
     }
 
     func testPinningRaisesTheWindowAboveItsUnpinnedLevel() {
-        XCTAssertGreaterThan(AlwaysOnTopPolicy.windowLevel(isPinned: true),
-                             AlwaysOnTopPolicy.windowLevel(isPinned: false))
+        XCTAssertGreaterThan(AlwaysOnTopPolicy.windowLevel(isPinned: true, isFullScreen: false),
+                             AlwaysOnTopPolicy.windowLevel(isPinned: false, isFullScreen: false))
+    }
+
+    // AppKit refuses full screen to any window above the normal level, which is
+    // what silently greyed out Enter Full Screen once a window was pinned.
+    func testPinnedWindowDropsToTheNormalLevelInFullScreen() {
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: true, isFullScreen: true),
+                       Int(CGWindowLevelForKey(.normalWindow)))
+    }
+
+    func testUnpinnedWindowStaysAtTheNormalLevelInFullScreen() {
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: false, isFullScreen: true),
+                       Int(CGWindowLevelForKey(.normalWindow)))
+    }
+
+    // The pin is intent, not the level itself: leaving full screen while still
+    // pinned has to float the window again rather than strand it at normal.
+    func testLeavingFullScreenWhilePinnedFloatsTheWindowAgain() {
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: true, isFullScreen: false),
+                       Int(CGWindowLevelForKey(.floatingWindow)))
     }
 
     func testUntabbedWindowIsTheOnlyOneAffected() {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/AlwaysOnTopPolicyTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/AlwaysOnTopPolicyTests.swift
@@ -1,0 +1,38 @@
+import CoreGraphics
+import XCTest
+@testable import MarkdownHelpers
+
+final class AlwaysOnTopPolicyTests: XCTestCase {
+    func testPinnedWindowSitsAtTheFloatingLevel() {
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: true),
+                       Int(CGWindowLevelForKey(.floatingWindow)))
+    }
+
+    func testUnpinnedWindowReturnsToTheNormalLevel() {
+        XCTAssertEqual(AlwaysOnTopPolicy.windowLevel(isPinned: false),
+                       Int(CGWindowLevelForKey(.normalWindow)))
+    }
+
+    func testPinningRaisesTheWindowAboveItsUnpinnedLevel() {
+        XCTAssertGreaterThan(AlwaysOnTopPolicy.windowLevel(isPinned: true),
+                             AlwaysOnTopPolicy.windowLevel(isPinned: false))
+    }
+
+    func testUntabbedWindowIsTheOnlyOneAffected() {
+        XCTAssertEqual(AlwaysOnTopPolicy.affectedWindows(toggling: "doc", tabGroup: nil),
+                       ["doc"])
+    }
+
+    func testTabbedWindowPinsEveryWindowInItsGroup() {
+        let group = ["notes", "readme", "changelog"]
+        XCTAssertEqual(AlwaysOnTopPolicy.affectedWindows(toggling: "readme", tabGroup: group),
+                       group)
+    }
+
+    // AppKit hands back an empty array rather than nil in some teardown
+    // orderings; the toggle must still reach the window the reader clicked.
+    func testEmptyTabGroupStillAffectsTheToggledWindow() {
+        XCTAssertEqual(AlwaysOnTopPolicy.affectedWindows(toggling: "doc", tabGroup: []),
+                       ["doc"])
+    }
+}


### PR DESCRIPTION
## Summary

Adds a per-window "Always on Top" toggle that keeps a preview window in front of other applications, so a Markdown file stays visible while you work in an editor or terminal next to it.

Reachable two ways:

- View menu → "Always on Top", ⌃⌘T, with a pin icon beside the zoom items
- An optional toolbar button, available through Customize Toolbar

<img width="413" height="612" alt="image" src="https://github.com/user-attachments/assets/81a96230-f755-4d6a-9daf-1f34254c7683" />


## Design notes

Three decisions worth surfacing, since each could reasonably have gone the other way.

**The floating level is intentional, and does not undo #245.** That PR deliberately set the Mermaid popup to `.normal` so a diagram never floats above other apps. This feature wants the opposite: it exists precisely to keep a window in sight while the reader works elsewhere. Both rationales now sit next to their respective code so neither gets "fixed" later by mistake.

**Pinning applies to a whole tab group.** A tab group presents as one on-screen window, so pinning a single tab would be ambiguous: whichever tab was frontmost would decide whether the group floats, and the check mark would flip as you switched tabs.

**The pinned state is not persisted across launches.** A window pinned for one reading session probably shouldn't come back floating. Easy to change if you'd rather it stuck.

Two smaller ones:

- The toolbar item is in the _allowed_ set, not the default set, so no existing toolbar gets rearranged. One line to promote it if you want it visible by default.
- `collectionBehavior` is untouched, so full screen behaves as before. A floating window still can't sit above another app's full-screen space, which is a macOS constraint rather than something to work around.

`installZoomMenuItemIcons` is renamed to `installViewMenuItemIcons`, since it now decorates a non-zoom item too. Happy to revert if you'd rather keep the diff tighter.

## Tests

`AlwaysOnTopPolicy` holds the two decisions above as pure, AppKit-free logic, mirrored into the SPM helper package like the other helpers.

```
swift test --package-path tests/swift-tests --filter AlwaysOnTopPolicyTests
```

## Test plan

Built Debug locally (ad-hoc signed) and exercised by hand:

- [x] View menu item appears with the pin icon and ⌃⌘T, and the check mark tracks state
- [x] Toggling on keeps the window in front of other applications; toggling off restores normal ordering
- [x] `swift test --package-path tests/swift-tests --filter AlwaysOnTopPolicyTests` passes (6 tests)
- [ ] Toolbar button via Customize Toolbar — implemented, not yet exercised by hand
- [ ] Tab group pinning as a whole — reasoned about rather than observed, so it's the part most deserving of your eye
- [ ] Mermaid popup still stays out of other apps (#245) — untouched by this change, but not re-verified

There's no UI test suite, so the unticked boxes are honest gaps rather than steps I skipped. Glad to go back and cover any of them if you'd like them confirmed before review.
