### PR TITLE
Make select-all and copy work in the Quick Look preview

### DIFF
--- a/quick-look/PreviewViewController.swift
+++ b/quick-look/PreviewViewController.swift
@@ -51,6 +51,29 @@ private final class QuickLookWebView: WKWebView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // The Quick Look host has no Edit menu, so ⌘A/⌘C never arrive as menu
+    // key equivalents — claim them here and hand them to WebKit's standard
+    // responder actions, which act on the page's DOM selection.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.type == .keyDown,
+           let command = QuickLookEditingCommands.command(
+               forCharactersIgnoringModifiers: event.charactersIgnoringModifiers,
+               modifierFlags: event.modifierFlags.rawValue
+           ) {
+            let action: Selector
+            switch command {
+            case .selectAll:
+                action = #selector(NSResponder.selectAll(_:))
+            case .copy:
+                action = #selector(NSText.copy(_:))
+            }
+            if NSApp.sendAction(action, to: self, from: nil) {
+                return true
+            }
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
     override func resetCursorRects() {
         super.resetCursorRects()
         for region in cursorRegions {
@@ -426,6 +449,16 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             // would let WebKit fetch rejected or over-budget relative images.
             baseURL: nil
         )
+    }
+
+    // Quick Look opens with keyboard focus in the host (Finder), so ⌘A/⌘C
+    // reach the preview only after the user clicks into it. Claiming first
+    // responder once the content loads propagates focus across the
+    // ViewBridge, making ⌘A/⌘C work immediately. The host still handles
+    // arrows (file navigation) and space (close panel) itself — verified
+    // against a focused preview.
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        view.window?.makeFirstResponder(self.webView)
     }
 
     func webView(

--- a/quick-look/QuickLookEditingCommands.swift
+++ b/quick-look/QuickLookEditingCommands.swift
@@ -1,0 +1,49 @@
+//
+//  QuickLookEditingCommands.swift
+//  quick-look
+//
+//  Created by Fauzaan on 8/15/26.
+//
+
+import Foundation
+
+/// Editing key equivalents the Quick Look preview must claim itself. The
+/// Quick Look host processes (Finder, QuickLookUIService) carry no Edit
+/// menu, so ⌘A / ⌘C never dispatch as menu key equivalents — without an
+/// explicit claim the events die in the host and Select All / Copy do
+/// nothing in the preview.
+nonisolated enum QuickLookEditingCommands {
+    enum Command: Equatable {
+        case selectAll
+        case copy
+    }
+
+    /// Mirrors `NSEvent.ModifierFlags.command.rawValue` (asserted in tests).
+    static let commandKeyMask: UInt = 1 << 20
+    /// Mirrors `NSEvent.ModifierFlags.capsLock.rawValue`.
+    static let capsLockKeyMask: UInt = 1 << 16
+    /// Mirrors `NSEvent.ModifierFlags.deviceIndependentFlagsMask.rawValue`.
+    static let deviceIndependentModifierMask: UInt = 0xFFFF_0000
+
+    /// Maps a key-equivalent press to a preview editing command. Only a
+    /// bare ⌘ chord qualifies (caps lock tolerated); any other modifier
+    /// leaves the event for WebKit's own handling.
+    static func command(
+        forCharactersIgnoringModifiers characters: String?,
+        modifierFlags: UInt
+    ) -> Command? {
+        let modifiers = modifierFlags
+            & deviceIndependentModifierMask
+            & ~capsLockKeyMask
+        guard modifiers == commandKeyMask else { return nil }
+
+        switch characters?.lowercased() {
+        case "a":
+            return .selectAll
+        case "c":
+            return .copy
+        default:
+            return nil
+        }
+    }
+}

--- a/tests/swift-tests/Sources/QuickLookHelpers/QuickLookEditingCommands.swift
+++ b/tests/swift-tests/Sources/QuickLookHelpers/QuickLookEditingCommands.swift
@@ -1,0 +1,1 @@
+../../../../quick-look/QuickLookEditingCommands.swift

--- a/tests/swift-tests/Tests/QuickLookHelperTests/QuickLookEditingCommandsTests.swift
+++ b/tests/swift-tests/Tests/QuickLookHelperTests/QuickLookEditingCommandsTests.swift
@@ -1,0 +1,133 @@
+import AppKit
+import XCTest
+@testable import QuickLookHelpers
+
+final class QuickLookEditingCommandsTests: XCTestCase {
+
+    private let command = NSEvent.ModifierFlags.command.rawValue
+    private let shift = NSEvent.ModifierFlags.shift.rawValue
+    private let option = NSEvent.ModifierFlags.option.rawValue
+    private let control = NSEvent.ModifierFlags.control.rawValue
+    private let capsLock = NSEvent.ModifierFlags.capsLock.rawValue
+
+    // The helper stays Foundation-only, so it mirrors the AppKit bit
+    // values instead of importing them. Pin the mirror to the real thing.
+    func testMasksMatchAppKit() {
+        XCTAssertEqual(
+            QuickLookEditingCommands.commandKeyMask,
+            NSEvent.ModifierFlags.command.rawValue
+        )
+        XCTAssertEqual(
+            QuickLookEditingCommands.capsLockKeyMask,
+            NSEvent.ModifierFlags.capsLock.rawValue
+        )
+        XCTAssertEqual(
+            QuickLookEditingCommands.deviceIndependentModifierMask,
+            NSEvent.ModifierFlags.deviceIndependentFlagsMask.rawValue
+        )
+    }
+
+    // MARK: - Mapping
+
+    func testCommandASelectsAll() {
+        XCTAssertEqual(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "a",
+                modifierFlags: command
+            ),
+            .selectAll
+        )
+    }
+
+    func testCommandCCopies() {
+        XCTAssertEqual(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "c",
+                modifierFlags: command
+            ),
+            .copy
+        )
+    }
+
+    func testCapsLockDoesNotBlockTheChord() {
+        XCTAssertEqual(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "A",
+                modifierFlags: command | capsLock
+            ),
+            .selectAll
+        )
+        XCTAssertEqual(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "C",
+                modifierFlags: command | capsLock
+            ),
+            .copy
+        )
+    }
+
+    func testDeviceDependentBitsAreIgnored() {
+        // Hardware/left-right key bits live below bit 16 and must not
+        // disqualify the chord.
+        let deviceDependentNoise: UInt = 0x0000_0108
+        XCTAssertEqual(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "a",
+                modifierFlags: command | deviceDependentNoise
+            ),
+            .selectAll
+        )
+    }
+
+    // MARK: - Non-matches stay with WebKit
+
+    func testOtherKeysAreNotClaimed() {
+        for characters in ["b", "v", "x", "z", " ", ""] {
+            XCTAssertNil(
+                QuickLookEditingCommands.command(
+                    forCharactersIgnoringModifiers: characters,
+                    modifierFlags: command
+                ),
+                "⌘\(characters) must not be claimed"
+            )
+        }
+        XCTAssertNil(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: nil,
+                modifierFlags: command
+            )
+        )
+    }
+
+    func testExtraModifiersAreNotClaimed() {
+        for extra in [shift, option, control] {
+            XCTAssertNil(
+                QuickLookEditingCommands.command(
+                    forCharactersIgnoringModifiers: "a",
+                    modifierFlags: command | extra
+                )
+            )
+            XCTAssertNil(
+                QuickLookEditingCommands.command(
+                    forCharactersIgnoringModifiers: "c",
+                    modifierFlags: command | extra
+                )
+            )
+        }
+    }
+
+    func testMissingCommandKeyIsNotClaimed() {
+        XCTAssertNil(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "a",
+                modifierFlags: 0
+            )
+        )
+        XCTAssertNil(
+            QuickLookEditingCommands.command(
+                forCharactersIgnoringModifiers: "c",
+                modifierFlags: control
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Cmd+A and Cmd+C did nothing in the Quick Look preview until the user clicked inside it: the panel opens with keyboard focus in the host (Finder), so the key events never reached the extension — Cmd+A selected the Finder items instead. Apple's own plain-text preview behaves the same way, but for a Markdown previewer the text is the point.

- **Claim keyboard focus on load** — `PreviewViewController` makes the web view first responder once the content finishes loading. Focus propagates across the ViewBridge, so ⌘A / ⌘C work immediately after the panel opens, with no click. The host still handles arrows (file navigation) and space (close panel) itself.
- **Claim ⌘A/⌘C in `performKeyEquivalent`** — the Quick Look host has no Edit menu, so the chords are dispatched straight to WebKit's standard `selectAll:` / `copy:` responder actions. The chord mapping lives in a new Foundation-only helper (`QuickLookEditingCommands`) shared with the test package.

## Test plan

- [x] Finder → space on a `.md` file → ⌘A, ⌘C with **no click**: pasteboard holds the rendered text (verified end-to-end with scripted key events; before the fix it held the Finder file list)
- [x] Mouse drag-selection → ⌘C: pasteboard holds exactly the selected text
- [x] Arrow keys still change the selected Finder file while the panel is open
- [x] Space still closes the panel
- [x] 8 new unit tests for the chord mapping (incl. pinning the mirrored AppKit modifier masks); full suite: 165 tests pass
- [x] `xcodebuild -scheme md-preview -configuration Debug build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)