### PR TITLE
Release 0.0.49 (53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.0.49] – 2026-08-15
+
+This release adds a Settings window that collects all the preferences of the application in one place. It also makes the keyboard commands and a new Copy button work in a Finder preview.
+
+### Added
+
+- **The application has a Settings window.** Press ⌘, or use Markdown Preview ▸ Settings… to open it. The window has three panes: General, Privacy, and About. The panes contain the preferences that were only in the menus before: the appearance, the text size, the content width, the application that File ▸ Open in… uses, the crash reports, and the automatic update checks from Sparkle. The window uses the icons and the layout of macOS System Settings. A change in the window and a change in the menu stay equal, and the About pane shows the date of the last update check immediately. A new installation checks for updates automatically, but the application keeps your choice if you made one before. The window is available in English and in Simplified Chinese ([#287](https://github.com/pluk-inc/markdown-preview/pull/287)).
+- **A Finder preview has a Copy button.** The button is in the bottom-right corner of the preview. It copies the Markdown source text of the file to the pasteboard, and you do not select the text first. The button shows "Copied" immediately after you click it, and it stays clear of the content of the preview ([#289](https://github.com/pluk-inc/markdown-preview/pull/289)).
+
+### Fixed
+
+- **⌘A and ⌘C work in a Finder preview immediately.** The preview panel opened with the keyboard focus in Finder. Therefore ⌘A selected the files in the Finder window, and the two commands did nothing in the preview until you clicked in it. The preview now takes the keyboard focus when the content is complete, and it accepts ⌘A and ⌘C directly. Finder keeps the other keys: the arrow keys change the selected file, and the space key closes the panel ([#288](https://github.com/pluk-inc/markdown-preview/pull/288)).
+
 ## [0.0.48] – 2026-08-15
 
 This release changes the vertical gaps and the type sizes in the preview and in the editor. It also lets you select text in a Finder preview, keep a preview window in front of other applications, and print and export diagrams correctly.

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -1,5 +1,5 @@
 // Centralized version configuration for all targets.
 // Bump these values to release a new version.
 
-MARKETING_VERSION = 0.0.48
-CURRENT_PROJECT_VERSION = 52
+MARKETING_VERSION = 0.0.49
+CURRENT_PROJECT_VERSION = 53


### PR DESCRIPTION
## Summary

- Bump `Version.xcconfig` to `MARKETING_VERSION = 0.0.49`, `CURRENT_PROJECT_VERSION = 53`
- Add the `CHANGELOG.md` entry for 0.0.49

## What's in 0.0.49

### Added

- **The application has a Settings window.** ⌘, or Markdown Preview ▸ Settings… opens General, Privacy, and About panes that collect the appearance, text size, content width, File ▸ Open in… target, crash reports, and Sparkle update preferences. Settings and menu stay in sync, the last-check date updates live, new installs default to automatic update checks, and the window ships in English and Simplified Chinese ([#287](https://github.com/pluk-inc/markdown-preview/pull/287)).
- **A Finder preview has a Copy button.** A compact control in the bottom-right corner copies the Markdown source to the pasteboard without selecting anything first, and shows "Copied" feedback ([#289](https://github.com/pluk-inc/markdown-preview/pull/289)).

### Fixed

- **⌘A and ⌘C work in a Finder preview immediately.** The panel opened with keyboard focus in Finder, so ⌘A selected Finder items and both chords did nothing until you clicked inside the preview. The web view now claims focus once the content loads and handles ⌘A / ⌘C directly; arrow keys and space still belong to Finder ([#288](https://github.com/pluk-inc/markdown-preview/pull/288)).

No external contributors in this range — all three PRs are maintainer-authored.

## Test plan

- [ ] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build` succeeds
- [ ] `swift test --package-path tests/swift-tests` passes
- [ ] About pane reports version 0.0.49 (53)
- [ ] `./scripts/release.sh` validates the changelog entry for 0.0.49

🤖 Generated with [Claude Code](https://claude.com/claude-code)