### PR TITLE
Paint larger list bullets

### DIFF
--- a/md-preview/EditorViewController.swift
+++ b/md-preview/EditorViewController.swift
@@ -417,7 +417,23 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             text-align: end;
             padding-inline-end: 0.45em;
             box-sizing: border-box;
-            color: var(--text);
+            /* The glyph keeps its box for alignment but renders transparent;
+               the ::after circle below matches the preview's painted bullet. */
+            color: transparent;
+            position: relative;
+        }
+        .cm-md-bullet::after {
+            content: "";
+            position: absolute;
+            /* Match the preview's 0.5em gap between the circle and the
+               item text. */
+            inset-inline-end: 0.5em;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 0;
+            height: 0;
+            border: 0.2em solid var(--text);
+            border-radius: 50%;
         }
         /* Keep the active raw "- " marker in the same hanging box as the
            inactive bullet widget. Revealing Markdown source must not move the

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -3652,6 +3652,22 @@ nonisolated enum MarkdownHTML {
 
     ul, ol { margin: \(paragraphSpacing)px 0 0; padding-left: 1.6em; }
     ul { list-style-type: "•  "; }
+    /* The text marker stays for copy/paste and for reserving the gutter,
+       but renders transparent; a 0.4em circle is painted in its place.
+       Drawn with a border, not a background, so PDF export keeps it even
+       when backgrounds are not printed. */
+    ul > li::marker { color: transparent; }
+    ul > li { position: relative; }
+    ul > li:not(.task-list-item)::before {
+        content: "";
+        position: absolute;
+        inset-inline-start: -0.9em;
+        top: 0.56em;
+        width: 0;
+        height: 0;
+        border: 0.2em solid var(--text);
+        border-radius: 50%;
+    }
     li { margin-top: \(listItemSpacing)px; }
     li:first-child { margin-top: 0; }
     li > ul, li > ol { margin-top: \(listItemSpacing)px; }


### PR DESCRIPTION
## Summary
- Stacked on the heading-scale PR.
- The `•` glyph rendered as a tiny dot. The text marker now renders transparent (it still reserves the gutter and survives copy/paste) and a 0.4em circle is painted in its place.
- Preview and editor draw the same circle with the same 0.5em gap to the item text.
- The circle is drawn with a border rather than a background, so PDF export keeps it even when backgrounds are not printed.

## Test plan
- `swift test`: 157 tests pass.
- Verified visually: bullets are clearly visible at every nesting level; task-list items are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)