### PR TITLE
Add native document picker

### DIFF
--- a/md-preview/App/AppDelegate.swift
+++ b/md-preview/App/AppDelegate.swift
@@ -84,6 +84,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
 
     private var settingsWindowController: SettingsWindowController?
+    private var documentPickerWindowController: DocumentPickerWindowController?
 
     private weak var hideSidebarMenuItem: NSMenuItem?
     private weak var outlineMenuItem: NSMenuItem?
@@ -124,7 +125,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         installViewMenuItemIcons()
         hasFinishedLaunching = true
         if !didReceiveOpenURLsDuringLaunch {
-            scheduleDocumentPrompt(requiresNoDocuments: true)
+            scheduleDocumentPicker(requiresNoDocuments: true)
         }
     }
 
@@ -137,13 +138,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationOpenUntitledFile(_ sender: NSApplication) -> Bool {
-        scheduleDocumentPrompt(requiresNoDocuments: true)
+        scheduleDocumentPicker(requiresNoDocuments: true)
         return true
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !flag {
-            scheduleDocumentPrompt(requiresNoDocuments: true)
+            scheduleDocumentPicker(requiresNoDocuments: true)
             return false
         }
         return true
@@ -177,23 +178,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.showWindowIfNeeded(for: document)
                 self.pendingOpenURLCount -= 1
                 if error != nil {
-                    self.scheduleDocumentPromptIfIdle()
+                    self.scheduleDocumentPickerIfIdle()
                 }
             }
         }
 
         if !malformedSchemeURLs.isEmpty {
             presentUnsupportedSchemeURLAlert(malformedSchemeURLs)
-            scheduleDocumentPromptIfIdle()
+            scheduleDocumentPickerIfIdle()
         }
     }
 
-    /// Re-offers the open panel once every open in the batch has failed —
-    /// without it the app would sit windowless after a bad link or a
-    /// vanished file.
-    private func scheduleDocumentPromptIfIdle() {
+    /// Re-offers the document picker once every open in the batch has failed.
+    private func scheduleDocumentPickerIfIdle() {
         guard pendingOpenURLCount == 0 else { return }
-        scheduleDocumentPrompt(requiresNoDocuments: true)
+        scheduleDocumentPicker(requiresNoDocuments: true)
     }
 
     /// A malformed md-preview:// link tells the reader what shape the app
@@ -404,7 +403,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @IBAction func openDocument(_ sender: Any?) {
+        documentPickerWindowController?.close()
         promptForDocument()
+    }
+
+    @IBAction func newDocument(_ sender: Any?) {
+        documentPickerWindowController?.close()
+        if activeOpenPanel != nil {
+            activeOpenPanel?.cancel(nil)
+            DispatchQueue.main.async { [weak self] in
+                self?.newDocument(nil)
+            }
+            return
+        }
+
+        let document = MarkdownDocument()
+        NSDocumentController.shared.addDocument(document)
+        document.makeWindowControllers()
+        document.showWindows()
+        (document.windowControllers.first as? DocumentWindowController)?.enterEditMode()
     }
 
     @IBAction func performFindPanelAction(_ sender: Any?) {
@@ -499,27 +516,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func promptForDocument() {
         guard !isPromptingForDocument else { return }
         isPromptingForDocument = true
-        defer { isPromptingForDocument = false }
 
         let panel = makeOpenPanel()
         activeOpenPanel = panel
-        defer { activeOpenPanel = nil }
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        if url.isExistingDirectory {
-            openFolder(url)
-            return
-        }
+        panel.begin { [weak self] response in
+            guard let self else { return }
+            self.activeOpenPanel = nil
+            self.isPromptingForDocument = false
+            guard response == .OK, let url = panel.url else { return }
+            if url.isExistingDirectory {
+                self.openFolder(url)
+                return
+            }
 
-        isOpeningDocumentFromPrompt = true
-        NSDocumentController.shared.openDocument(withContentsOf: url,
-                                                 display: true) { [weak self] _, _, error in
-            self?.isOpeningDocumentFromPrompt = false
-            guard let error else { return }
-            NSAlert(error: error).runModal()
+            self.isOpeningDocumentFromPrompt = true
+            NSDocumentController.shared.openDocument(withContentsOf: url,
+                                                     display: true) { [weak self] _, _, error in
+                self?.isOpeningDocumentFromPrompt = false
+                guard let error else { return }
+                NSAlert(error: error).runModal()
+            }
         }
     }
 
-    private func scheduleDocumentPrompt(requiresNoDocuments: Bool = false) {
+    private func scheduleDocumentPicker(requiresNoDocuments: Bool = false) {
         guard !isPromptingForDocument,
               !isDocumentPromptScheduled else { return }
 
@@ -532,8 +552,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.isDocumentPromptScheduled = false
             guard !requiresNoDocuments || NSDocumentController.shared.documents.isEmpty else { return }
             NSApp.activate(ignoringOtherApps: true)
-            self.promptForDocument()
+            self.showDocumentPicker()
         }
+    }
+
+    private func showDocumentPicker() {
+        let controller = documentPickerWindowController ?? DocumentPickerWindowController(
+            onNewDocument: { [weak self] in self?.newDocument(nil) },
+            onOpenDocument: { [weak self] in self?.promptForDocument() },
+            onDismiss: { [weak self] in self?.documentPickerWindowController = nil }
+        )
+        documentPickerWindowController = controller
+        controller.show()
     }
 
     private func cancelScheduledDocumentPrompt() {

--- a/md-preview/App/DocumentPickerWindowController.swift
+++ b/md-preview/App/DocumentPickerWindowController.swift
@@ -1,0 +1,136 @@
+//
+//  DocumentPickerWindowController.swift
+//  md-preview
+//
+
+import Cocoa
+
+final class DocumentPickerWindowController: NSWindowController, NSWindowDelegate {
+    private let onNewDocument: () -> Void
+    private let onOpenDocument: () -> Void
+    private let onDismiss: () -> Void
+
+    init(
+        onNewDocument: @escaping () -> Void,
+        onOpenDocument: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.onNewDocument = onNewDocument
+        self.onOpenDocument = onOpenDocument
+        self.onDismiss = onDismiss
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 310),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = NSLocalizedString("Markdown Preview", comment: "Document picker title")
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+
+        super.init(window: window)
+        window.contentView = Self.makeContentView(target: self)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        window?.center()
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onDismiss()
+    }
+
+    @objc private func createNewDocument(_ sender: Any?) {
+        window?.close()
+        onNewDocument()
+    }
+
+    @objc private func openExistingDocument(_ sender: Any?) {
+        window?.close()
+        onOpenDocument()
+    }
+
+    private static func makeContentView(target: DocumentPickerWindowController) -> NSView {
+        let icon = NSImageView()
+        icon.image = NSApp.applicationIconImage
+        icon.imageScaling = .scaleProportionallyUpOrDown
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.widthAnchor.constraint(equalToConstant: 52).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: 52).isActive = true
+
+        let title = NSTextField(labelWithString: NSLocalizedString(
+            "Markdown Preview",
+            comment: "Document picker heading"
+        ))
+        title.font = .systemFont(ofSize: 22, weight: .semibold)
+        title.alignment = .center
+
+        let message = NSTextField(wrappingLabelWithString: NSLocalizedString(
+            "Create a Markdown document or open an existing file.",
+            comment: "Document picker message"
+        ))
+        message.alignment = .center
+        message.textColor = .secondaryLabelColor
+        message.maximumNumberOfLines = 2
+
+        let newDocument = NSButton(frame: .zero)
+        newDocument.title = NSLocalizedString("New Document", comment: "Document picker new button")
+        newDocument.target = target
+        newDocument.action = #selector(createNewDocument(_:))
+        newDocument.keyEquivalent = "\r"
+        newDocument.image = NSImage(
+            systemSymbolName: "square.and.pencil",
+            accessibilityDescription: newDocument.title
+        )
+        newDocument.imagePosition = .imageLeading
+        newDocument.bezelStyle = .rounded
+        newDocument.controlSize = .large
+
+        let openDocument = NSButton(frame: .zero)
+        openDocument.title = NSLocalizedString("Open Existing…", comment: "Document picker open button")
+        openDocument.target = target
+        openDocument.action = #selector(openExistingDocument(_:))
+        openDocument.image = NSImage(
+            systemSymbolName: "folder",
+            accessibilityDescription: openDocument.title
+        )
+        openDocument.imagePosition = .imageLeading
+        openDocument.bezelStyle = .rounded
+        openDocument.controlSize = .large
+
+        let buttons = NSStackView(views: [newDocument, openDocument])
+        buttons.orientation = .vertical
+        buttons.alignment = .centerX
+        buttons.spacing = 8
+
+        let stack = NSStackView(views: [icon, title, message, buttons])
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 10
+        stack.setCustomSpacing(16, after: message)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let contentView = NSView()
+        contentView.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 36),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -36),
+            stack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 4),
+            newDocument.widthAnchor.constraint(equalToConstant: 176),
+            openDocument.widthAnchor.constraint(equalTo: newDocument.widthAnchor),
+        ])
+        return contentView
+    }
+}

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -80,7 +80,7 @@
                         <items>
                             <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
                                 <connections>
-                                    <action selector="newDocument:" target="-1" id="4Si-XN-c54"/>
+                                    <action selector="newDocument:" target="Voe-Tx-rLC" id="4Si-XN-c54"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">

--- a/md-preview/Document/DocumentWindowController+DocumentOpening.swift
+++ b/md-preview/Document/DocumentWindowController+DocumentOpening.swift
@@ -199,11 +199,12 @@ extension DocumentWindowController {
         NSAlert(error: error).beginSheetModal(for: documentWindow)
     }
 
-    func renderCurrentDocument(text: String, fileURL: URL) {
+    func renderCurrentDocument(text: String, fileURL: URL?) {
         (documentWindow.contentViewController as? MainSplitViewController)?
             .display(markdown: text,
-                     fileName: fileURL.lastPathComponent,
+                     fileName: fileURL?.lastPathComponent
+                         ?? NSLocalizedString("Untitled", comment: "Untitled document name"),
                      url: fileURL,
-                     assetBaseURL: fileURL.deletingLastPathComponent())
+                     assetBaseURL: fileURL?.deletingLastPathComponent())
     }
 }

--- a/md-preview/Document/DocumentWindowController+EditMode.swift
+++ b/md-preview/Document/DocumentWindowController+EditMode.swift
@@ -19,7 +19,7 @@ extension DocumentWindowController {
     }
 
     var canToggleEditMode: Bool {
-        isEditing || (currentFileURL != nil && currentMarkdown != nil)
+        isEditing || currentMarkdown != nil
     }
 
     var canFormatMarkdown: Bool { isEditing }
@@ -85,7 +85,7 @@ extension DocumentWindowController {
             ? NSLocalizedString("Stop editing and return to preview", comment: "Edit toolbar item tooltip while editing")
             : NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
         editButton?.toolTip = editItem?.toolTip
-        editButton?.isEnabled = editing || (currentFileURL != nil && currentMarkdown != nil)
+        editButton?.isEnabled = editing || currentMarkdown != nil
     }
 
     @objc private func toggleEditAction(_ sender: Any?) {

--- a/md-preview/Document/DocumentWindowController+EditSession.swift
+++ b/md-preview/Document/DocumentWindowController+EditSession.swift
@@ -6,11 +6,11 @@
 //
 
 import Cocoa
+import UniformTypeIdentifiers
 
 extension DocumentWindowController {
     func enterEditMode() {
         guard let split = mainSplit, !split.isEditingDocument,
-              currentFileURL != nil,
               let markdown = editorDraftMarkdown ?? currentMarkdown else {
             NSSound.beep()
             return
@@ -43,7 +43,7 @@ extension DocumentWindowController {
     func previewPendingEdits() {
         guard let split = mainSplit, let editor = split.editorViewController else { return }
         editor.fetchMarkdown { [weak self] markdown in
-            guard let self, let markdown, let url = self.currentFileURL else {
+            guard let self, let markdown else {
                 NSSound.beep()
                 return
             }
@@ -54,7 +54,11 @@ extension DocumentWindowController {
                 self.editorDraftMarkdown = nil
                 self.editorBaselineMarkdown = nil
             }
-            self.markdownDocument?.replaceContents(markdown: markdown, fileURL: url)
+            if let url = self.currentFileURL {
+                self.markdownDocument?.replaceContents(markdown: markdown, fileURL: url)
+            } else {
+                self.markdownDocument?.replaceContents(markdown: markdown)
+            }
             // exitEditMode(rerender: true) renders the pending markdown once
             // the editor's scroll anchor has been captured; rendering here as
             // well raced the anchor hand-off and re-laid the preview out
@@ -65,6 +69,44 @@ extension DocumentWindowController {
             self.exitEditMode(rerender: true,
                               preserveUnsavedChanges: true,
                               hidesAccessoryAfterFade: true) {}
+        }
+    }
+
+    private func saveUntitledMarkdown(
+        _ text: String,
+        completion: @escaping (EditedMarkdownSaveResult) -> Void
+    ) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
+        panel.allowsOtherFileTypes = false
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = "Untitled.md"
+        panel.message = NSLocalizedString(
+            "Choose a name and location for the new Markdown file.",
+            comment: "New Markdown file panel prompt"
+        )
+        panel.prompt = NSLocalizedString("Save", comment: "Untitled Markdown file save panel button")
+        panel.beginSheetModal(for: documentWindow) { [weak self] response in
+            guard let self, response == .OK, let url = panel.url else {
+                completion(.cancelled)
+                return
+            }
+            guard self.write(text, to: url) else {
+                completion(.cancelled)
+                return
+            }
+
+            self.currentFileURL = url
+            self.documentWindow.title = url.lastPathComponent
+            self.markdownDocument?.replaceContents(markdown: text, fileURL: url)
+            self.resetAutoSaveFeedback()
+            self.refreshOpenWithItem()
+            self.refreshOpenInLLMItem()
+            self.refreshOpenActionsItem()
+            self.updateEditToolbarItem()
+            self.startWatching(url)
+            NSDocumentController.shared.noteNewRecentDocumentURL(url)
+            completion(.saved)
         }
     }
 
@@ -220,6 +262,17 @@ extension DocumentWindowController {
                                             revision: Int? = nil,
                                             exitAfter: Bool) {
         isEditorCommitInFlight = true
+        if currentFileURL == nil {
+            saveUntitledMarkdown(body) { result in
+                self.handleEditedMarkdownSaveResult(result,
+                                                    body: body,
+                                                    editor: editor,
+                                                    revision: revision,
+                                                    exitAfter: exitAfter)
+            }
+            return
+        }
+
         let baseline = editorBaselineMarkdown ?? currentMarkdown
         let diskState = diskFileState(for: currentFileURL,
                                       expectedMarkdown: baseline)
@@ -385,8 +438,8 @@ extension DocumentWindowController {
             if self.editAccessory == nil {
                 self.updateEditToolbarItem()
             }
-            if rerender, let url = self.currentFileURL, let markdown = self.currentMarkdown {
-                self.renderCurrentDocument(text: markdown, fileURL: url)
+            if rerender, let markdown = self.currentMarkdown {
+                self.renderCurrentDocument(text: markdown, fileURL: self.currentFileURL)
             }
             completion()
         }

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -515,7 +515,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         return components.url ?? url
     }
 
-    private func startWatching(_ url: URL) {
+    func startWatching(_ url: URL) {
         fileWatcher?.cancel()
         let watcher = FileWatcher(url: url) { [weak self] in
             // While editing, disk changes (including our own ⌘S writes)

--- a/md-preview/Document/MarkdownDocument.swift
+++ b/md-preview/Document/MarkdownDocument.swift
@@ -88,6 +88,11 @@ final class MarkdownDocument: NSDocument {
         replaceFileURL(fileURL)
     }
 
+    func replaceContents(markdown: String) {
+        markdownStorage.withLock { $0 = markdown }
+        updateChangeCount(.changeCleared)
+    }
+
     func replaceFileURL(_ fileURL: URL) {
         self.fileURL = fileURL
         updateChangeCount(.changeCleared)

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -79,6 +79,12 @@
 
 /* File menu */
 "New Tab" = "New Tab";
+"Choose a name and location for the new Markdown file." = "Choose a name and location for the new Markdown file.";
+
+/* Document picker */
+"Create a Markdown document or open an existing file." = "Create a Markdown document or open an existing file.";
+"New Document" = "New Document";
+"Open Existing…" = "Open Existing…";
 
 /* Print panel */
 "Font Size:" = "Font Size:";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -79,6 +79,12 @@
 
 /* File menu */
 "New Tab" = "新建标签页";
+"Choose a name and location for the new Markdown file." = "为新的 Markdown 文件选择名称和位置。";
+
+/* Document picker */
+"Create a Markdown document or open an existing file." = "创建 Markdown 文稿或打开现有文件。";
+"New Document" = "新建文稿";
+"Open Existing…" = "打开现有文件…";
 
 /* Print panel */
 "Font Size:" = "字体大小：";


### PR DESCRIPTION
## Summary

- Add a native document picker with **New Document** and **Open Existing…** actions.
- Open new Markdown files as editable untitled documents and use the native save panel on first save.
- Make **New Document** the native default action.

## Validation

- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `swift test --package-path tests/swift-tests` (210 passed, 1 skipped)
