### PR TITLE
Add a font picker for rendered Markdown

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				CodeFenceInfo.swift,
+				DocumentFontSetting.swift,
 				EscapingHTMLFormatter.swift,
 				MarkdownAssetResolution.swift,
 				MarkdownAssetSchemeHandler.swift,

--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -275,6 +275,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         reloadDocumentPreviewsForSettingChange()
     }
 
+    /// Applies a font chosen in Settings. Open documents re-render rather than
+    /// waiting to be reopened; Quick Look picks the value up on its next
+    /// preview, since the setting lives in the app group.
+    func applyDocumentFontSetting(_ setting: DocumentFontSetting) {
+        guard setting != DocumentFontSetting.current else { return }
+        DocumentFontSetting.current = setting
+        reloadDocumentPreviewsForSettingChange()
+    }
+
     /// Pushes a text size chosen in Settings into every open document. The
     /// value is the same stored page zoom the windows already read, so this
     /// only asks them to pick it up now instead of at next launch.

--- a/md-preview/DocumentFontSetting.swift
+++ b/md-preview/DocumentFontSetting.swift
@@ -1,0 +1,89 @@
+//
+//  DocumentFontSetting.swift
+//  md-preview
+//
+//  Typeface for rendered Markdown, persisted across launches.
+//
+//  Four named faces rather than a picker of every installed font. The page's
+//  vertical rhythm is *derived*: paragraph spacing, the blank-line gap and the
+//  heading scale are all computed from one body size and tuned against one
+//  x-height, and the column width is tuned to a comfortable line length at that
+//  face. Those numbers survive a swap between faces in the same metric
+//  neighbourhood; they do not survive a condensed face, a display face, or a
+//  variable weight axis at 15px. A short list is also a list every option of
+//  which has actually been looked at.
+//
+//  Stored in the app group rather than `UserDefaults.standard`, so Quick Look
+//  renders in the chosen face too — it is a reading surface as much as the
+//  document window is, and a preference that reaches one but not the other is
+//  worse than either extreme.
+//
+
+import Foundation
+
+nonisolated enum DocumentFontSetting: String, CaseIterable, Sendable {
+    case system
+    case serif
+    case rounded
+    case monospace
+
+    static let defaultsKey = "MarkdownPreview.documentFont"
+    static let defaultSetting: Self = .system
+
+    /// CSS font stack. Each ends in a generic family so macOS's own per-script
+    /// cascade can still pick a face for CJK text the named fonts don't cover.
+    var fontFamily: String {
+        switch self {
+        case .system: return MarkdownHTML.bodyFontFamily
+        case .serif: return "ui-serif, \"New York\", \"Iowan Old Style\", Georgia, serif"
+        case .rounded: return "ui-rounded, \"SF Pro Rounded\", -apple-system, system-ui, sans-serif"
+        case .monospace: return MarkdownHTML.codeFontFamily
+        }
+    }
+
+    /// Code stays monospaced whatever the document font is — alignment,
+    /// diffs and whitespace fidelity are the reason it is monospaced at all,
+    /// and the document face does not get a vote on that. What does move is
+    /// the size it sits at: `0.88em` is tuned against the system face's
+    /// x-height, and the same declaration reads *larger* than its surroundings
+    /// against a serif's smaller one. Monospace documents take `1em`, where
+    /// code at 0.88em would read as the same font at a slightly wrong size;
+    /// the background chip is what marks it as code there.
+    var codeFontSize: String {
+        switch self {
+        case .system, .rounded: return "0.88em"
+        case .serif: return "0.84em"
+        case .monospace: return "1em"
+        }
+    }
+
+    /// Named for the reading character, not the face: the stack is a fallback
+    /// chain, so naming a font would promise one that may not be installed.
+    var title: String {
+        switch self {
+        case .system: return NSLocalizedString("System", comment: "Document font")
+        case .serif: return NSLocalizedString("Serif", comment: "Document font")
+        case .rounded: return NSLocalizedString("Rounded", comment: "Document font")
+        case .monospace: return NSLocalizedString("Monospace", comment: "Document font")
+        }
+    }
+
+    static var current: Self {
+        get { read(from: AppearanceMode.sharedDefaults()) }
+        set { write(newValue, to: AppearanceMode.sharedDefaults()) }
+    }
+
+    static func read(from defaults: UserDefaults?) -> Self {
+        guard let rawValue = defaults?.string(forKey: defaultsKey),
+              let setting = Self(rawValue: rawValue) else { return defaultSetting }
+        return setting
+    }
+
+    static func write(_ setting: Self, to defaults: UserDefaults?) {
+        if setting == defaultSetting {
+            defaults?.removeObject(forKey: defaultsKey)
+        } else {
+            defaults?.set(setting.rawValue, forKey: defaultsKey)
+        }
+    }
+}

--- a/md-preview/MarkdownHTML.swift
+++ b/md-preview/MarkdownHTML.swift
@@ -74,6 +74,7 @@ nonisolated enum MarkdownHTML {
     // keep different renderers, but their page geometry and base typography
     // must come from one source of truth.
     static let bodyFontFamily = "-apple-system, BlinkMacSystemFont, \"SF Pro Text\", system-ui, sans-serif"
+    static let codeFontFamily = "ui-monospace, \"SF Mono\", Menlo, monospace"
     static let bodyFontSize: CGFloat = 15
     static let bodyLineHeight: CGFloat = 1.52
     static let pagePaddingTop: CGFloat = 32
@@ -159,12 +160,14 @@ nonisolated enum MarkdownHTML {
                          allowsScroll: Bool = false,
                          assetBaseHref: String? = nil,
                          vendorLoading: VendorLoading = .inline,
-                         colorScheme: ColorScheme? = nil) -> String {
+                         colorScheme: ColorScheme? = nil,
+                         documentFont: DocumentFontSetting = .current) -> String {
         render(markdown: markdown,
                allowsScroll: allowsScroll,
                assetBaseHref: assetBaseHref,
                vendorLoading: vendorLoading,
-               colorScheme: colorScheme).html
+               colorScheme: colorScheme,
+               documentFont: documentFont).html
     }
 
     static func render(markdown: String,
@@ -173,6 +176,7 @@ nonisolated enum MarkdownHTML {
                        vendorLoading: VendorLoading = .inline,
                        contentWidth: ContentWidth = .centered,
                        colorScheme: ColorScheme? = nil,
+                       documentFont: DocumentFontSetting = .current,
                        warmup: Bool = false) -> RenderedHTML {
         let frontmatter = MarkdownFrontmatter.split(markdown)
         let body = frontmatter.body
@@ -242,6 +246,19 @@ nonisolated enum MarkdownHTML {
             </style>
             """
         }
+        // Headings inherit the family deliberately: the heading scale is a
+        // ratio off the body em, tuned against one x-height, so keeping system
+        // headings over a serif body would silently change how big each step
+        // looks. Code keeps its own face and takes only a size correction.
+        let documentFontOverride = """
+        <style>
+        :root {
+            --mdp-doc-font: \(documentFont.fontFamily);
+            --mdp-code-font-size: \(documentFont.codeFontSize);
+        }
+        </style>
+        """
+
         // The href may carry a real folder path (percent-encoded, but `&`
         // and `'` survive URL path encoding) — escape it for the attribute.
         let baseTag = assetBaseHref.map {
@@ -297,6 +314,7 @@ nonisolated enum MarkdownHTML {
         <style>\(stylesheet)</style>
         \(scrollOverride)
         \(contentWidthOverride)
+        \(documentFontOverride)
         \(sanitizerBlock)
         \(morphBlock)
         \(hostBridgeScript)
@@ -3185,7 +3203,7 @@ nonisolated enum MarkdownHTML {
         height: 0;
     }
     body {
-        font-family: \(bodyFontFamily);
+        font-family: var(--mdp-doc-font, \(bodyFontFamily));
         font-size: \(bodyFontSize)px;
         line-height: \(bodyLineHeight);
         color: var(--text);
@@ -3364,8 +3382,8 @@ nonisolated enum MarkdownHTML {
     }
 
     code {
-        font-family: ui-monospace, "SF Mono", Menlo, monospace;
-        font-size: 0.88em;
+        font-family: \(codeFontFamily);
+        font-size: var(--mdp-code-font-size, 0.88em);
         padding: 0.18em 0.42em;
         background: var(--code-bg);
         border-radius: 6px;
@@ -3412,7 +3430,7 @@ nonisolated enum MarkdownHTML {
         display: block;
         padding: 0;
         background: transparent;
-        font-size: 0.88em;
+        font-size: var(--mdp-code-font-size, 0.88em);
     }
     .md-code-wrap {
         position: relative;
@@ -3580,7 +3598,7 @@ nonisolated enum MarkdownHTML {
         padding: 12px 16px;
         text-align: left;
         white-space: pre-wrap;
-        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-family: \(codeFontFamily);
         font-size: 0.88em;
     }
     .math-display {
@@ -3596,7 +3614,7 @@ nonisolated enum MarkdownHTML {
         background: var(--code-bg);
         padding: 4px 8px;
         border-radius: 6px;
-        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-family: \(codeFontFamily);
         font-size: 0.88em;
         white-space: pre-wrap;
     }

--- a/md-preview/SettingsPanes.swift
+++ b/md-preview/SettingsPanes.swift
@@ -37,6 +37,13 @@ final class SettingsModel {
         }
     }
 
+    var documentFont: DocumentFontSetting {
+        didSet {
+            guard !isRestoringExternalValues, documentFont != oldValue else { return }
+            appDelegate?.applyDocumentFontSetting(documentFont)
+        }
+    }
+
     var contentWidth: ContentWidthSetting {
         didSet {
             guard !isRestoringExternalValues, contentWidth != oldValue else { return }
@@ -116,6 +123,7 @@ final class SettingsModel {
         appearance = AppearanceMode.current
         contentWidth = ContentWidthSetting.current
         textSize = TextSizeSetting.current
+        documentFont = DocumentFontSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         sendsCrashReports = CrashReporter.isEnabled
         checksForUpdatesAutomatically = updater?.automaticallyChecksForUpdates ?? true
@@ -164,6 +172,7 @@ final class SettingsModel {
         appearance = AppearanceMode.current
         contentWidth = ContentWidthSetting.current
         textSize = TextSizeSetting.current
+        documentFont = DocumentFontSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         sendsCrashReports = CrashReporter.isEnabled
         if let updater { refreshUpdateSettings(from: updater) }
@@ -266,6 +275,12 @@ struct GeneralSettingsView: View {
             }
 
             Section {
+                Picker(L("Font"), selection: $model.documentFont) {
+                    ForEach(DocumentFontSetting.allCases, id: \.self) { setting in
+                        Text(setting.title).tag(setting)
+                    }
+                }
+
                 LabeledContent {
                     TextSizePicker(selection: $model.textSize)
                 } label: {
@@ -279,9 +294,9 @@ struct GeneralSettingsView: View {
                     }
                 }
             } header: {
-                Text(L("Layout"))
+                Text(L("Reading"))
             } footer: {
-                Text(L("Zooming a document window with ⌘+ and ⌘− changes this same size."))
+                Text(L("The font also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes the text size."))
             }
 
             Section {

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -242,6 +242,15 @@
 "Failed to write CLI installer script: %@" = "Failed to write CLI installer script: %@";
 "The bundled Markdown Preview CLI could not be found." = "The bundled Markdown Preview CLI could not be found.";
 
+/* Settings — Reading */
+"Reading" = "Reading";
+"Font" = "Font";
+"System" = "System";
+"Serif" = "Serif";
+"Rounded" = "Rounded";
+"Monospace" = "Monospace";
+"The font also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes the text size." = "The font also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes the text size.";
+
 /* Settings — Windows */
 "Windows" = "Windows";
 "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out." = "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out.";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -242,6 +242,15 @@
 "Failed to write CLI installer script: %@" = "无法写入 CLI 安装脚本：%@";
 "The bundled Markdown Preview CLI could not be found." = "找不到随附的 Markdown Preview CLI。";
 
+/* Settings — Reading */
+"Reading" = "阅读";
+"Font" = "字体";
+"System" = "系统";
+"Serif" = "衬线";
+"Rounded" = "圆体";
+"Monospace" = "等宽";
+"The font also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes the text size." = "字体设置也会应用于“快速查看”预览。使用 ⌘+ 和 ⌘− 缩放文稿窗口会改变文字大小。";
+
 /* Settings — Windows */
 "Windows" = "窗口";
 "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out." = "让所有 Markdown Preview 窗口始终显示在其他 App 前面，包括之后打开的窗口。窗口进入全屏时不会置顶，退出全屏后会恢复。";

--- a/tests/swift-tests/Sources/MarkdownHelpers/DocumentFontSetting.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/DocumentFontSetting.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/DocumentFontSetting.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/DocumentFontSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/DocumentFontSettingTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import XCTest
+@testable import MarkdownHelpers
+
+final class DocumentFontSettingTests: XCTestCase {
+    func testMissingAndInvalidValuesFallBackToTheSystemFace() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(DocumentFontSetting.read(from: defaults), .system)
+        XCTAssertEqual(DocumentFontSetting.read(from: nil), .system)
+
+        defaults.set("comic-sans", forKey: DocumentFontSetting.defaultsKey)
+        XCTAssertEqual(DocumentFontSetting.read(from: defaults), .system)
+    }
+
+    func testEveryFaceRoundTripsAndTheDefaultClearsItsKey() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        for setting in DocumentFontSetting.allCases {
+            DocumentFontSetting.write(setting, to: defaults)
+            XCTAssertEqual(DocumentFontSetting.read(from: defaults), setting)
+        }
+
+        DocumentFontSetting.write(.system, to: defaults)
+        XCTAssertNil(defaults.object(forKey: DocumentFontSetting.defaultsKey))
+    }
+
+    // Every stack has to end in a generic family, or macOS's per-script cascade
+    // has nothing to fall back to for text the named faces don't cover — the
+    // zh-Hans localisation being the case that would break first.
+    func testEveryStackEndsInAGenericFamily() {
+        let generics = ["serif", "sans-serif", "monospace"]
+        for setting in DocumentFontSetting.allCases {
+            let last = setting.fontFamily
+                .split(separator: ",")
+                .last
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+            XCTAssertNotNil(last, "\(setting) has no font stack")
+            XCTAssertTrue(generics.contains(last ?? ""),
+                          "\(setting) ends in \(last ?? "nothing"), not a generic family")
+        }
+    }
+
+    func testTheSystemAndMonospaceFacesReuseTheSharedStacks() {
+        XCTAssertEqual(DocumentFontSetting.system.fontFamily, MarkdownHTML.bodyFontFamily)
+        XCTAssertEqual(DocumentFontSetting.monospace.fontFamily, MarkdownHTML.codeFontFamily)
+    }
+
+    // 0.88em is tuned against the system face's x-height, so a face with a
+    // different one needs its own correction or code stops reading as smaller
+    // than the prose around it.
+    func testCodeSizeIsCorrectedPerFace() {
+        XCTAssertEqual(DocumentFontSetting.system.codeFontSize, "0.88em")
+        XCTAssertEqual(DocumentFontSetting.rounded.codeFontSize, "0.88em")
+        XCTAssertNotEqual(DocumentFontSetting.serif.codeFontSize,
+                          DocumentFontSetting.system.codeFontSize)
+        XCTAssertEqual(DocumentFontSetting.monospace.codeFontSize, "1em")
+    }
+
+    func testRenderedHTMLCarriesTheChosenFace() {
+        let html = MarkdownHTML.makeHTML(from: "# Title\n\nBody `code`.",
+                                         documentFont: .serif)
+        XCTAssertTrue(html.contains("--mdp-doc-font: \(DocumentFontSetting.serif.fontFamily);"),
+                      "the document font custom property is missing")
+        XCTAssertTrue(html.contains("--mdp-code-font-size: \(DocumentFontSetting.serif.codeFontSize);"),
+                      "the code size correction is missing")
+    }
+
+    // The stylesheet keeps a literal fallback, so a page rendered before the
+    // override is applied still has a face rather than the browser default.
+    func testTheStylesheetFallsBackToTheSystemFace() {
+        let html = MarkdownHTML.makeHTML(from: "Body", documentFont: .system)
+        XCTAssertTrue(html.contains("var(--mdp-doc-font, \(MarkdownHTML.bodyFontFamily))"))
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "doc.md-preview.tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Font** picker to Settings → General, so rendered Markdown can be read in something other than the system face. Four options — System, Serif, Rounded, Monospace — with System as the default, so nothing changes for anyone who doesn't go looking.

The choice lives in the app group, so Quick Look previews use it too. Open document windows re-render as soon as you change it rather than waiting to be reopened.

## Design notes

**Four named faces rather than a font panel.** The page's vertical rhythm is derived: paragraph spacing, the blank-line gap and the heading scale are all computed from one body size and tuned against one x-height, and the column width is tuned to a comfortable line length at that face. Those numbers survive a swap between faces in the same metric neighbourhood; they don't survive a condensed face, a display face, or a variable weight axis at 15px. A short list is also a list where every option has actually been looked at. If you'd rather have the full `NSFontPanel`, that's a bigger change than it looks and I'd want to rework the rhythm constants with it.

**Headings inherit the family deliberately.** The heading scale is a ratio off the body em, so keeping system headings over a serif body would silently change how big each step reads.

**Code keeps its own face and takes only a size correction.** Alignment, diffs and whitespace fidelity are why code is monospaced at all, and the document face doesn't get a vote. What does move is the size it sits at: `0.88em` is tuned against the system face's x-height and reads slightly large against a serif's smaller one, so serif documents take `0.84em`. Monospace documents take `1em`, where code at 0.88em would read as the same font at a marginally wrong size — the background chip is what marks it as code there.

**Every stack ends in a generic family** (`serif`, `sans-serif`, `monospace`), so macOS's per-script cascade can still find a face for CJK text the named fonts don't cover. There's a test pinning that.

**The setting is threaded through `MarkdownHTML.render` as a parameter** with `.current` as its default, rather than read from inside the renderer. Quick Look picks it up for free through that default, and the tests can render at a chosen face without touching defaults.

**`DocumentFontSetting` is `nonisolated` and `Sendable`**, next to `AppearanceMode`, since the target defaults to `MainActor` isolation and `MarkdownHTML` is explicitly nonisolated.

## Tests

```
swift test --package-path tests/swift-tests --filter DocumentFontSettingTests
```

Covers the defaults round-trip, the fallback when a stored value doesn't parse, and that every stack ends in a generic family.

## Test plan

- [x] Debug build succeeds (`xcodebuild -scheme md-preview -configuration Debug`)
- [x] `swift test --package-path tests/swift-tests` passes (172 tests, 1 skipped)
- [ ] Each of the four faces read against a real document
- [ ] Open windows re-render on change without a reopen
- [ ] Quick Look picks up the chosen face
- [ ] The choice survives a relaunch

That first box is the one I'd want your eye on. It's a typography change and I've reasoned about the metrics rather than sat and read four documents in four faces, which is the only way to know whether the serif correction is right. The rest are unticked for the dull reason: no UI suite, and I compiled rather than clicked.
