### PR TITLE
Enable native text selection and cursor feedback in Quick Look

### DIFF
--- a/quick-look/Info.plist
+++ b/quick-look/Info.plist
@@ -8,8 +8,6 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
-			<key>QLIsDataBasedPreview</key>
-			<true/>
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>public.markdown</string>
@@ -29,7 +27,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.quicklook.preview</string>
 		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).PreviewProvider</string>
+		<string>$(PRODUCT_MODULE_NAME).PreviewViewController</string>
 	</dict>
 </dict>
 </plist>

--- a/quick-look/InlineLocalAssets.swift
+++ b/quick-look/InlineLocalAssets.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 
 enum InlineLocalAssets {
 
@@ -72,6 +73,43 @@ enum InlineLocalAssets {
         output += nsHtml.substring(from: cursor)
 
         return Result(html: output, attachments: attachments)
+    }
+
+    static func dataURLHTML(from result: Result) -> String {
+        let nsHtml = result.html as NSString
+        let matches = imgSrcRegex.matches(
+            in: result.html,
+            range: NSRange(location: 0, length: nsHtml.length)
+        )
+        guard !matches.isEmpty else { return result.html }
+
+        var output = ""
+        output.reserveCapacity(result.html.count)
+        var cursor = 0
+
+        for match in matches {
+            output += nsHtml.substring(with: NSRange(
+                location: cursor,
+                length: match.range.location - cursor
+            ))
+
+            let src = nsHtml.substring(with: match.range(at: 2))
+            let contentID = src.hasPrefix("cid:") ? String(src.dropFirst(4)) : ""
+            if let attachment = result.attachments[contentID] {
+                let prefix = nsHtml.substring(with: match.range(at: 1))
+                let suffix = nsHtml.substring(with: match.range(at: 3))
+                let mimeType = UTType(filenameExtension: attachment.pathExtension)?.preferredMIMEType
+                    ?? "application/octet-stream"
+                let dataURL = "data:\(mimeType);base64,\(attachment.data.base64EncodedString())"
+                output += "\(prefix)\(dataURL)\(suffix)"
+            } else {
+                output += nsHtml.substring(with: match.range)
+            }
+
+            cursor = match.range.location + match.range.length
+        }
+        output += nsHtml.substring(from: cursor)
+        return output
     }
 
     // Matches the double-quoted image tags emitted by MarkdownHTML's renderer.

--- a/quick-look/PreviewViewController.swift
+++ b/quick-look/PreviewViewController.swift
@@ -9,11 +9,380 @@ import Cocoa
 import Quartz
 import WebKit
 
+private final class CursorRegionMessageProxy: NSObject, WKScriptMessageHandler {
+    weak var owner: QuickLookWebView?
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.frameInfo.isMainFrame else { return }
+        owner?.updateCursorRegions(from: message.body)
+    }
+}
+
+private final class QuickLookWebView: WKWebView {
+    private struct CursorRegion {
+        let rect: NSRect
+        let cursor: NSCursor
+    }
+
+    private static let cursorRegionMessageName = "mdPreviewCursorRegions"
+    private static let maximumVisibleCursorRegions = 4_096
+    private var cursorRegions: [CursorRegion] = []
+
+    override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+        let messageProxy = CursorRegionMessageProxy()
+        configuration.userContentController.add(
+            messageProxy,
+            name: Self.cursorRegionMessageName
+        )
+        configuration.userContentController.addUserScript(WKUserScript(
+            source: Self.cursorRegionReportingScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        ))
+        super.init(frame: frame, configuration: configuration)
+        messageProxy.owner = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        for region in cursorRegions {
+            let rect = region.rect.intersection(visibleRect)
+            guard !rect.isNull, !rect.isEmpty else { continue }
+            addCursorRect(rect, cursor: region.cursor)
+        }
+    }
+
+    fileprivate func updateCursorRegions(from body: Any) {
+        guard let rows = body as? [Any] else { return }
+
+        cursorRegions = rows.prefix(Self.maximumVisibleCursorRegions).compactMap { row in
+            guard let values = row as? [Any],
+                  values.count == 5,
+                  let kind = values[0] as? String,
+                  let x = (values[1] as? NSNumber)?.doubleValue,
+                  let y = (values[2] as? NSNumber)?.doubleValue,
+                  let width = (values[3] as? NSNumber)?.doubleValue,
+                  let height = (values[4] as? NSNumber)?.doubleValue,
+                  [x, y, width, height].allSatisfy(\.isFinite),
+                  width > 0,
+                  height > 0 else { return nil }
+
+            let localX = bounds.minX + x
+            let localY = isFlipped ? bounds.minY + y : bounds.maxY - y - height
+            let rect = NSRect(x: localX, y: localY, width: width, height: height)
+                .intersection(bounds)
+            guard !rect.isNull, !rect.isEmpty else { return nil }
+
+            let cursor: NSCursor
+            switch kind {
+            case "text":
+                cursor = .iBeam
+            case "pointer":
+                cursor = .pointingHand
+            default:
+                return nil
+            }
+            return CursorRegion(rect: rect, cursor: cursor)
+        }
+
+        window?.invalidateCursorRects(for: self)
+    }
+
+    fileprivate func clearCursorRegions() {
+        cursorRegions = []
+        window?.invalidateCursorRects(for: self)
+    }
+
+    // A Quick Look preview is hosted through ViewBridge. WebKit's direct
+    // cursor update is not forwarded reliably across that remote-window
+    // boundary, while AppKit cursor rects are. Cache DOM layout rectangles
+    // when layout changes, then only project that cache while scrolling; no
+    // mouse-move listener or per-hover DOM hit testing is involved.
+    private static let cursorRegionReportingScript = """
+    (() => {
+        const handler = window.webkit?.messageHandlers?.mdPreviewCursorRegions;
+        if (!handler) return;
+
+        const pointerSelector = [
+            'a[href]',
+            'button:not([disabled])',
+            'summary',
+            '[role="button"]',
+            'input[type="checkbox"]:not([disabled])',
+            'input[type="radio"]:not([disabled])',
+            '.md-code-copy'
+        ].join(',');
+        const textExclusionSelector = [
+            'a', 'button', 'input', 'select', 'textarea', 'summary',
+            '[role="button"]', '.md-code-copy', '.mermaid-stage'
+        ].join(',');
+
+        let cachedRegions = [];
+        let layoutFrame = null;
+        let viewportFrame = null;
+        let resizeObserver = null;
+        let observedArticle = null;
+        const maximumVisibleRegions = 4096;
+
+        const isRenderable = (element) => {
+            const style = getComputedStyle(element);
+            return style.display !== 'none'
+                && style.visibility !== 'hidden'
+                && style.pointerEvents !== 'none';
+        };
+
+        const documentRect = (rect, scrollX, scrollY) => [
+            rect.left + scrollX,
+            rect.top + scrollY,
+            rect.width,
+            rect.height
+        ];
+
+        const clipsOverflow = (value) => [
+            'auto', 'scroll', 'hidden', 'clip', 'overlay'
+        ].includes(value);
+
+        const clipToAncestors = (rect, startElement, article) => {
+            let left = rect.left;
+            let top = rect.top;
+            let right = rect.right;
+            let bottom = rect.bottom;
+
+            for (let element = startElement; element; element = element.parentElement) {
+                const style = getComputedStyle(element);
+                const clipsX = clipsOverflow(style.overflowX);
+                const clipsY = clipsOverflow(style.overflowY);
+                if (clipsX || clipsY) {
+                    const bounds = element.getBoundingClientRect();
+                    const clipLeft = bounds.left + element.clientLeft;
+                    const clipTop = bounds.top + element.clientTop;
+                    const clipRight = clipLeft + element.clientWidth;
+                    const clipBottom = clipTop + element.clientHeight;
+                    if (clipsX) {
+                        left = Math.max(left, clipLeft);
+                        right = Math.min(right, clipRight);
+                    }
+                    if (clipsY) {
+                        top = Math.max(top, clipTop);
+                        bottom = Math.min(bottom, clipBottom);
+                    }
+                    if (right <= left || bottom <= top) return null;
+                }
+                if (element === article) break;
+            }
+
+            return {
+                left,
+                top,
+                right,
+                bottom,
+                width: right - left,
+                height: bottom - top
+            };
+        };
+
+        const subtractRect = (rect, cut) => {
+            const rectRight = rect[0] + rect[2];
+            const rectBottom = rect[1] + rect[3];
+            const cutRight = cut[0] + cut[2];
+            const cutBottom = cut[1] + cut[3];
+            const overlapLeft = Math.max(rect[0], cut[0]);
+            const overlapTop = Math.max(rect[1], cut[1]);
+            const overlapRight = Math.min(rectRight, cutRight);
+            const overlapBottom = Math.min(rectBottom, cutBottom);
+            if (overlapRight <= overlapLeft || overlapBottom <= overlapTop) {
+                return [rect];
+            }
+
+            const pieces = [];
+            if (overlapTop > rect[1]) {
+                pieces.push([rect[0], rect[1], rect[2], overlapTop - rect[1]]);
+            }
+            if (overlapBottom < rectBottom) {
+                pieces.push([rect[0], overlapBottom, rect[2], rectBottom - overlapBottom]);
+            }
+            if (overlapLeft > rect[0]) {
+                pieces.push([
+                    rect[0], overlapTop,
+                    overlapLeft - rect[0], overlapBottom - overlapTop
+                ]);
+            }
+            if (overlapRight < rectRight) {
+                pieces.push([
+                    overlapRight, overlapTop,
+                    rectRight - overlapRight, overlapBottom - overlapTop
+                ]);
+            }
+            return pieces;
+        };
+
+        const subtractRects = (rect, cuts) => {
+            let pieces = [rect];
+            for (const cut of cuts) {
+                pieces = pieces.flatMap((piece) => subtractRect(piece, cut));
+                if (pieces.length === 0) break;
+            }
+            return pieces;
+        };
+
+        const postVisibleRegions = () => {
+            viewportFrame = null;
+            const scrollX = window.scrollX;
+            const scrollY = window.scrollY;
+            const viewportWidth = document.documentElement.clientWidth;
+            const viewportHeight = document.documentElement.clientHeight;
+            const visiblePointerRects = [];
+            const visibleTextRects = [];
+
+            for (const [kind, documentX, documentY, width, height] of cachedRegions) {
+                const x = documentX - scrollX;
+                const y = documentY - scrollY;
+                if (x + width <= 0 || y + height <= 0
+                    || x >= viewportWidth || y >= viewportHeight) continue;
+
+                const rect = [x, y, width, height];
+                if (kind === 'pointer') {
+                    visiblePointerRects.push(...subtractRects(rect, visiblePointerRects));
+                } else {
+                    visibleTextRects.push(rect);
+                }
+            }
+
+            const visible = visiblePointerRects
+                .slice(0, maximumVisibleRegions)
+                .map((rect) => ['pointer', ...rect]);
+            textRegions: for (const rect of visibleTextRects) {
+                for (const piece of subtractRects(rect, visiblePointerRects)) {
+                    if (visible.length >= maximumVisibleRegions) break textRegions;
+                    visible.push(['text', ...piece]);
+                }
+            }
+            handler.postMessage(visible);
+        };
+
+        const scheduleViewportProjection = () => {
+            if (viewportFrame !== null) return;
+            viewportFrame = requestAnimationFrame(postVisibleRegions);
+        };
+
+        const rebuildLayoutCache = () => {
+            layoutFrame = null;
+            if (viewportFrame !== null) {
+                cancelAnimationFrame(viewportFrame);
+                viewportFrame = null;
+            }
+            const article = document.querySelector('article.markdown-body');
+            cachedRegions = [];
+            if (!article) {
+                handler.postMessage([]);
+                return;
+            }
+
+            if (observedArticle !== article && window.ResizeObserver) {
+                resizeObserver?.disconnect();
+                resizeObserver = new ResizeObserver(scheduleLayoutRebuild);
+                resizeObserver.observe(article);
+                observedArticle = article;
+            }
+
+            const scrollX = window.scrollX;
+            const scrollY = window.scrollY;
+
+            for (const element of article.querySelectorAll(pointerSelector)) {
+                if (!isRenderable(element) || element.getAttribute('aria-disabled') === 'true') {
+                    continue;
+                }
+                for (const rect of element.getClientRects()) {
+                    const clipped = clipToAncestors(rect, element.parentElement, article);
+                    if (!clipped) continue;
+                    cachedRegions.push([
+                        'pointer',
+                        ...documentRect(clipped, scrollX, scrollY)
+                    ]);
+                }
+            }
+
+            const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+            let node;
+            while ((node = walker.nextNode())) {
+                if (!node.nodeValue || !node.nodeValue.trim()) continue;
+                const parent = node.parentElement;
+                if (!parent || parent.closest(textExclusionSelector) || !isRenderable(parent)) {
+                    continue;
+                }
+
+                const style = getComputedStyle(parent);
+                if (style.userSelect === 'none' || style.webkitUserSelect === 'none') continue;
+
+                const range = document.createRange();
+                range.selectNodeContents(node);
+                for (const rect of range.getClientRects()) {
+                    const clipped = clipToAncestors(rect, parent, article);
+                    if (!clipped) continue;
+                    cachedRegions.push([
+                        'text',
+                        ...documentRect(clipped, scrollX, scrollY)
+                    ]);
+                }
+            }
+
+            postVisibleRegions();
+        };
+
+        function scheduleLayoutRebuild() {
+            if (layoutFrame !== null) return;
+            layoutFrame = requestAnimationFrame(rebuildLayoutCache);
+        }
+
+        const handleScroll = (event) => {
+            const target = event.target;
+            const rootScroll = target === window
+                || target === document
+                || target === document.scrollingElement
+                || target === document.documentElement
+                || target === document.body;
+            if (rootScroll) {
+                scheduleViewportProjection();
+            } else {
+                scheduleLayoutRebuild();
+            }
+        };
+
+        addEventListener('scroll', handleScroll, true);
+        addEventListener('resize', scheduleLayoutRebuild);
+        document.addEventListener('DOMContentLoaded', scheduleLayoutRebuild, { once: true });
+        document.addEventListener('load', scheduleLayoutRebuild, true);
+        document.addEventListener('error', scheduleLayoutRebuild, true);
+        document.addEventListener('toggle', scheduleLayoutRebuild, true);
+        for (const eventName of [
+            'md-preview-math-rendered',
+            'md-preview-hljs-rendered',
+            'md-preview-mermaid-rendered'
+        ]) {
+            addEventListener(eventName, scheduleLayoutRebuild);
+        }
+        document.fonts?.ready.then(scheduleLayoutRebuild);
+        scheduleLayoutRebuild();
+    })();
+    """
+}
+
 final class PreviewViewController: NSViewController, QLPreviewingController, WKNavigationDelegate {
-    private var webView: WKWebView!
+    private var webView: QuickLookWebView!
 
     override func loadView() {
-        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        webView = QuickLookWebView(
+            frame: .zero,
+            configuration: WKWebViewConfiguration()
+        )
         webView.navigationDelegate = self
         view = webView
         preferredContentSize = NSSize(
@@ -50,6 +419,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         )
 
         loadViewIfNeeded()
+        webView.clearCursorRegions()
         webView.loadHTMLString(
             InlineLocalAssets.dataURLHTML(from: rewrite),
             // Admitted local images are already data URLs. A directory base

--- a/quick-look/PreviewViewController.swift
+++ b/quick-look/PreviewViewController.swift
@@ -7,33 +7,83 @@
 
 import Cocoa
 import Quartz
+import WebKit
 
-class PreviewViewController: NSViewController, QLPreviewingController {
-
-    override var nibName: NSNib.Name? {
-        return NSNib.Name("PreviewViewController")
-    }
+final class PreviewViewController: NSViewController, QLPreviewingController, WKNavigationDelegate {
+    private var webView: WKWebView!
 
     override func loadView() {
-        super.loadView()
-        // Do any additional setup after loading the view.
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        webView.navigationDelegate = self
+        view = webView
+        preferredContentSize = NSSize(
+            width: MarkdownHTML.preferredPageWidth,
+            height: MarkdownHTML.preferredPageWidth
+        )
     }
-
-    /*
-    func preparePreviewOfSearchableItem(identifier: String, queryString: String?) async throws {
-        // Implement this method and set QLSupportsSearchableItems to YES in the Info.plist of the extension if you support CoreSpotlight.
-
-        // Perform any setup necessary in order to prepare the view.
-        // Quick Look will display a loading spinner until this returns.
-    }
-    */
 
     func preparePreviewOfFile(at url: URL) async throws {
-        // Add the supported content types to the QLSupportedContentTypes array in the Info.plist of the extension.
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let appearanceMode = AppearanceMode.current
+        let colorScheme: MarkdownHTML.ColorScheme
+        switch appearanceMode {
+        case .automatic:
+            let appearance = NSApplication.shared.effectiveAppearance
+            let systemIsDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            colorScheme = appearanceMode.resolvedColorScheme(systemIsDark: systemIsDark)
+        case .light:
+            colorScheme = .light
+        case .dark:
+            colorScheme = .dark
+        }
 
-        // Perform any setup necessary in order to prepare the view.
+        let renderedHTML = MarkdownHTML.makeHTML(
+            from: text,
+            allowsScroll: true,
+            colorScheme: colorScheme
+        )
+        let baseDirectory = url.deletingLastPathComponent()
+        let rewrite = InlineLocalAssets.rewriteRelativeImages(
+            html: renderedHTML,
+            baseDirectory: baseDirectory,
+            reader: { try Data(contentsOf: $0) }
+        )
 
-        // Quick Look will display a loading spinner until this returns.
+        loadViewIfNeeded()
+        webView.loadHTMLString(
+            InlineLocalAssets.dataURLHTML(from: rewrite),
+            // Admitted local images are already data URLs. A directory base
+            // would let WebKit fetch rejected or over-budget relative images.
+            baseURL: nil
+        )
     }
 
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+    ) {
+        guard navigationAction.navigationType == .linkActivated else {
+            decisionHandler(.allow)
+            return
+        }
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        let isPageFragment = url.scheme == "about"
+            && url.path == "blank"
+            && url.fragment != nil
+        if isPageFragment {
+            decisionHandler(.allow)
+            return
+        }
+
+        if let scheme = url.scheme?.lowercased(),
+           ["http", "https", "mailto"].contains(scheme) {
+            NSWorkspace.shared.open(url)
+        }
+        decisionHandler(.cancel)
+    }
 }

--- a/tests/swift-tests/Tests/QuickLookHelperTests/InlineLocalAssetsTests.swift
+++ b/tests/swift-tests/Tests/QuickLookHelperTests/InlineLocalAssetsTests.swift
@@ -235,4 +235,58 @@ final class InlineLocalAssetsTests: XCTestCase {
             Set([red, blue])
         )
     }
+
+    func testAttachmentsCanBeEmbeddedAsDataURLsForViewBasedPreview() {
+        let result = InlineLocalAssets.rewriteRelativeImages(
+            html: #"<img src="a.png"><img src="b">"#,
+            baseDirectory: baseDir,
+            reader: reader([
+                "/tmp/qltest-fixture/a.png": red,
+                "/tmp/qltest-fixture/b": blue,
+            ])
+        )
+
+        let html = InlineLocalAssets.dataURLHTML(from: result)
+
+        XCTAssertFalse(html.contains("cid:"))
+        XCTAssertTrue(html.contains("data:image/png;base64,\(red.base64EncodedString())"))
+        XCTAssertTrue(html.contains(
+            "data:application/octet-stream;base64,\(blue.base64EncodedString())"
+        ))
+    }
+
+    func testDataURLConversionKeepsOverlappingContentIDsDistinct() {
+        let sources = (0...10).map { "image-\($0).png" }
+        let html = sources.map { #"<img src="\#($0)">"# }.joined()
+        let files = Dictionary(uniqueKeysWithValues: sources.enumerated().map { index, source in
+            ("/tmp/qltest-fixture/\(source)", Data([UInt8(index)]))
+        })
+        let result = InlineLocalAssets.rewriteRelativeImages(
+            html: html,
+            baseDirectory: baseDir,
+            reader: reader(files)
+        )
+
+        let converted = InlineLocalAssets.dataURLHTML(from: result)
+
+        XCTAssertEqual(result.attachments.count, 11)
+        XCTAssertFalse(converted.contains("cid:"))
+        for index in 0...10 {
+            let encoded = Data([UInt8(index)]).base64EncodedString()
+            XCTAssertTrue(converted.contains(#"src="data:image/png;base64,\#(encoded)""#))
+        }
+    }
+
+    func testDataURLConversionDoesNotReplaceCIDTextOutsideImageSources() {
+        let result = InlineLocalAssets.rewriteRelativeImages(
+            html: #"<p>cid:md-asset-0</p><img src="a.png">"#,
+            baseDirectory: baseDir,
+            reader: reader(["/tmp/qltest-fixture/a.png": red])
+        )
+
+        let html = InlineLocalAssets.dataURLHTML(from: result)
+
+        XCTAssertTrue(html.contains("<p>cid:md-asset-0</p>"))
+        XCTAssertTrue(html.contains("data:image/png;base64,\(red.base64EncodedString())"))
+    }
 }


### PR DESCRIPTION
## Summary

- switch the Quick Look extension from a data-based HTML reply to a view-based `WKWebView`, so rendered selections use WebKit's native responder and Command-C behavior
- bridge text and link cursor regions through AppKit cursor rectangles for Finder's ViewBridge-hosted preview
- preserve local-image support while hardening data-URL conversion, rejected-resource handling, and link navigation

## Why

With a data-based Quick Look reply, Finder's file list remains the effective copy responder, so Command-C copies the Markdown file instead of the selected rendered text. A view-based `WKWebView` gives the rendered selection WebKit's normal native selection and clipboard path.

Finder hosts that view across a ViewBridge remote-window boundary. WebKit still performs the correct DOM hit test, but its process-local cursor update is not reliably forwarded to the Finder window. The extension therefore reports layout-derived text/link rectangles to AppKit, whose cursor-rectangle lifecycle does cross that boundary.

## Implementation notes

- selection, first-responder handling, key equivalents, and pasteboard writes remain native WebKit behavior
- the cursor bridge is layout-driven: it rebuilds after rendering, font/image load, resize, disclosure, and nested scrolling; root-page scrolling only projects the cached geometry
- there is no mousemove listener, per-hover DOM hit test, polling loop, event monitor, forced first responder, or custom clipboard fallback
- text regions are clipped to overflow ancestors and visible bounds, pointer regions take precedence, and visible output is capped at 4,096 rectangles
- admitted local images keep the existing per-image and cumulative byte budgets and are embedded as exact `img src` data URLs
- `baseURL` is intentionally nil so rejected, out-of-directory, or over-budget relative resources cannot be loaded independently by WebKit
- page fragments stay in the preview; HTTP(S) and mail links open externally instead of replacing the Quick Look page

## Validation

- side-loaded the built app and verified Finder Quick Look renders Markdown, selects rendered text, copies it with Command-C, and restores text/link/whitespace cursor feedback
- [full validation workflow](https://github.com/Avi7ii/markdown-preview/actions/runs/31456680530): Swift tests, unsigned Debug app and Quick Look extension build, packaging, and artifact publication all passed
- `swift build --package-path tests/swift-tests --target QuickLookHelpers`
- `swiftc -typecheck` for `PreviewViewController.swift`
- cursor-geometry harness covering overflow clipping and pointer/text separation
- regression harness covering 11 overlapping content IDs and ensuring CID-like body text is not rewritten
