### PR TITLE
Add ⌘L shortcut for toggling the sidebar

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -261,6 +261,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         activeDocumentWindowController?.handleFindAction(sender)
     }
 
+    @objc private func toggleSidebarFromMenu(_ sender: Any?) {
+        activeDocumentWindowController?.toggleSidebarFromMenu(sender)
+        syncSidebarViewMenuState()
+    }
+
     @objc private func hideSidebarFromMenu(_ sender: Any?) {
         activeDocumentWindowController?.hideSidebarFromMenu(sender)
         syncSidebarViewMenuState()
@@ -300,7 +305,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         syncAppearanceMenuState()
         syncContentWidthMenuState()
         switch menuItem.action {
-        case #selector(hideSidebarFromMenu(_:)),
+        case #selector(toggleSidebarFromMenu(_:)),
+             #selector(hideSidebarFromMenu(_:)),
              #selector(selectOutlineMode(_:)),
              #selector(selectFilesMode(_:)),
              #selector(performFindPanelAction(_:)),
@@ -946,28 +952,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let insertIndex = (viewMenu.items.firstIndex(where: { $0.isSeparatorItem }) ?? -1) + 1
 
+        // Plain ⌘L: the panes below stay on ⌃⌘, and ⌘B — the chord this
+        // would otherwise want — belongs to Format › Bold, which swallows it
+        // even while disabled instead of falling through to this menu.
+        let toggle = makeSidebarViewMenuItem(title: L("Toggle Sidebar"),
+                                             symbol: "sidebar.leading",
+                                             keyEquivalent: "l",
+                                             modifiers: [.command],
+                                             action: #selector(toggleSidebarFromMenu(_:)))
+        viewMenu.insertItem(toggle, at: insertIndex)
+
         let hide = makeSidebarViewMenuItem(title: L("Hide Sidebar"),
                                            symbol: "sidebar.leading",
                                            keyEquivalent: "1",
                                            action: #selector(hideSidebarFromMenu(_:)))
-        viewMenu.insertItem(hide, at: insertIndex)
+        viewMenu.insertItem(hide, at: insertIndex + 1)
         hideSidebarMenuItem = hide
 
         let outline = makeSidebarViewMenuItem(title: L("Table of Contents"),
                                               symbol: "list.bullet.indent",
                                               keyEquivalent: "2",
                                               action: #selector(selectOutlineMode(_:)))
-        viewMenu.insertItem(outline, at: insertIndex + 1)
+        viewMenu.insertItem(outline, at: insertIndex + 2)
         outlineMenuItem = outline
 
         let files = makeSidebarViewMenuItem(title: L("Project Navigator"),
                                             symbol: "folder",
                                             keyEquivalent: "3",
                                             action: #selector(selectFilesMode(_:)))
-        viewMenu.insertItem(files, at: insertIndex + 2)
+        viewMenu.insertItem(files, at: insertIndex + 3)
         filesMenuItem = files
 
-        viewMenu.insertItem(.separator(), at: insertIndex + 3)
+        viewMenu.insertItem(.separator(), at: insertIndex + 4)
     }
 
     private func installEditModeMenuItem() {
@@ -1047,10 +1063,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func makeSidebarViewMenuItem(title: String,
                                          symbol: String,
                                          keyEquivalent: String,
+                                         modifiers: NSEvent.ModifierFlags = [.control, .command],
                                          action: Selector) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
         // ⌃⌘ like Safari's sidebar panes; ⌥⌘1–3 belong to Format headings.
-        item.keyEquivalentModifierMask = [.control, .command]
+        item.keyEquivalentModifierMask = modifiers
         item.target = self
         if let image = NSImage(systemSymbolName: symbol, accessibilityDescription: title) {
             image.isTemplate = true

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "Content Width" = "Content Width";
 "Normal" = "Normal";
 "Full Width" = "Full Width";
+"Toggle Sidebar" = "Toggle Sidebar";
 "Hide Sidebar" = "Hide Sidebar";
 "Table of Contents" = "Table of Contents";
 "Project Navigator" = "Project Navigator";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "Content Width" = "内容宽度";
 "Normal" = "标准";
 "Full Width" = "全宽";
+"Toggle Sidebar" = "切换边栏";
 "Hide Sidebar" = "隐藏边栏";
 "Table of Contents" = "目录";
 "Project Navigator" = "项目导航器";


### PR DESCRIPTION
## Summary

Adds a **Toggle Sidebar** item to the View menu, on ⌘L. The sidebar has no toggle shortcut today.

Nothing new underneath: the item calls `DocumentWindowController.toggleSidebarFromMenu(_:)`, which was already written but never wired to anything.

## Why ⌘L

⌘B is the obvious chord, and it's taken — Format › Bold has it. I tried making it context-sensitive anyway, since Bold is disabled outside edit mode. That doesn't work: a disabled menu item still swallows its key equivalent instead of letting the search fall through to the View menu. So ⌘L, which is free.

## Test plan

Debug build, by hand: ⌘L opens and closes the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)