### PR TITLE
Strike through completed task items

### DIFF
--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -3674,6 +3674,11 @@ nonisolated enum MarkdownHTML {
     li > p:first-child { margin-top: 0; }
 
     li.task-list-item { list-style: none; }
+    /* Completed tasks read as done — struck through and muted. */
+    li.task-list-item:has(input.task-list-item-checkbox:checked) {
+        color: var(--secondary);
+        text-decoration: line-through;
+    }
     li.task-list-item > p:first-of-type { display: inline; margin-top: 0; }
     .task-list-item-checkbox {
         -webkit-appearance: none;


### PR DESCRIPTION
## Summary
- Stacked on the list-bullets PR.
- A checked task item now renders its text struck through and muted, so done tasks read as done at a glance.

## Test plan
- `swift test`: 157 tests pass.
- Verified visually: `- [x]` items show the strikethrough and muted color; `- [ ]` items are unchanged; toggling a checkbox in the preview updates the style live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)