### PR TITLE
Render Mermaid diagrams before print and export

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -105,6 +105,11 @@ nonisolated enum MarkdownHTML {
             width: \(contentColumnWidth)px;
             padding: 0;
         }
+        /* The figure clips an absolutely-positioned stage, so a page break
+           through it discards everything past the break. */
+        html.\(previewPrintClass) .mermaid-figure {
+            break-inside: avoid;
+        }
     }
     """
 
@@ -2626,8 +2631,9 @@ nonisolated enum MarkdownHTML {
             ));
             const states = new WeakMap();
             const queue = [];
-            let draining = false;
-            let initialized = false;
+            let drainPromise = null;
+            let initializedTheme = null;
+            let themeOverride = null;
 
             function selectedTheme() {
                 const nativeScheme = document.documentElement.dataset.mdpColorScheme;
@@ -2637,35 +2643,84 @@ nonisolated enum MarkdownHTML {
                 return dark ? 'dark' : 'default';
             }
 
-            function ensureInit() {
-                if (initialized) return;
-                initialized = true;
+            // Paper printing forces the light palette while mermaid bakes its
+            // theme into the SVG, so the host can pin a theme for the length
+            // of a print operation.
+            function activeTheme() {
+                return themeOverride || selectedTheme();
+            }
+
+            function ensureInit(theme) {
+                if (initializedTheme === theme) return;
+                initializedTheme = theme;
                 mermaid.initialize({
                     startOnLoad: false,
-                    theme: selectedTheme(),
+                    theme,
                     securityLevel: 'strict',
                     fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif'
                 });
             }
 
-            async function drain() {
-                if (draining) return;
-                draining = true;
-                while (queue.length) {
-                    const figure = queue.shift();
-                    await renderOne(figure);
+            function drain() {
+                if (drainPromise) return drainPromise;
+                drainPromise = (async () => {
+                    while (queue.length) {
+                        const figure = queue.shift();
+                        try {
+                            await renderOne(figure);
+                        } catch (err) {
+                            figure.classList.add('mermaid-error');
+                        }
+                    }
+                })().then(() => {
+                    drainPromise = null;
+                    if (queue.length) return drain();
+                    window.dispatchEvent(new Event('md-preview-mermaid-rendered'));
+                });
+                return drainPromise;
+            }
+
+            // Rendering is viewport-driven, so pagination (print/export) must
+            // force every remaining figure through the queue and wait for the
+            // drain to settle before the page is captured. Passing a theme
+            // pins it (and re-renders mismatched figures) until the next call
+            // without one restores the on-screen theme.
+            async function renderAll(theme) {
+                themeOverride = theme || null;
+                const want = activeTheme();
+                document.querySelectorAll('.mermaid-figure').forEach((figure) => {
+                    const node = figure.querySelector('.mermaid');
+                    if (!node || queue.includes(figure)) return;
+                    if (node.dataset.mmDone !== '1' || node.dataset.mmTheme !== want) {
+                        queue.push(figure);
+                    }
+                });
+                while (queue.length || drainPromise) {
+                    await drain();
                 }
-                draining = false;
-                window.dispatchEvent(new Event('md-preview-mermaid-rendered'));
             }
 
             async function renderOne(figure) {
-                ensureInit();
+                const theme = activeTheme();
+                ensureInit(theme);
                 const node = figure.querySelector('.mermaid');
-                if (!node || node.dataset.mmDone === '1') return;
-                // Pre-render source, stashed so MdPreview.update can pair
-                // unchanged diagrams with their SVGs during DOM diffs.
-                node.__mdSrc = node.textContent;
+                if (!node) return;
+                if (node.dataset.mmDone === '1') {
+                    if (node.dataset.mmTheme === theme) return;
+                    if (typeof node.__mdSrc !== 'string') return;
+                    // Theme change: put the stashed source back and clear any
+                    // pan/zoom transform now, so a pagination that starts
+                    // before the next frame never captures a stale state.
+                    const prior = states.get(figure);
+                    if (prior && prior.surface) prior.surface.style.transform = '';
+                    node.textContent = node.__mdSrc;
+                    node.removeAttribute('data-processed');
+                    delete node.dataset.mmDone;
+                } else {
+                    // Pre-render source, stashed so MdPreview.update can pair
+                    // unchanged diagrams with their SVGs during DOM diffs.
+                    node.__mdSrc = node.textContent;
+                }
                 try {
                     await mermaid.run({ nodes: [node], suppressErrors: true });
                 } catch (err) {
@@ -2678,6 +2733,7 @@ nonisolated enum MarkdownHTML {
                     return;
                 }
                 node.dataset.mmDone = '1';
+                node.dataset.mmTheme = theme;
                 attachZoom(figure, svg);
             }
 
@@ -2706,6 +2762,7 @@ nonisolated enum MarkdownHTML {
                     figure.style.setProperty('--mm-aspect', vbW + ' / ' + vbH);
                 }
 
+                const alreadyWired = states.has(figure);
                 const state = {
                     tx: 0, ty: 0, scale: 1, min: 1, max: 8,
                     rect: null, raf: 0, dragging: false,
@@ -2714,6 +2771,13 @@ nonisolated enum MarkdownHTML {
                 };
                 states.set(figure, state);
                 cacheRect(figure);
+
+                // A theme re-render reuses the figure and its listeners; only
+                // the state and HUD need resetting for the fresh SVG.
+                if (alreadyWired) {
+                    apply(figure, state);
+                    return;
+                }
 
                 figure.addEventListener('pointerenter', () => postMermaidHover(true));
                 figure.addEventListener('pointerleave', () => postMermaidHover(false));
@@ -2955,6 +3019,9 @@ nonisolated enum MarkdownHTML {
                 }, { rootMargin: '300px 0px' });
                 figures.forEach((f) => io.observe(f));
             }
+
+            window.MdPreview = window.MdPreview || {};
+            window.MdPreview.mermaidRenderAll = renderAll;
 
             return { bootstrap };
         })()
@@ -3760,7 +3827,8 @@ nonisolated enum MarkdownHTML {
 
         /* Interaction affordances are screen-only. */
         .md-code-copy,
-        .md-search-burst { display: none !important; }
+        .md-search-burst,
+        .mermaid-hud { display: none !important; }
         mark.md-search-highlight,
         mark.md-search-highlight-current {
             background: transparent;

--- a/md-preview/MarkdownWebView+PDFExport.swift
+++ b/md-preview/MarkdownWebView+PDFExport.swift
@@ -792,31 +792,76 @@ extension MarkdownWebView {
         return operation
     }
 
+    /// Mermaid theme for paper printing. Diagrams bake their colors into the
+    /// SVG at render time, so the forced-light print stylesheet needs figures
+    /// re-rendered with mermaid's light theme.
+    private static let paperPrintMermaidTheme = "default"
+
     private func runPrintOperation(
         _ operation: NSPrintOperation,
         from window: NSWindow,
         matchesPreview: Bool = false
     ) {
-        let run = {
-            operation.runModal(
-                for: window,
-                delegate: nil,
-                didRun: nil,
-                contextInfo: nil
-            )
-        }
-
         // Export keeps the live read-only stylesheet intact. Regular Print
-        // retains its paper-oriented size and pagination controls.
+        // retains its paper-oriented size and pagination controls, forces the
+        // light palette, and restores the on-screen theme when the panel ends.
         if matchesPreview {
-            applyPreviewPrintMode(completion: run)
+            renderAllMermaidDiagrams {
+                self.applyPreviewPrintMode {
+                    operation.runModal(
+                        for: window,
+                        delegate: nil,
+                        didRun: nil,
+                        contextInfo: nil
+                    )
+                }
+            }
         } else {
-            applyPaperPrintMode {
-                self.applyPrintPointSize(
-                    PrintSizeOptions.pointSize,
-                    completion: run
+            renderAllMermaidDiagrams(forcedTheme: Self.paperPrintMermaidTheme) {
+                self.applyPaperPrintMode {
+                    self.applyPrintPointSize(PrintSizeOptions.pointSize) {
+                        operation.runModal(
+                            for: window,
+                            delegate: self,
+                            didRun: #selector(Self.paperPrintOperationDidRun(_:success:contextInfo:)),
+                            contextInfo: nil
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @objc private func paperPrintOperationDidRun(
+        _ operation: NSPrintOperation,
+        success: Bool,
+        contextInfo: UnsafeMutableRawPointer?
+    ) {
+        renderAllMermaidDiagrams {}
+    }
+
+    /// Mermaid renders lazily as figures scroll into view, but pagination
+    /// captures the whole document at once — a diagram that never got near
+    /// the viewport would print as its raw source text. `forcedTheme` pins the
+    /// mermaid theme (re-rendering mismatched figures); calling again without
+    /// one restores the on-screen theme.
+    private func renderAllMermaidDiagrams(
+        forcedTheme: String? = nil,
+        completion: @escaping () -> Void
+    ) {
+        let themeArgument = forcedTheme.map { "'\($0)'" } ?? ""
+        let script = """
+        if (window.MdPreview && typeof window.MdPreview.mermaidRenderAll === 'function') {
+            await window.MdPreview.mermaidRenderAll(\(themeArgument));
+        }
+        """
+        webView.callAsyncJavaScript(script, in: nil, in: .page) { result in
+            if case .failure(let error) = result {
+                Logger.perf.debug(
+                    "mermaid print pre-render failed: \(error.localizedDescription, privacy: .public)"
                 )
             }
+            completion()
         }
     }
 

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -1001,6 +1001,181 @@ final class MarkdownHTMLRenderTests: XCTestCase {
     }
 
     @MainActor
+    func testMermaidRenderAllRendersFiguresTheObserverNeverReached() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```mermaid
+            flowchart LR
+                A --> B
+            ```
+
+            ```mermaid
+            flowchart LR
+                C --> D
+            ```
+            """,
+            vendorLoading: .lazy
+        )
+
+        // The observer never fires, standing in for figures that stay far
+        // outside the viewport — print/export must still render them all.
+        let html = """
+        <!DOCTYPE html>
+        <html><head>
+        <script>
+        window.__runs = 0;
+        window.IntersectionObserver = class {
+            observe() {}
+            unobserve() {}
+        };
+        window.ResizeObserver = class {
+            observe() {}
+        };
+        window.mermaid = {
+            initialize() {},
+            async run({ nodes }) {
+                window.__runs += 1;
+                for (const node of nodes) {
+                    node.innerHTML = '<svg viewBox="0 0 400 200"></svg>';
+                }
+            }
+        };
+        </script></head><body>
+        <article class="markdown-body">\(rendered.articleHTML)</article>
+        <script>
+        const __mdpMermaid = \(MarkdownHTML.mermaidInitWiring);
+        __mdpMermaid.bootstrap();
+        window.__renderAllSettled = false;
+        window.MdPreview.mermaidRenderAll().then(() => {
+            window.__renderAllSettled = true;
+        });
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        var allRendered = false
+        for _ in 0..<100 {
+            let state = try await webView.evaluateJavaScript("""
+            JSON.stringify({
+                settled: window.__renderAllSettled,
+                runs: window.__runs,
+                done: Array.from(document.querySelectorAll('.mermaid'))
+                    .map((n) => n.dataset.mmDone || '')
+            })
+            """) as? String
+            if state == #"{"settled":true,"runs":2,"done":["1","1"]}"# {
+                allRendered = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTAssertTrue(
+            allRendered,
+            "renderAll must render every unobserved figure and settle afterwards"
+        )
+    }
+
+    @MainActor
+    func testMermaidRenderAllRethemesForPaperPrintAndRestores() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```mermaid
+            flowchart LR
+                A --> B
+            ```
+            """,
+            vendorLoading: .lazy,
+            colorScheme: .dark
+        )
+
+        let html = """
+        <!DOCTYPE html>
+        <html data-mdp-color-scheme="dark"><head>
+        <script>
+        window.__themes = [];
+        window.IntersectionObserver = class {
+            constructor(callback) { this.callback = callback; }
+            observe(target) { this.callback([{ target, isIntersecting: true }]); }
+            unobserve() {}
+        };
+        window.ResizeObserver = class {
+            observe() {}
+        };
+        window.mermaid = {
+            initialize(options) { window.__themes.push(options.theme); },
+            async run({ nodes }) {
+                const theme = window.__themes[window.__themes.length - 1];
+                for (const node of nodes) {
+                    node.innerHTML = '<svg viewBox="0 0 400 200" data-theme="' + theme + '"></svg>';
+                }
+            }
+        };
+        </script></head><body>
+        <article class="markdown-body">\(rendered.articleHTML)</article>
+        <script>
+        const __mdpMermaid = \(MarkdownHTML.mermaidInitWiring);
+        __mdpMermaid.bootstrap();
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        func diagramState() async throws -> String? {
+            try await webView.evaluateJavaScript("""
+            JSON.stringify({
+                themes: window.__themes,
+                mmTheme: document.querySelector('.mermaid')?.dataset.mmTheme || '',
+                svgTheme: document.querySelector('.mermaid svg')?.dataset.theme || ''
+            })
+            """) as? String
+        }
+
+        func waitFor(_ expected: String) async throws -> Bool {
+            for _ in 0..<100 {
+                if try await diagramState() == expected { return true }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            return false
+        }
+
+        let renderedDark = try await waitFor(
+            #"{"themes":["dark"],"mmTheme":"dark","svgTheme":"dark"}"#
+        )
+        XCTAssertTrue(renderedDark, "initial render must use the native dark theme")
+
+        // Paper print: pin the light theme and re-render the finished figure.
+        _ = try await webView.evaluateJavaScript("""
+        window.__paperDone = false;
+        window.MdPreview.mermaidRenderAll('default').then(() => {
+            window.__paperDone = true;
+        });
+        true
+        """)
+        let rethemed = try await waitFor(
+            #"{"themes":["dark","default"],"mmTheme":"default","svgTheme":"default"}"#
+        )
+        XCTAssertTrue(rethemed, "a pinned theme must re-render already-finished figures")
+
+        // Panel dismissed: restore the on-screen theme.
+        _ = try await webView.evaluateJavaScript(
+            "window.MdPreview.mermaidRenderAll(); true"
+        )
+        let restored = try await waitFor(
+            #"{"themes":["dark","default","dark"],"mmTheme":"dark","svgTheme":"dark"}"#
+        )
+        XCTAssertTrue(restored, "a bare renderAll must restore the on-screen theme")
+    }
+
+    @MainActor
     private func waitForMermaidPopupMessage(
         in webView: WKWebView,
         timeoutMs: Int = 2000


### PR DESCRIPTION
## Summary

Fixes #274.

Mermaid figures render lazily through an `IntersectionObserver` (300px root margin), but print/export paginates the whole document at once — any diagram that never got near the viewport still held its raw source text when the page was captured, producing an empty figure box and the Mermaid source as plain text in the PDF.

## What changed

- **`mermaidInitWiring` gains `renderAll(theme?)`** (exposed as `window.MdPreview.mermaidRenderAll`): queues every pending figure and resolves once the render queue fully drains. The drain loop is now promise-tracked so one failing diagram can't wedge the queue.
- **Both File ▸ Print… and File ▸ Export… await it** (via `callAsyncJavaScript`) before entering the print pipeline. PNG export is covered too, since it captures the live page after this runs; HTML export already re-renders in the browser.
- **Paper printing re-themes diagrams to light.** The paper stylesheet forces the light palette, but Mermaid bakes its theme into the SVG at render time — so Print… from a dark-mode window used to embed dark-theme SVGs on white paper. Print now pins Mermaid's light theme (restoring the stashed `__mdSrc` source and re-rendering finished figures), then restores the on-screen theme when the panel ends, via the print operation's `didRun` callback. Export keeps preview fidelity and renders with the active appearance. Re-renders reuse the figure's existing listeners and reset pan/zoom state, so no double-wiring.
- **Export-mode CSS keeps a figure on one page** (`break-inside: avoid`): the figure clips an absolutely-positioned stage, so a page break through it discarded everything past the break — the empty box in the issue screenshot.
- **The zoom HUD is excluded from printed output** — it could previously print if a figure had focus.

## Test plan

- Two new WKWebView-driven tests in `MarkdownHTMLRenderTests` (stub `mermaid` global, same harness as the existing wiring tests):
  - an `IntersectionObserver` that never fires — standing in for offscreen figures — must still leave every figure rendered and the `renderAll` promise settled;
  - a dark-rendered figure re-themes to `default` when pinned and back to `dark` on restore, tracked through `initialize` calls and the rendered SVG.
- Full SPM helper suite: 125 tests, 0 failures.
- By hand: export a long document with a diagram at the bottom without scrolling to it; Print… from a dark-mode window and check the panel's page thumbnails show light diagrams, with the on-screen document returning to dark afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)