### PR TITLE
Add configurable automatic saving for edited documents

### DIFF
--- a/md-preview/AppDelegate.swift
+++ b/md-preview/AppDelegate.swift
@@ -286,6 +286,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .forEach { $0.applyTextSizeSetting() }
     }
 
+    func applyAutoSaveIntervalSetting(_ minutes: Int) {
+        AutoSaveSetting.store(minutes: minutes)
+        NSDocumentController.shared.documents
+            .flatMap(\.windowControllers)
+            .compactMap { $0 as? DocumentWindowController }
+            .forEach { $0.applyAutoSaveIntervalSetting() }
+    }
+
     func installCommandLineToolsFromSettings() {
         installCommandLineTools(nil)
     }

--- a/md-preview/AutoSaveSetting.swift
+++ b/md-preview/AutoSaveSetting.swift
@@ -8,6 +8,9 @@ import Foundation
 /// Shared interval used by the editor's periodic save timer and Settings.
 enum AutoSaveSetting {
     static let defaultsKey = "MarkdownPreview.autoSaveIntervalMinutes"
+    // Keep the existing minute-based preference key compatible without
+    // confusing the new 30-second choice with a stored minute count.
+    static let thirtySeconds = -30
     static let disabledMinutes = 0
     static let minimumMinutes = 1
     static let maximumMinutes = 60
@@ -28,13 +31,23 @@ enum AutoSaveSetting {
     }
 
     static func clampedMinutes(_ minutes: Int) -> Int {
+        if minutes == thirtySeconds { return thirtySeconds }
         guard minutes != disabledMinutes else { return disabledMinutes }
         return min(max(minutes, minimumMinutes), maximumMinutes)
     }
 
     static var interval: TimeInterval? {
-        let minutes = currentMinutes
-        guard minutes != disabledMinutes else { return nil }
-        return TimeInterval(minutes * 60)
+        interval(for: currentMinutes)
+    }
+
+    static func interval(for minutes: Int) -> TimeInterval? {
+        switch minutes {
+        case disabledMinutes:
+            return nil
+        case thirtySeconds:
+            return 30
+        default:
+            return TimeInterval(minutes * 60)
+        }
     }
 }

--- a/md-preview/AutoSaveSetting.swift
+++ b/md-preview/AutoSaveSetting.swift
@@ -1,0 +1,37 @@
+//
+//  AutoSaveSetting.swift
+//  md-preview
+//
+
+import Foundation
+
+/// Shared interval used by the editor's periodic save timer and Settings.
+enum AutoSaveSetting {
+    static let defaultsKey = "MarkdownPreview.autoSaveIntervalMinutes"
+    static let defaultMinutes = 5
+    static let minimumMinutes = 1
+    static let maximumMinutes = 60
+
+    static var currentMinutes: Int {
+        currentMinutes(from: .standard)
+    }
+
+    static func currentMinutes(from defaults: UserDefaults) -> Int {
+        guard let stored = defaults.object(forKey: defaultsKey) as? NSNumber else {
+            return defaultMinutes
+        }
+        return clampedMinutes(stored.intValue)
+    }
+
+    static func store(minutes: Int, in defaults: UserDefaults = .standard) {
+        defaults.set(clampedMinutes(minutes), forKey: defaultsKey)
+    }
+
+    static func clampedMinutes(_ minutes: Int) -> Int {
+        min(max(minutes, minimumMinutes), maximumMinutes)
+    }
+
+    static var interval: TimeInterval {
+        TimeInterval(currentMinutes * 60)
+    }
+}

--- a/md-preview/AutoSaveSetting.swift
+++ b/md-preview/AutoSaveSetting.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Shared interval used by the editor's periodic save timer and Settings.
 enum AutoSaveSetting {
     static let defaultsKey = "MarkdownPreview.autoSaveIntervalMinutes"
-    static let defaultMinutes = 5
+    static let disabledMinutes = 0
     static let minimumMinutes = 1
     static let maximumMinutes = 60
 
@@ -18,7 +18,7 @@ enum AutoSaveSetting {
 
     static func currentMinutes(from defaults: UserDefaults) -> Int {
         guard let stored = defaults.object(forKey: defaultsKey) as? NSNumber else {
-            return defaultMinutes
+            return disabledMinutes
         }
         return clampedMinutes(stored.intValue)
     }
@@ -28,10 +28,13 @@ enum AutoSaveSetting {
     }
 
     static func clampedMinutes(_ minutes: Int) -> Int {
-        min(max(minutes, minimumMinutes), maximumMinutes)
+        guard minutes != disabledMinutes else { return disabledMinutes }
+        return min(max(minutes, minimumMinutes), maximumMinutes)
     }
 
-    static var interval: TimeInterval {
-        TimeInterval(currentMinutes * 60)
+    static var interval: TimeInterval? {
+        let minutes = currentMinutes
+        guard minutes != disabledMinutes else { return nil }
+        return TimeInterval(minutes * 60)
     }
 }

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -101,12 +101,14 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// Last known on-disk source, retained while preview displays a draft.
     private var editorBaselineMarkdown: String?
     private var isEditorCommitInFlight = false
+    private var pendingEditorCommitRequested = false
     private var pendingCommitShouldExit = false
     private var pendingCommitCompletions: [(Bool) -> Void] = []
     /// When sidebar navigation starts from edit mode, the newly loaded file
     /// should return to edit mode instead of dropping the user into preview.
     private var pendingEditModeURL: URL?
     private var autoSaveTimer: Timer?
+    private var autoSaveTimerID: UUID?
     private var isPerformingAutomaticSave = false
     private var autoSaveFeedbackResetWork: DispatchWorkItem?
     private var autoSaveFeedback = AutoSaveFeedback.none {
@@ -1013,17 +1015,25 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
               currentFileURL != nil,
               hasUnsavedEditorChanges,
               let interval = AutoSaveSetting.interval else { return }
+        let timerID = UUID()
+        autoSaveTimerID = timerID
         autoSaveTimer = Timer.scheduledTimer(
             withTimeInterval: interval,
-            repeats: true
-        ) { [weak self] _ in
-            self?.performAutomaticSave()
+            repeats: false
+        ) { [weak self, timerID] _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.autoSaveTimerID == timerID else { return }
+                self.autoSaveTimer = nil
+                self.autoSaveTimerID = nil
+                self.performAutomaticSave()
+            }
         }
     }
 
     private func stopAutoSaveTimer() {
         autoSaveTimer?.invalidate()
         autoSaveTimer = nil
+        autoSaveTimerID = nil
     }
 
     private func performAutomaticSave() {
@@ -1360,6 +1370,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         editor.contentDidChange = { [weak self] in
             self?.editorChangeRevision += 1
             self?.hasUnsavedEditorChanges = true
+            self?.stopAutoSaveTimer()
+            self?.startAutoSaveTimerIfNeeded()
         }
         if editorBaselineMarkdown == nil {
             editorBaselineMarkdown = currentMarkdown
@@ -1510,7 +1522,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         if let completion {
             pendingCommitCompletions.append(completion)
         }
-        guard !isEditorCommitInFlight else { return }
+        guard !isEditorCommitInFlight else {
+            pendingEditorCommitRequested = true
+            return
+        }
         performPendingEditorCommit()
     }
 
@@ -1660,7 +1675,15 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
 
     private func finishEditorCommit(success: Bool) {
         isEditorCommitInFlight = false
-        if success, hasUnsavedEditorChanges || pendingCommitShouldExit {
+        if pendingEditorCommitRequested {
+            pendingEditorCommitRequested = false
+            isPerformingAutomaticSave = false
+            performPendingEditorCommit()
+            return
+        }
+        if success,
+           pendingCommitShouldExit
+            || (hasUnsavedEditorChanges && !isPerformingAutomaticSave) {
             startAutoSaveTimerIfNeeded()
             performPendingEditorCommit()
             return
@@ -1672,6 +1695,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             stopAutoSaveTimer()
         }
 
+        pendingEditorCommitRequested = false
         pendingCommitShouldExit = false
         let completions = pendingCommitCompletions
         pendingCommitCompletions.removeAll()

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -68,8 +68,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     }
 
     private enum AutoSaveFeedback: Equatable {
-        case interval
-        case saved
+        case none
         case failed
     }
 
@@ -108,18 +107,17 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// should return to edit mode instead of dropping the user into preview.
     private var pendingEditModeURL: URL?
     private var autoSaveTimer: Timer?
+    private var isPerformingAutomaticSave = false
     private var autoSaveFeedbackResetWork: DispatchWorkItem?
-    private var autoSaveFeedback = AutoSaveFeedback.interval {
+    private var autoSaveFeedback = AutoSaveFeedback.none {
         didSet { updateWindowSubtitle() }
     }
-    /// Drives the native titlebar subtitle for the editor state and autosave
-    /// status. `NSWindow.subtitle` is rendered as quiet secondary text beside
-    /// the file name, which keeps the main toolbar unchanged.
+    /// Drives the native titlebar subtitle while the editor contains changes
+    /// that have not yet been written successfully.
     private var hasUnsavedEditorChanges = false {
         didSet {
             guard oldValue != hasUnsavedEditorChanges else { return }
             if hasUnsavedEditorChanges {
-                showAutoSaveFeedback(.interval)
                 startAutoSaveTimerIfNeeded()
             } else if !isEditorCommitInFlight {
                 stopAutoSaveTimer()
@@ -1005,22 +1003,18 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     // MARK: - Autosave
 
     func applyAutoSaveIntervalSetting() {
-        resetAutoSaveFeedback()
-        guard hasUnsavedEditorChanges else {
-            updateWindowSubtitle()
-            return
-        }
+        guard hasUnsavedEditorChanges else { return }
         stopAutoSaveTimer()
         startAutoSaveTimerIfNeeded()
-        updateWindowSubtitle()
     }
 
     private func startAutoSaveTimerIfNeeded() {
         guard autoSaveTimer == nil,
               currentFileURL != nil,
-              hasUnsavedEditorChanges else { return }
+              hasUnsavedEditorChanges,
+              let interval = AutoSaveSetting.interval else { return }
         autoSaveTimer = Timer.scheduledTimer(
-            withTimeInterval: AutoSaveSetting.interval,
+            withTimeInterval: interval,
             repeats: true
         ) { [weak self] _ in
             self?.performAutomaticSave()
@@ -1037,28 +1031,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
               !isEditorCommitInFlight,
               currentFileURL != nil else { return }
 
+        isPerformingAutomaticSave = true
         commitEdits(exitAfter: false) { [weak self] success in
             guard let self else { return }
-            if success {
-                if !self.hasUnsavedEditorChanges {
-                    self.showAutoSaveFeedback(.saved)
-                }
-            } else {
-                self.showAutoSaveFeedback(.failed)
-            }
+            self.isPerformingAutomaticSave = false
+            guard !success else { return }
+            self.showAutoSaveFailure()
         }
     }
 
-    private func showAutoSaveFeedback(_ feedback: AutoSaveFeedback) {
+    private func showAutoSaveFailure() {
         autoSaveFeedbackResetWork?.cancel()
         autoSaveFeedbackResetWork = nil
-        autoSaveFeedback = feedback
-        guard feedback != .interval else { return }
+        autoSaveFeedback = .failed
 
         let work = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.autoSaveFeedbackResetWork = nil
-            self.autoSaveFeedback = .interval
+            self.autoSaveFeedback = .none
         }
         autoSaveFeedbackResetWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
@@ -1067,61 +1057,19 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func resetAutoSaveFeedback() {
         autoSaveFeedbackResetWork?.cancel()
         autoSaveFeedbackResetWork = nil
-        autoSaveFeedback = .interval
+        autoSaveFeedback = .none
     }
 
     private func updateWindowSubtitle() {
-        guard currentFileURL != nil else {
-            documentWindow.subtitle = hasUnsavedEditorChanges
-                ? NSLocalizedString("Edited", comment: "Window subtitle for unsaved changes")
-                : ""
-            return
-        }
-
         switch autoSaveFeedback {
-        case .saved:
-            documentWindow.subtitle = NSLocalizedString(
-                "Auto-saved", comment: "Window subtitle after an automatic save")
         case .failed:
             documentWindow.subtitle = NSLocalizedString(
                 "Auto-save failed", comment: "Window subtitle after an automatic save failure")
-        case .interval:
+        case .none:
             documentWindow.subtitle = hasUnsavedEditorChanges
-                ? editedAutoSaveSubtitle()
-                : autoSaveIntervalSubtitle()
+                ? NSLocalizedString("Edited", comment: "Window subtitle for unsaved changes")
+                : ""
         }
-    }
-
-    private func autoSaveIntervalSubtitle() -> String {
-        let minutes = AutoSaveSetting.currentMinutes
-        if minutes == 1 {
-            return NSLocalizedString(
-                "Autosaves every minute", comment: "Window subtitle for the autosave interval")
-        }
-        return String(
-            format: NSLocalizedString(
-                "Autosaves every %d minutes",
-                comment: "Window subtitle for the autosave interval"
-            ),
-            minutes
-        )
-    }
-
-    private func editedAutoSaveSubtitle() -> String {
-        let minutes = AutoSaveSetting.currentMinutes
-        if minutes == 1 {
-            return NSLocalizedString(
-                "Edited; autosaves every minute",
-                comment: "Window subtitle for unsaved edits and autosave"
-            )
-        }
-        return String(
-            format: NSLocalizedString(
-                "Edited; autosaves every %d minutes",
-                comment: "Window subtitle for unsaved edits and autosave"
-            ),
-            minutes
-        )
     }
 
     private func copyIdleImage() -> NSImage? {
@@ -1782,6 +1730,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             completion(.cancelled)
             return
         }
+        if isPerformingAutomaticSave {
+            guard case .unchanged = diskState else {
+                completion(.cancelled)
+                return
+            }
+        }
         switch diskState {
         case .unchanged:
             persistEditedMarkdown(text, to: url, completion: completion)
@@ -2070,6 +2024,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     ) {
         if write(text, to: url) {
             completion(.saved)
+            return
+        }
+        guard !isPerformingAutomaticSave else {
+            completion(.cancelled)
             return
         }
         // Sandbox denied the write — the file came in through the read-only

--- a/md-preview/DocumentWindowController.swift
+++ b/md-preview/DocumentWindowController.swift
@@ -67,6 +67,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         case cancel
     }
 
+    private enum AutoSaveFeedback: Equatable {
+        case interval
+        case saved
+        case failed
+    }
+
     private struct HistoryEntry {
         let url: URL
         /// Scroll offset when the user navigated away; restored on back/forward.
@@ -101,14 +107,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// When sidebar navigation starts from edit mode, the newly loaded file
     /// should return to edit mode instead of dropping the user into preview.
     private var pendingEditModeURL: URL?
-    /// Drives the native titlebar subtitle while the editor contains changes
-    /// that have not yet been written successfully.
+    private var autoSaveTimer: Timer?
+    private var autoSaveFeedbackResetWork: DispatchWorkItem?
+    private var autoSaveFeedback = AutoSaveFeedback.interval {
+        didSet { updateWindowSubtitle() }
+    }
+    /// Drives the native titlebar subtitle for the editor state and autosave
+    /// status. `NSWindow.subtitle` is rendered as quiet secondary text beside
+    /// the file name, which keeps the main toolbar unchanged.
     private var hasUnsavedEditorChanges = false {
         didSet {
             guard oldValue != hasUnsavedEditorChanges else { return }
-            documentWindow.subtitle = hasUnsavedEditorChanges
-                ? NSLocalizedString("Edited", comment: "Window subtitle for unsaved changes")
-                : ""
+            if hasUnsavedEditorChanges {
+                showAutoSaveFeedback(.interval)
+                startAutoSaveTimerIfNeeded()
+            } else if !isEditorCommitInFlight {
+                stopAutoSaveTimer()
+            }
+            updateWindowSubtitle()
         }
     }
     private weak var editAccessory: NSTitlebarAccessoryViewController?
@@ -264,6 +280,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     func windowWillClose(_ notification: Notification) {
         fileWatcher?.cancel()
         fileWatcher = nil
+        stopAutoSaveTimer()
+        autoSaveFeedbackResetWork?.cancel()
+        autoSaveFeedbackResetWork = nil
     }
 
     func windowWillEnterFullScreen(_ notification: Notification) {
@@ -282,8 +301,13 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         tableUndoManager.removeAllActions()
         currentFileURL = fileURL
         currentMarkdown = markdown
+        resetAutoSaveFeedback()
+        if fileURL == nil {
+            stopAutoSaveTimer()
+        }
         documentWindow.title = fileURL?.lastPathComponent
             ?? NSLocalizedString("Untitled", comment: "Window title when no document is open")
+        updateWindowSubtitle()
         attachToExistingTabGroupIfNeeded()
         documentWindow.makeKeyAndOrderFront(nil)
         // Tab placement is settled once the window is shown; a window opened
@@ -348,6 +372,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         pendingEditModeURL = preservingEditMode ? url.standardizedFileURL : nil
         markdownDocument?.replaceFileURL(url)
         documentWindow.title = url.lastPathComponent
+        resetAutoSaveFeedback()
+        updateWindowSubtitle()
         if isFileSwitch {
             split?.clearContent()
         }
@@ -444,6 +470,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         currentFileURL = newURL
         markdownDocument?.replaceFileURL(newURL)
         documentWindow.title = newURL.lastPathComponent
+        updateWindowSubtitle()
         NSDocumentController.shared.noteNewRecentDocumentURL(newURL)
         refreshOpenWithItem()
         refreshOpenActionsItem()
@@ -972,6 +999,128 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         copyFeedbackWork = work
         DispatchQueue.main.asyncAfter(
             deadline: .now() + Self.copyFeedbackDuration, execute: work
+        )
+    }
+
+    // MARK: - Autosave
+
+    func applyAutoSaveIntervalSetting() {
+        resetAutoSaveFeedback()
+        guard hasUnsavedEditorChanges else {
+            updateWindowSubtitle()
+            return
+        }
+        stopAutoSaveTimer()
+        startAutoSaveTimerIfNeeded()
+        updateWindowSubtitle()
+    }
+
+    private func startAutoSaveTimerIfNeeded() {
+        guard autoSaveTimer == nil,
+              currentFileURL != nil,
+              hasUnsavedEditorChanges else { return }
+        autoSaveTimer = Timer.scheduledTimer(
+            withTimeInterval: AutoSaveSetting.interval,
+            repeats: true
+        ) { [weak self] _ in
+            self?.performAutomaticSave()
+        }
+    }
+
+    private func stopAutoSaveTimer() {
+        autoSaveTimer?.invalidate()
+        autoSaveTimer = nil
+    }
+
+    private func performAutomaticSave() {
+        guard hasUnsavedEditorChanges,
+              !isEditorCommitInFlight,
+              currentFileURL != nil else { return }
+
+        commitEdits(exitAfter: false) { [weak self] success in
+            guard let self else { return }
+            if success {
+                if !self.hasUnsavedEditorChanges {
+                    self.showAutoSaveFeedback(.saved)
+                }
+            } else {
+                self.showAutoSaveFeedback(.failed)
+            }
+        }
+    }
+
+    private func showAutoSaveFeedback(_ feedback: AutoSaveFeedback) {
+        autoSaveFeedbackResetWork?.cancel()
+        autoSaveFeedbackResetWork = nil
+        autoSaveFeedback = feedback
+        guard feedback != .interval else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.autoSaveFeedbackResetWork = nil
+            self.autoSaveFeedback = .interval
+        }
+        autoSaveFeedbackResetWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+    }
+
+    private func resetAutoSaveFeedback() {
+        autoSaveFeedbackResetWork?.cancel()
+        autoSaveFeedbackResetWork = nil
+        autoSaveFeedback = .interval
+    }
+
+    private func updateWindowSubtitle() {
+        guard currentFileURL != nil else {
+            documentWindow.subtitle = hasUnsavedEditorChanges
+                ? NSLocalizedString("Edited", comment: "Window subtitle for unsaved changes")
+                : ""
+            return
+        }
+
+        switch autoSaveFeedback {
+        case .saved:
+            documentWindow.subtitle = NSLocalizedString(
+                "Auto-saved", comment: "Window subtitle after an automatic save")
+        case .failed:
+            documentWindow.subtitle = NSLocalizedString(
+                "Auto-save failed", comment: "Window subtitle after an automatic save failure")
+        case .interval:
+            documentWindow.subtitle = hasUnsavedEditorChanges
+                ? editedAutoSaveSubtitle()
+                : autoSaveIntervalSubtitle()
+        }
+    }
+
+    private func autoSaveIntervalSubtitle() -> String {
+        let minutes = AutoSaveSetting.currentMinutes
+        if minutes == 1 {
+            return NSLocalizedString(
+                "Autosaves every minute", comment: "Window subtitle for the autosave interval")
+        }
+        return String(
+            format: NSLocalizedString(
+                "Autosaves every %d minutes",
+                comment: "Window subtitle for the autosave interval"
+            ),
+            minutes
+        )
+    }
+
+    private func editedAutoSaveSubtitle() -> String {
+        let minutes = AutoSaveSetting.currentMinutes
+        if minutes == 1 {
+            return NSLocalizedString(
+                "Edited; autosaves every minute",
+                comment: "Window subtitle for unsaved edits and autosave"
+            )
+        }
+        return String(
+            format: NSLocalizedString(
+                "Edited; autosaves every %d minutes",
+                comment: "Window subtitle for unsaved edits and autosave"
+            ),
+            minutes
         )
     }
 
@@ -1564,8 +1713,15 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func finishEditorCommit(success: Bool) {
         isEditorCommitInFlight = false
         if success, hasUnsavedEditorChanges || pendingCommitShouldExit {
+            startAutoSaveTimerIfNeeded()
             performPendingEditorCommit()
             return
+        }
+
+        if hasUnsavedEditorChanges {
+            startAutoSaveTimerIfNeeded()
+        } else {
+            stopAutoSaveTimer()
         }
 
         pendingCommitShouldExit = false
@@ -2813,6 +2969,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         let folderURL = folderURL.standardizedFileURL
         if currentFileURL == nil {
             documentWindow.title = folderURL.lastPathComponent
+            updateWindowSubtitle()
         }
         (documentWindow.contentViewController as? MainSplitViewController)?
             .openFolder(folderURL, selectedFileURL: currentFileURL)
@@ -2936,6 +3093,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     private func applyLoadedMarkdown(_ text: String, fileURL: URL) {
         guard currentFileURL?.standardizedFileURL == fileURL.standardizedFileURL else { return }
         currentMarkdown = text
+        resetAutoSaveFeedback()
+        updateWindowSubtitle()
         refreshOpenInLLMItem()
         updateEditToolbarItem()
         markdownDocument?.replaceContents(markdown: text, fileURL: fileURL)

--- a/md-preview/SettingsPanes.swift
+++ b/md-preview/SettingsPanes.swift
@@ -293,13 +293,15 @@ struct GeneralSettingsView: View {
                 LabeledContent {
                     Stepper(
                         value: $model.autoSaveIntervalMinutes,
-                        in: AutoSaveSetting.minimumMinutes...AutoSaveSetting.maximumMinutes,
+                        in: AutoSaveSetting.disabledMinutes...AutoSaveSetting.maximumMinutes,
                         step: 1
                     ) {
-                        Text(String(
-                            format: L("%d minutes"),
-                            model.autoSaveIntervalMinutes
-                        ))
+                        Text(model.autoSaveIntervalMinutes == AutoSaveSetting.disabledMinutes
+                             ? L("Never")
+                             : String(
+                                 format: L("%d minutes"),
+                                 model.autoSaveIntervalMinutes
+                             ))
                         .monospacedDigit()
                         .frame(minWidth: 72, alignment: .trailing)
                     }

--- a/md-preview/SettingsPanes.swift
+++ b/md-preview/SettingsPanes.swift
@@ -291,20 +291,16 @@ struct GeneralSettingsView: View {
 
             Section {
                 LabeledContent {
-                    Stepper(
-                        value: $model.autoSaveIntervalMinutes,
-                        in: AutoSaveSetting.disabledMinutes...AutoSaveSetting.maximumMinutes,
-                        step: 1
-                    ) {
-                        Text(model.autoSaveIntervalMinutes == AutoSaveSetting.disabledMinutes
-                             ? L("Never")
-                             : String(
-                                 format: L("%d minutes"),
-                                 model.autoSaveIntervalMinutes
-                             ))
-                        .monospacedDigit()
-                        .frame(minWidth: 72, alignment: .trailing)
+                    Picker("", selection: $model.autoSaveIntervalMinutes) {
+                        Text(L("Never")).tag(AutoSaveSetting.disabledMinutes)
+                        Text(L("1 minute")).tag(1)
+                        ForEach([5, 10, 15, 30, 60], id: \.self) { minutes in
+                            Text(String(format: L("%d minutes"), minutes))
+                                .tag(minutes)
+                        }
                     }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
                 } label: {
                     Text(L("Automatic saving"))
                     Text(L("Save edited documents periodically."))

--- a/md-preview/SettingsPanes.swift
+++ b/md-preview/SettingsPanes.swift
@@ -44,6 +44,19 @@ final class SettingsModel {
         }
     }
 
+    var autoSaveIntervalMinutes: Int {
+        didSet {
+            let normalized = AutoSaveSetting.clampedMinutes(autoSaveIntervalMinutes)
+            guard normalized == autoSaveIntervalMinutes else {
+                autoSaveIntervalMinutes = normalized
+                return
+            }
+            guard !isRestoringExternalValues,
+                  autoSaveIntervalMinutes != oldValue else { return }
+            appDelegate?.applyAutoSaveIntervalSetting(autoSaveIntervalMinutes)
+        }
+    }
+
     /// Optional because ⌘+ / ⌘− can leave the stored zoom between the named
     /// stops; the picker then shows nothing selected rather than lying.
     var textSize: TextSizeSetting? {
@@ -108,6 +121,7 @@ final class SettingsModel {
         let updater = (NSApp.delegate as? AppDelegate)?.updaterController.updater
         appearance = AppearanceMode.current
         contentWidth = ContentWidthSetting.current
+        autoSaveIntervalMinutes = AutoSaveSetting.currentMinutes
         textSize = TextSizeSetting.current
         sendsCrashReports = CrashReporter.isEnabled
         checksForUpdatesAutomatically = updater?.automaticallyChecksForUpdates ?? true
@@ -154,6 +168,7 @@ final class SettingsModel {
 
         appearance = AppearanceMode.current
         contentWidth = ContentWidthSetting.current
+        autoSaveIntervalMinutes = AutoSaveSetting.currentMinutes
         textSize = TextSizeSetting.current
         sendsCrashReports = CrashReporter.isEnabled
         if let updater { refreshUpdateSettings(from: updater) }
@@ -272,6 +287,30 @@ struct GeneralSettingsView: View {
                 Text(L("Layout"))
             } footer: {
                 Text(L("Zooming a document window with ⌘+ and ⌘− changes this same size."))
+            }
+
+            Section {
+                LabeledContent {
+                    Stepper(
+                        value: $model.autoSaveIntervalMinutes,
+                        in: AutoSaveSetting.minimumMinutes...AutoSaveSetting.maximumMinutes,
+                        step: 1
+                    ) {
+                        Text(String(
+                            format: L("%d minutes"),
+                            model.autoSaveIntervalMinutes
+                        ))
+                        .monospacedDigit()
+                        .frame(minWidth: 72, alignment: .trailing)
+                    }
+                } label: {
+                    Text(L("Automatic saving"))
+                    Text(L("Save edited documents periodically."))
+                }
+            } header: {
+                Text(L("Editing"))
+            } footer: {
+                Text(L("Automatic saving runs while a document has unsaved edits."))
             }
 
             Section {

--- a/md-preview/SettingsPanes.swift
+++ b/md-preview/SettingsPanes.swift
@@ -293,6 +293,7 @@ struct GeneralSettingsView: View {
                 LabeledContent {
                     Picker("", selection: $model.autoSaveIntervalMinutes) {
                         Text(L("Never")).tag(AutoSaveSetting.disabledMinutes)
+                        Text(L("30 seconds")).tag(AutoSaveSetting.thirtySeconds)
                         Text(L("1 minute")).tag(1)
                         ForEach([5, 10, 15, 30, 60], id: \.self) { minutes in
                             Text(String(format: L("%d minutes"), minutes))

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "Automatic saving" = "Automatic saving";
 "Save edited documents periodically." = "Save edited documents periodically.";
 "Automatic saving runs while a document has unsaved edits." = "Automatic saving runs while a document has unsaved edits.";
+"1 minute" = "1 minute";
 "%d minutes" = "%d minutes";
 "Hand-off" = "Hand-off";
 "Open documents in" = "Open documents in";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "Automatic saving" = "Automatic saving";
 "Save edited documents periodically." = "Save edited documents periodically.";
 "Automatic saving runs while a document has unsaved edits." = "Automatic saving runs while a document has unsaved edits.";
+"30 seconds" = "30 seconds";
 "1 minute" = "1 minute";
 "%d minutes" = "%d minutes";
 "Hand-off" = "Hand-off";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -174,11 +174,6 @@
 
 /* Document state and save dialogs */
 "Edited" = "Edited";
-"Autosaves every minute" = "Autosaves every minute";
-"Autosaves every %d minutes" = "Autosaves every %d minutes";
-"Edited; autosaves every minute" = "Edited; autosaves every minute";
-"Edited; autosaves every %d minutes" = "Edited; autosaves every %d minutes";
-"Auto-saved" = "Auto-saved";
 "Auto-save failed" = "Auto-save failed";
 "Do you want to save your changes?" = "Do you want to save your changes?";
 "this document" = "this document";

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -15,6 +15,11 @@
 "Large" = "Large";
 "Content width" = "Content width";
 "Zooming a document window with ⌘+ and ⌘− changes this same size." = "Zooming a document window with ⌘+ and ⌘− changes this same size.";
+"Editing" = "Editing";
+"Automatic saving" = "Automatic saving";
+"Save edited documents periodically." = "Save edited documents periodically.";
+"Automatic saving runs while a document has unsaved edits." = "Automatic saving runs while a document has unsaved edits.";
+"%d minutes" = "%d minutes";
 "Hand-off" = "Hand-off";
 "Open documents in" = "Open documents in";
 "AI apps" = "AI apps";
@@ -169,6 +174,12 @@
 
 /* Document state and save dialogs */
 "Edited" = "Edited";
+"Autosaves every minute" = "Autosaves every minute";
+"Autosaves every %d minutes" = "Autosaves every %d minutes";
+"Edited; autosaves every minute" = "Edited; autosaves every minute";
+"Edited; autosaves every %d minutes" = "Edited; autosaves every %d minutes";
+"Auto-saved" = "Auto-saved";
+"Auto-save failed" = "Auto-save failed";
 "Do you want to save your changes?" = "Do you want to save your changes?";
 "this document" = "this document";
 "Your changes to %@ will be lost if you don’t save them." = "Your changes to %@ will be lost if you don’t save them.";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "Automatic saving" = "自动保存";
 "Save edited documents periodically." = "定期保存编辑中的文稿。";
 "Automatic saving runs while a document has unsaved edits." = "文稿有未保存的编辑时，自动保存会运行。";
+"30 seconds" = "30 秒";
 "1 minute" = "1 分钟";
 "%d minutes" = "%d 分钟";
 "Hand-off" = "打开方式";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "Automatic saving" = "自动保存";
 "Save edited documents periodically." = "定期保存编辑中的文稿。";
 "Automatic saving runs while a document has unsaved edits." = "文稿有未保存的编辑时，自动保存会运行。";
+"1 minute" = "1 分钟";
 "%d minutes" = "%d 分钟";
 "Hand-off" = "打开方式";
 "Open documents in" = "打开文稿时使用";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -15,6 +15,11 @@
 "Large" = "大";
 "Content width" = "内容宽度";
 "Zooming a document window with ⌘+ and ⌘− changes this same size." = "使用 ⌘+ 和 ⌘− 缩放文稿窗口会更改同一大小设置。";
+"Editing" = "编辑";
+"Automatic saving" = "自动保存";
+"Save edited documents periodically." = "定期保存编辑中的文稿。";
+"Automatic saving runs while a document has unsaved edits." = "文稿有未保存的编辑时，自动保存会运行。";
+"%d minutes" = "%d 分钟";
 "Hand-off" = "打开方式";
 "Open documents in" = "打开文稿时使用";
 "AI apps" = "AI App";
@@ -169,6 +174,12 @@
 
 /* Document state and save dialogs */
 "Edited" = "已编辑";
+"Autosaves every minute" = "每分钟自动保存";
+"Autosaves every %d minutes" = "每 %d 分钟自动保存";
+"Edited; autosaves every minute" = "已编辑；每分钟自动保存";
+"Edited; autosaves every %d minutes" = "已编辑；每 %d 分钟自动保存";
+"Auto-saved" = "已自动保存";
+"Auto-save failed" = "自动保存失败";
 "Do you want to save your changes?" = "要存储您的更改吗？";
 "this document" = "此文稿";
 "Your changes to %@ will be lost if you don’t save them." = "如果不存储，对 %@ 所做的更改将丢失。";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -174,11 +174,6 @@
 
 /* Document state and save dialogs */
 "Edited" = "已编辑";
-"Autosaves every minute" = "每分钟自动保存";
-"Autosaves every %d minutes" = "每 %d 分钟自动保存";
-"Edited; autosaves every minute" = "已编辑；每分钟自动保存";
-"Edited; autosaves every %d minutes" = "已编辑；每 %d 分钟自动保存";
-"Auto-saved" = "已自动保存";
 "Auto-save failed" = "自动保存失败";
 "Do you want to save your changes?" = "要存储您的更改吗？";
 "this document" = "此文稿";

--- a/tests/swift-tests/Sources/MarkdownHelpers/AutoSaveSetting.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/AutoSaveSetting.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/AutoSaveSetting.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/AutoSaveSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/AutoSaveSettingTests.swift
@@ -38,6 +38,18 @@ final class AutoSaveSettingTests: XCTestCase {
         XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 12)
     }
 
+    func testThirtySecondIntervalUsesDedicatedValue() throws {
+        let defaults = try makeDefaults()
+
+        defaults.set(AutoSaveSetting.thirtySeconds, forKey: AutoSaveSetting.defaultsKey)
+
+        XCTAssertEqual(
+            AutoSaveSetting.currentMinutes(from: defaults),
+            AutoSaveSetting.thirtySeconds
+        )
+        XCTAssertEqual(AutoSaveSetting.interval(for: AutoSaveSetting.thirtySeconds), 30)
+    }
+
     private func makeDefaults() throws -> UserDefaults {
         let suiteName = "AutoSaveSettingTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/AutoSaveSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/AutoSaveSettingTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import MarkdownHelpers
+
+final class AutoSaveSettingTests: XCTestCase {
+    func testMissingValueUsesFiveMinutes() throws {
+        let defaults = try makeDefaults()
+
+        XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 5)
+    }
+
+    func testStoredValueIsClampedToSupportedRange() throws {
+        let defaults = try makeDefaults()
+
+        defaults.set(0, forKey: AutoSaveSetting.defaultsKey)
+        XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 1)
+
+        defaults.set(120, forKey: AutoSaveSetting.defaultsKey)
+        XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 60)
+    }
+
+    func testStoreNormalizesValueBeforePersisting() throws {
+        let defaults = try makeDefaults()
+
+        AutoSaveSetting.store(minutes: 0, in: defaults)
+        XCTAssertEqual(defaults.integer(forKey: AutoSaveSetting.defaultsKey), 1)
+
+        AutoSaveSetting.store(minutes: 12, in: defaults)
+        XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 12)
+    }
+
+    private func makeDefaults() throws -> UserDefaults {
+        let suiteName = "AutoSaveSettingTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+}

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/AutoSaveSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/AutoSaveSettingTests.swift
@@ -3,17 +3,23 @@ import XCTest
 @testable import MarkdownHelpers
 
 final class AutoSaveSettingTests: XCTestCase {
-    func testMissingValueUsesFiveMinutes() throws {
+    func testMissingValueDisablesAutomaticSaving() throws {
         let defaults = try makeDefaults()
 
-        XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 5)
+        XCTAssertEqual(
+            AutoSaveSetting.currentMinutes(from: defaults),
+            AutoSaveSetting.disabledMinutes
+        )
     }
 
     func testStoredValueIsClampedToSupportedRange() throws {
         let defaults = try makeDefaults()
 
         defaults.set(0, forKey: AutoSaveSetting.defaultsKey)
-        XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 1)
+        XCTAssertEqual(
+            AutoSaveSetting.currentMinutes(from: defaults),
+            AutoSaveSetting.disabledMinutes
+        )
 
         defaults.set(120, forKey: AutoSaveSetting.defaultsKey)
         XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 60)
@@ -23,7 +29,10 @@ final class AutoSaveSettingTests: XCTestCase {
         let defaults = try makeDefaults()
 
         AutoSaveSetting.store(minutes: 0, in: defaults)
-        XCTAssertEqual(defaults.integer(forKey: AutoSaveSetting.defaultsKey), 1)
+        XCTAssertEqual(
+            defaults.integer(forKey: AutoSaveSetting.defaultsKey),
+            AutoSaveSetting.disabledMinutes
+        )
 
         AutoSaveSetting.store(minutes: 12, in: defaults)
         XCTAssertEqual(AutoSaveSetting.currentMinutes(from: defaults), 12)
@@ -34,7 +43,7 @@ final class AutoSaveSettingTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
         addTeardownBlock {
-            defaults.removePersistentDomain(forName: suiteName)
+            UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
         }
         return defaults
     }


### PR DESCRIPTION
## Summary
Adds configurable automatic saving for edited Markdown documents while reusing the existing save and conflict-handling path.

## Motivation
Users can lose editor changes when they forget to save manually. A bounded, user-controlled interval provides protection without changing the existing explicit-save workflow.

## Changes
- Persist the automatic-save interval in `UserDefaults`, with a 5-minute default and a supported range of 1–60 minutes.
- Add an Automatic Saving control to General Settings and localize the new UI and status text in English and Simplified Chinese.
- Start a per-document timer only for file-backed documents with unsaved editor changes.
- Reuse `commitEdits(exitAfter: false)`, avoid overlapping commits, and stop the timer when there are no unsaved changes or when the window closes.
- Apply interval changes immediately to open document windows.
- Show a quiet secondary title-bar subtitle for the configured interval, successful automatic saves, and failures.
- Add focused tests covering the default value, range clamping, and persistence normalization.

## User impact
Users can choose how often edited documents are saved automatically. Automatic saving does not run for untitled documents or documents without unsaved edits. A failed save leaves the editor dirty and reports the failure in the title bar.

## Validation
- PASS: `swiftc -typecheck md-preview/AutoSaveSetting.swift`
- PASS: `plutil -lint md-preview/en.lproj/Localizable.strings md-preview/zh-Hans.lproj/Localizable.strings`
- PASS: `git diff --check`
- PASS: `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/markdown-preview-auto-save-debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build`
- NOT COMPLETED: `swift test --package-path tests/swift-tests` was attempted, but the GitHub dependency download timed out in the local environment. The temporary package build output was removed; the repository CI workflow should run the complete suite.

## Compatibility and risk
- No document format or migration changes.
- The implementation routes through the existing save/conflict handling, so external-change protection remains centralized.
- The full Swift package test suite is pending CI because of the local dependency-download timeout.

## Rollback
Revert commit `56320a4` or close this PR. The persisted setting is additive and does not require a migration rollback.