### PR TITLE
Fix reopening a file whose window was closed

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -159,17 +159,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             pendingOpenURLCount += 1
             NSDocumentController.shared.openDocument(withContentsOf: url,
-                                                     display: true) { [weak self] _, _, error in
+                                                     display: true) { [weak self] document, _, error in
                 if let error {
                     NSAlert(error: error).runModal()
                 }
                 guard let self else { return }
+                self.showWindowIfNeeded(for: document)
                 self.pendingOpenURLCount -= 1
                 if error != nil, self.pendingOpenURLCount == 0 {
                     self.scheduleDocumentPrompt(requiresNoDocuments: true)
                 }
             }
         }
+    }
+
+    /// `openDocument(withContentsOf:display:)` returns an existing document
+    /// unchanged. If its window was closed earlier (while the app kept
+    /// running), the document has no window controllers and `display: true`
+    /// does not create a window for it, so the file appears not to open.
+    /// Make and show a window in that case.
+    private func showWindowIfNeeded(for document: NSDocument?) {
+        guard let document, document.windowControllers.isEmpty else { return }
+        document.makeWindowControllers()
+        document.showWindows()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {


### PR DESCRIPTION
## Summary

Fixes #297 — reopening a previously opened file shows no window while the app keeps running.

**Root cause:** when a file's window is closed while the app keeps running, the underlying `NSDocument` stays open with no window controllers. Reopening the same file returns that existing windowless document, and `display: true` does not create a window for it, so nothing appears. Quitting the app resets the state, which is why that path works.

**Fix:** in `application(_:open:)`, after `openDocument(withContentsOf:display:)` completes, check whether the returned document has no window controllers and, if so, make and show one.

## Test plan

Verified with a local Debug build (macOS 26.5, Apple Silicon):

1. Open a `.md` file → preview window appears.
2. Close the window (Cmd+W) → app stays running with no windows.
3. Reopen the **same** file from Finder → the preview window now appears (previously nothing happened).
4. Repeat the close/reopen cycle → the window appears every time.
5. Opening a different, never-opened file still works as before.
