### PR TITLE
Release 0.0.46 (50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.0.46] – 2026-08-08
+
+The sidebar gets a keyboard shortcut, and headings after blank lines no longer leave a gaping hole in the page.
+
+### Added
+
+- **⌘L toggles the sidebar.** A Toggle Sidebar item in the View menu shows and hides the sidebar from the keyboard ([#267](https://github.com/pluk-inc/markdown-preview/pull/267)).
+
+### Fixed
+
+- **Headings after blank lines use compact spacing.** A blank line already renders its own height, and the heading's margin stacked on top of it, producing oversized gaps. Authored blank lines are preserved, but the stacked margin above them drops to 4 px — in reading mode and for both ATX and Setext headings in edit mode ([#264](https://github.com/pluk-inc/markdown-preview/pull/264), [#263](https://github.com/pluk-inc/markdown-preview/issues/263)).
+
+### Contributors
+
+Thanks to the external contributors who helped improve this release:
+
+- [@inceenes10](https://github.com/inceenes10) — added the ⌘L sidebar shortcut ([#267](https://github.com/pluk-inc/markdown-preview/pull/267))
+- [@t9mike](https://github.com/t9mike) — reported the excess vertical space around headings ([#263](https://github.com/pluk-inc/markdown-preview/issues/263))
+
 ## [0.0.45] – 2026-08-05
 
 Mermaid diagrams in Quick Look now match the system appearance.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.45
-CURRENT_PROJECT_VERSION = 49
+MARKETING_VERSION = 0.0.46
+CURRENT_PROJECT_VERSION = 50


### PR DESCRIPTION
## Summary

- Bump `Version.xcconfig` to `0.0.46` (build `50`)
- Add the `CHANGELOG.md` entry for 0.0.46

## What's in 0.0.46

- **⌘L toggles the sidebar.** A Toggle Sidebar item in the View menu shows and hides the sidebar from the keyboard ([#267](https://github.com/pluk-inc/markdown-preview/pull/267)).
- **Headings after blank lines use compact spacing.** Authored blank lines are preserved, but the heading margin stacked above them drops to 4 px — in reading mode and for both ATX and Setext headings in edit mode ([#264](https://github.com/pluk-inc/markdown-preview/pull/264), [#263](https://github.com/pluk-inc/markdown-preview/issues/263)).

Contributors this release: [@inceenes10](https://github.com/inceenes10) (⌘L shortcut) and [@t9mike](https://github.com/t9mike) (reported the heading spacing issue).

## Test plan

- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` succeeds
- [ ] App and Quick Look extension both report version 0.0.46 (50)
- [ ] Changelog renders correctly and the release notes extract cleanly for `./scripts/release.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)