### PR TITLE
Add an opt-in setting to open documents in tabs

### DIFF
--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -222,7 +222,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// makeWindowControllers, before showWindows), so the window is already
     /// visible and placement never happens on its own. Join the frontmost
     /// document window's tab group explicitly on first show instead — but
-    /// only when the open was an explicit tab request, or the system
+    /// only when the open was an explicit tab request, when this app's own
+    /// "Open documents in tabs" preference is on, or when the system
     /// "Prefer tabs when opening documents" setting asks for it. Plain
     /// opens (Finder, ⌘O, recents) otherwise get their own window.
     private func attachToExistingTabGroupIfNeeded() {
@@ -236,18 +237,20 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                           && $0.tabbingIdentifier == documentWindow.tabbingIdentifier
                   }) else { return }
 
-        let joins: Bool
-        if joinsTabGroupOnFirstShow {
-            joins = true
-        } else {
-            switch NSWindow.userTabbingPreference {
-            case .always: joins = true
-            case .inFullScreen: joins = host.styleMask.contains(.fullScreen)
-            case .manual: joins = false
-            @unknown default: joins = false
-            }
+        let systemPreference: TabOpeningPolicy.SystemPreference
+        switch NSWindow.userTabbingPreference {
+        case .always: systemPreference = .always
+        case .inFullScreen: systemPreference = .inFullScreen
+        case .manual: systemPreference = .manual
+        @unknown default: systemPreference = .manual
         }
-        guard joins else { return }
+
+        guard TabOpeningPolicy.joinsExistingTabGroup(
+            isExplicitTabRequest: joinsTabGroupOnFirstShow,
+            opensDocumentsInTabs: TabOpeningPolicy.isEnabled,
+            systemPreference: systemPreference,
+            hostIsFullScreen: host.styleMask.contains(.fullScreen)
+        ) else { return }
         host.addTabbedWindow(documentWindow, ordered: .above)
     }
 

--- a/md-preview/SettingsPanes.swift
+++ b/md-preview/SettingsPanes.swift
@@ -60,6 +60,15 @@ final class SettingsModel {
         }
     }
 
+    /// A plain stored default with nothing to apply: it is read the next time
+    /// a document opens, so unlike the settings above it has no fan-out.
+    var opensDocumentsInTabs: Bool {
+        didSet {
+            guard !isRestoringExternalValues, opensDocumentsInTabs != oldValue else { return }
+            TabOpeningPolicy.isEnabled = opensDocumentsInTabs
+        }
+    }
+
     var sendsCrashReports: Bool {
         didSet {
             guard !isRestoringExternalValues, sendsCrashReports != oldValue else { return }
@@ -117,6 +126,7 @@ final class SettingsModel {
         contentWidth = ContentWidthSetting.current
         textSize = TextSizeSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
+        opensDocumentsInTabs = TabOpeningPolicy.isEnabled
         sendsCrashReports = CrashReporter.isEnabled
         checksForUpdatesAutomatically = updater?.automaticallyChecksForUpdates ?? true
         downloadsUpdatesAutomatically = updater?.automaticallyDownloadsUpdates ?? false
@@ -165,6 +175,7 @@ final class SettingsModel {
         contentWidth = ContentWidthSetting.current
         textSize = TextSizeSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
+        opensDocumentsInTabs = TabOpeningPolicy.isEnabled
         sendsCrashReports = CrashReporter.isEnabled
         if let updater { refreshUpdateSettings(from: updater) }
     }
@@ -285,11 +296,17 @@ struct GeneralSettingsView: View {
             }
 
             Section {
-                Toggle(L("Always on Top"), isOn: $model.isAlwaysOnTop)
+                Toggle(isOn: $model.isAlwaysOnTop) {
+                    Text(L("Always on Top"))
+                    Text(L("Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out."))
+                }
+
+                Toggle(isOn: $model.opensDocumentsInTabs) {
+                    Text(L("Open documents in tabs"))
+                    Text(L("A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window."))
+                }
             } header: {
                 Text(L("Windows"))
-            } footer: {
-                Text(L("Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out."))
             }
 
             Section {

--- a/md-preview/TabOpeningPolicy.swift
+++ b/md-preview/TabOpeningPolicy.swift
@@ -1,0 +1,67 @@
+//
+//  TabOpeningPolicy.swift
+//  md-preview
+//
+//  Decides whether a document being opened joins the front window as a tab or
+//  gets a window of its own. Kept free of AppKit so the SPM helper tests can
+//  exercise it without a GUI host.
+//
+
+import Foundation
+
+enum TabOpeningPolicy {
+    /// Mirrors `NSWindow.TabbingPreference`, which the controller translates at
+    /// the call site. Restated here so the decision stays testable.
+    enum SystemPreference {
+        case manual
+        case inFullScreen
+        case always
+    }
+
+    /// - Parameters:
+    ///   - isExplicitTabRequest: The open came from "Open in New Tab", ⌘T, or
+    ///     the tab bar's "+", which asks for a tab whatever anything else says.
+    ///   - opensDocumentsInTabs: This app's own preference — the reader wants
+    ///     one Markdown Preview window with the documents inside it.
+    ///   - systemPreference: macOS's "Prefer tabs when opening documents".
+    ///   - hostIsFullScreen: Whether the window that would host the tab is in
+    ///     full screen, which is the only thing `inFullScreen` turns on.
+    static func joinsExistingTabGroup(isExplicitTabRequest: Bool,
+                                      opensDocumentsInTabs: Bool,
+                                      systemPreference: SystemPreference,
+                                      hostIsFullScreen: Bool) -> Bool {
+        if isExplicitTabRequest || opensDocumentsInTabs { return true }
+        switch systemPreference {
+        case .always: return true
+        case .inFullScreen: return hostIsFullScreen
+        case .manual: return false
+        }
+    }
+
+    // MARK: - Storage
+
+    /// The app's own preference, deliberately additive to the system one: it
+    /// can only turn tabbing *on*. Someone who has set macOS to always prefer
+    /// tabs already gets them, and "Open in New Window" still opens a window —
+    /// an explicit request for one window beats a standing preference for none.
+    static let defaultsKey = "MarkdownPreview.opensDocumentsInTabs"
+
+    static var isEnabled: Bool {
+        get { read(from: .standard) }
+        set { write(newValue, to: .standard) }
+    }
+
+    static func read(from defaults: UserDefaults?) -> Bool {
+        defaults?.bool(forKey: defaultsKey) ?? false
+    }
+
+    /// Off clears the key rather than storing `false`, as the other
+    /// preferences do: an untouched preference leaves no trace.
+    static func write(_ isEnabled: Bool, to defaults: UserDefaults?) {
+        if isEnabled {
+            defaults?.set(true, forKey: defaultsKey)
+        } else {
+            defaults?.removeObject(forKey: defaultsKey)
+        }
+    }
+}

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -245,3 +245,5 @@
 /* Settings — Windows */
 "Windows" = "Windows";
 "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out." = "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out.";
+"Open documents in tabs" = "Open documents in tabs";
+"A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window." = "A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window.";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -245,3 +245,5 @@
 /* Settings — Windows */
 "Windows" = "窗口";
 "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out." = "让所有 Markdown Preview 窗口始终显示在其他 App 前面，包括之后打开的窗口。窗口进入全屏时不会置顶，退出全屏后会恢复。";
+"Open documents in tabs" = "以标签页打开文稿";
+"A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window." = "从“访达”打开的文件会作为标签页加入最前面的窗口，而不是各自新建一个窗口——“在新窗口中打开”仍会打开新窗口。";

--- a/tests/swift-tests/Sources/MarkdownHelpers/TabOpeningPolicy.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/TabOpeningPolicy.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/TabOpeningPolicy.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/TabOpeningPolicyTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/TabOpeningPolicyTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import XCTest
+@testable import MarkdownHelpers
+
+final class TabOpeningPolicyTests: XCTestCase {
+    private func joins(explicit: Bool = false,
+                       inTabs: Bool = false,
+                       system: TabOpeningPolicy.SystemPreference = .manual,
+                       hostIsFullScreen: Bool = false) -> Bool {
+        TabOpeningPolicy.joinsExistingTabGroup(isExplicitTabRequest: explicit,
+                                               opensDocumentsInTabs: inTabs,
+                                               systemPreference: system,
+                                               hostIsFullScreen: hostIsFullScreen)
+    }
+
+    func testAPlainOpenGetsItsOwnWindowByDefault() {
+        XCTAssertFalse(joins())
+    }
+
+    func testAnExplicitTabRequestAlwaysJoins() {
+        XCTAssertTrue(joins(explicit: true))
+        XCTAssertTrue(joins(explicit: true, system: .manual))
+    }
+
+    func testThePreferenceMakesAPlainOpenJoinTheFrontWindow() {
+        XCTAssertTrue(joins(inTabs: true))
+        XCTAssertTrue(joins(inTabs: true, system: .manual))
+    }
+
+    // The app preference is additive to the system one, so nothing about the
+    // existing behaviour changes for readers who never turn it on.
+    func testSystemPreferenceStillDecidesWhenTheAppPreferenceIsOff() {
+        XCTAssertTrue(joins(system: .always))
+        XCTAssertFalse(joins(system: .inFullScreen, hostIsFullScreen: false))
+        XCTAssertTrue(joins(system: .inFullScreen, hostIsFullScreen: true))
+    }
+
+    func testPreferenceIsOffWhenNothingHasBeenStored() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(TabOpeningPolicy.read(from: defaults))
+        XCTAssertFalse(TabOpeningPolicy.read(from: nil))
+    }
+
+    func testPreferenceRoundTripsAndClearsItsKeyWhenOff() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        TabOpeningPolicy.write(true, to: defaults)
+        XCTAssertTrue(TabOpeningPolicy.read(from: defaults))
+
+        TabOpeningPolicy.write(false, to: defaults)
+        XCTAssertFalse(TabOpeningPolicy.read(from: defaults))
+        XCTAssertNil(defaults.object(forKey: TabOpeningPolicy.defaultsKey))
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "doc.md-preview.tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **Open documents in tabs** toggle to Settings → General → Windows. With it on, a Markdown file opened from Finder, ⌘O or the recents list joins the front window as a tab instead of getting a window of its own.

This is the toggle you described in #230 — opt-in, current behaviour still the default, no change for anyone who doesn't turn it on.

## Design notes

**The preference is additive: it can only turn tabbing on.** macOS already has "Prefer tabs when opening documents" in System Settings, and someone who has set that to _always_ already gets tabs. This adds a reason to tab, never a reason not to. The decision is now a single function:

```swift
if isExplicitTabRequest || opensDocumentsInTabs { return true }
switch systemPreference {
case .always:       return true
case .inFullScreen: return hostIsFullScreen
case .manual:       return false
}
```

**"Open in New Window" still opens a window.** An explicit request for one window beats a standing preference for none — the same way an explicit tab request (⌘T, the tab bar's `+`) wins whatever the system preference says.

**The decision moved out of `DocumentWindowController` into `TabOpeningPolicy`**, free of AppKit, so the SPM helper package can exercise every branch without a GUI host. `NSWindow.userTabbingPreference` is translated at the call site into a small enum the policy owns. That's the same shape `AlwaysOnTopPolicy` already uses.

**Nothing to apply when it changes.** Unlike appearance or text size, this one is read the next time a document opens, so there's no fan-out to open windows.

**Deliberately not in scope**, from your issue: gating on directory structure or an open "project", and double-click in the file navigator opening a tab rather than replacing the content. Both are real and both are bigger than this. Neither needs to block a toggle. I'd take either on separately if you want them.

## Tests

```
swift test --package-path tests/swift-tests --filter TabOpeningPolicyTests
```

Six tests: the explicit tab request, the app preference, each of the three system preference cases, and the defaults round-trip.

## Test plan

- [x] Debug build succeeds (`xcodebuild -scheme md-preview -configuration Debug`)
- [x] `swift test --package-path tests/swift-tests` passes (171 tests, 1 skipped)
- [ ] Opening a second file from Finder with the toggle on joins the front window
- [ ] The first file still opens a window normally when nothing is open yet
- [ ] "Open in New Window" still opens a window with the toggle on
- [ ] Tab switching, closing and the document lifecycle behave as before
- [ ] With the toggle off, behaviour is unchanged for each of the three system tabbing preferences

Unticked means not done, not skipped: it compiles and the policy is covered, but I haven't driven it by hand and there's no UI suite standing in for that.

Addresses #230 — I have left it open rather than auto-closing it, since the two larger ideas in that thread are still standing. Yours to close if you think the toggle is enough.
