### PR TITLE
Fix sidebar file navigator selection flicker on file switch

### DIFF
--- a/md-preview/SidebarViewController.swift
+++ b/md-preview/SidebarViewController.swift
@@ -627,10 +627,9 @@ final class ProjectNavigatorView: NSView {
         if !node.isDirectory {
             let requestedURL = node.url.standardizedFileURL
             guard requestedURL != currentFileURL else { return }
-            // NSOutlineView selects before dispatching its action. Restore the
-            // committed document immediately; display(markdown:fileURL:) will
-            // select the requested file only after navigation succeeds.
-            setCurrentFile(currentFileURL)
+            // `shouldSelectItem` keeps the highlight on the committed file,
+            // so there's no AppKit selection to undo here — display(markdown:)
+            // selects the requested file only after navigation succeeds.
             onSelectFile?(node.url)
         }
     }
@@ -797,6 +796,17 @@ extension ProjectNavigatorView: NSOutlineViewDelegate {
 
     func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
         return 24
+    }
+
+    /// A click must not move the selection away from the committed file:
+    /// the highlight only follows after navigation actually succeeds
+    /// (`setCurrentFile`). Preventing the native selection here is what
+    /// stops the O → X → O bounce on file switches. Directories stay
+    /// selectable — they have no navigation side effect.
+    func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
+        guard let node = item as? FileNode else { return false }
+        if node.isDirectory { return true }
+        return node.url.standardizedFileURL == currentFileURL?.standardizedFileURL
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {


### PR DESCRIPTION
## Summary

Fixes the sidebar selection flicker when switching files in the Project Navigator (Files mode). The highlighted row no longer bounces (clicked row → reverted → re-applied after load); it stays on the committed file until navigation succeeds and then moves once.

- Add `outlineView(_:shouldSelectItem:)` for the file navigator so a click cannot move the selection away from the currently open file.
- Drop the now-redundant `setCurrentFile(currentFileURL)` revert in `ProjectNavigatorView.rowClicked()`.

The existing design intent is preserved: the sidebar only highlights a file after navigation actually succeeds (e.g. it won't move while a Save/Cancel sheet for pending edits is up).

Fixes #295

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build`
- Manual: open a folder in Files mode, click file A, then file B → highlight stays on A and moves to B once after load, no bounce.
- Directories remain selectable (no navigation side effect).
