### PR TITLE
Release 0.0.47 (51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.47] – 2026-08-08
+
+The Appearance setting now covers Finder previews too, so the app and Quick Look stop disagreeing about light and dark.
+
+### Changed
+
+- **View ▸ Appearance controls Quick Look as well.** The existing Automatic / Light / Dark choice was stored only in the app's own defaults, so the sandboxed Quick Look extension couldn't see it and kept following the system appearance. The setting now lives in storage shared by both targets — and is migrated over from the old location on first launch — so a fixed Light or Dark applies to the page surface, text, math errors, syntax highlighting, and Mermaid diagrams in Finder previews. Automatic still follows each host's native appearance ([#265](https://github.com/pluk-inc/markdown-preview/pull/265)).
+
+### Contributors
+
+Thanks to the external contributor who shipped in this release:
+
+- [@Avi7ii](https://github.com/Avi7ii) — shared the app's appearance setting with Quick Look ([#265](https://github.com/pluk-inc/markdown-preview/pull/265))
+
 ## [0.0.46] – 2026-08-08
 
 The sidebar gets a keyboard shortcut, and headings after blank lines no longer leave a gaping hole in the page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,27 @@
 
 ## [0.0.47] – 2026-08-08
 
-The Appearance setting now covers Finder previews too, so the app and Quick Look stop disagreeing about light and dark.
+The Appearance setting now covers Finder previews too, so the app and Quick Look stop disagreeing about light and dark. Because 0.0.46 shipped only briefly, its sidebar shortcut and heading-spacing fix are listed here as well — most people will pick them up in this update.
+
+### Added
+
+- **⌘L toggles the sidebar.** A Toggle Sidebar item in the View menu shows and hides the sidebar from the keyboard ([#267](https://github.com/pluk-inc/markdown-preview/pull/267)).
 
 ### Changed
 
 - **View ▸ Appearance controls Quick Look as well.** The existing Automatic / Light / Dark choice was stored only in the app's own defaults, so the sandboxed Quick Look extension couldn't see it and kept following the system appearance. The setting now lives in storage shared by both targets — and is migrated over from the old location on first launch — so a fixed Light or Dark applies to the page surface, text, math errors, syntax highlighting, and Mermaid diagrams in Finder previews. Automatic still follows each host's native appearance ([#265](https://github.com/pluk-inc/markdown-preview/pull/265)).
 
+### Fixed
+
+- **Headings after blank lines use compact spacing.** A blank line already renders its own height, and the heading's margin stacked on top of it, producing oversized gaps. Authored blank lines are preserved, but the stacked margin above them drops to 4 px — in reading mode and for both ATX and Setext headings in edit mode ([#264](https://github.com/pluk-inc/markdown-preview/pull/264), [#263](https://github.com/pluk-inc/markdown-preview/issues/263)).
+
 ### Contributors
 
-Thanks to the external contributor who shipped in this release:
+Thanks to the external contributors who helped improve this release:
 
 - [@Avi7ii](https://github.com/Avi7ii) — shared the app's appearance setting with Quick Look ([#265](https://github.com/pluk-inc/markdown-preview/pull/265))
+- [@inceenes10](https://github.com/inceenes10) — added the ⌘L sidebar shortcut ([#267](https://github.com/pluk-inc/markdown-preview/pull/267))
+- [@t9mike](https://github.com/t9mike) — reported the excess vertical space around headings ([#263](https://github.com/pluk-inc/markdown-preview/issues/263))
 
 ## [0.0.46] – 2026-08-08
 

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.46
-CURRENT_PROJECT_VERSION = 50
+MARKETING_VERSION = 0.0.47
+CURRENT_PROJECT_VERSION = 51


### PR DESCRIPTION
## Summary

- Bump `Version.xcconfig` to `0.0.47` (build `51`)
- Add the `CHANGELOG.md` entry for 0.0.47, which also carries the 0.0.46 items — 0.0.46 was published only briefly, so most users will receive both sets of changes in this update

## What's in 0.0.47

### Added

- **⌘L toggles the sidebar.** A Toggle Sidebar item in the View menu shows and hides the sidebar from the keyboard (#267).

### Changed

- **View ▸ Appearance controls Quick Look as well.** The existing Automatic / Light / Dark choice was stored only in the app's own defaults, so the sandboxed Quick Look extension couldn't see it and kept following the system appearance. The setting now lives in storage shared by both targets — and is migrated over from the old location on first launch — so a fixed Light or Dark applies to the page surface, text, math errors, syntax highlighting, and Mermaid diagrams in Finder previews. Automatic still follows each host's native appearance (#265).

### Fixed

- **Headings after blank lines use compact spacing.** A blank line already renders its own height, and the heading's margin stacked on top of it, producing oversized gaps. Authored blank lines are preserved, but the stacked margin above them drops to 4 px — in reading mode and for both ATX and Setext headings in edit mode (#264, #263).

### Contributors

- @Avi7ii — shared the app's appearance setting with Quick Look (#265)
- @inceenes10 — added the ⌘L sidebar shortcut (#267)
- @t9mike — reported the excess vertical space around headings (#263)

## Notes

The 0.0.46 section is left in `CHANGELOG.md` untouched — that version was tagged and released, so its history stays accurate. The 0.0.47 entry restates those two items so `extract_notes` picks them up for the appcast and GitHub release.

## Test plan

- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` succeeds
- [ ] About window and `Info.plist` report 0.0.47 (51) for both the app and the embedded Quick Look extension
- [ ] Set View ▸ Appearance to Light and to Dark; confirm Finder Quick Look follows each fixed choice, and that Automatic still tracks the system appearance
- [ ] ⌘L toggles the sidebar; headings after blank lines keep the compact spacing
- [ ] After merge, `./scripts/release.sh` validates the changelog entry and runs the Amore pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)