### PR TITLE
Fix centered preview gutter scrolling and toolbar seam

### DIFF
--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -18,6 +18,8 @@ final class ContentViewController: NSViewController {
     private static let pageZoomDefaultsKey = TextSizeSetting.defaultsKey
 
     private var webView: MarkdownWebView!
+    private var toolbarGutterView: PreviewToolbarGutterView!
+    private var toolbarGutterHeightConstraint: NSLayoutConstraint?
     private var webViewCenteredLeadingConstraint: NSLayoutConstraint?
     private var webViewCenteredConstraints: [NSLayoutConstraint] = []
     private var webViewFullWidthConstraints: [NSLayoutConstraint] = []
@@ -119,6 +121,13 @@ final class ContentViewController: NSViewController {
         }
         webView.enablePersistentZoom(defaultsKey: Self.pageZoomDefaultsKey)
 
+        // The WKWebView paints its obscured toolbar strip with
+        // underPageBackgroundColor. In centered mode the native gutter to
+        // its left would otherwise expose the document background there,
+        // producing a sharp color change at the web view's leading edge.
+        toolbarGutterView = PreviewToolbarGutterView()
+        toolbarGutterView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(toolbarGutterView)
         container.addSubview(webView)
         // In normal-width mode the web view starts at the centered article's
         // leading edge, leaving a native gutter between it and the split-view
@@ -156,6 +165,15 @@ final class ContentViewController: NSViewController {
         webViewFullWidthConstraints = [
             webView.leadingAnchor.constraint(equalTo: container.leadingAnchor)
         ]
+
+        let toolbarGutterHeight = toolbarGutterView.heightAnchor.constraint(equalToConstant: 0)
+        toolbarGutterHeightConstraint = toolbarGutterHeight
+        NSLayoutConstraint.activate([
+            toolbarGutterView.topAnchor.constraint(equalTo: container.topAnchor),
+            toolbarGutterView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            toolbarGutterView.trailingAnchor.constraint(equalTo: webView.leadingAnchor),
+            toolbarGutterHeight,
+        ])
 
         // Keep the WKWebView viewport-sized and let WebKit own vertical
         // scrolling. Expanding it to the full document height creates an
@@ -352,6 +370,7 @@ final class ContentViewController: NSViewController {
 
     func applyThemeColors() {
         view.needsDisplay = true
+        toolbarGutterView.needsDisplay = true
         updateUnderPageBackgroundColor()
         updateObscuredContentInsets()
         webView.applyThemeColors()
@@ -413,13 +432,19 @@ final class ContentViewController: NSViewController {
     }
 
     private func updateObscuredContentInsets() {
-        guard #available(macOS 26.0, *) else { return }
+        guard #available(macOS 26.0, *) else {
+            toolbarGutterHeightConstraint?.constant = 0
+            return
+        }
         // Theme-independent, and never 0: WebKit adopts the titlebar inset
         // automatically on macOS 26 and an explicit 0 stomps that for the
         // web view's lifetime — the page then collides with the toolbar
         // until the window is recreated. Keeping the explicit value equal
         // to the chrome strip matches the automatic behavior exactly.
         let inset = obscuredTopInset
+        if toolbarGutterHeightConstraint?.constant != inset {
+            toolbarGutterHeightConstraint?.constant = inset
+        }
         guard view.window != nil, inset > 0 else { return }
         if webView.webView.obscuredContentInsets.top != inset {
             webView.webView.obscuredContentInsets = NSEdgeInsets(
@@ -633,6 +658,37 @@ final class ContentViewController: NSViewController {
             if offset <= activationLine { active = index } else { break }
         }
         return active
+    }
+}
+
+/// Continues WebKit's obscured toolbar backing across the native gutter that
+/// centered mode leaves to the web view's left. Its height is kept in sync
+/// with `WKWebView.obscuredContentInsets`; full-width mode naturally reduces
+/// its width to zero.
+private final class PreviewToolbarGutterView: NSView {
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+    }
+
+    override var wantsUpdateLayer: Bool { true }
+
+    /// Purely visual: keep native toolbar hit-testing and window dragging
+    /// unchanged in the strip this view paints beneath.
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func updateLayer() {
+        let isDark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let color = ThemeColorsSetting.current.color(
+            .windowBackground, isDark ? .dark : .light
+        ) ?? .windowBackgroundColor
+        layer?.backgroundColor = color.cgColor
     }
 }
 

--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -120,6 +120,10 @@ final class ContentViewController: NSViewController {
         webView.enablePersistentZoom(defaultsKey: Self.pageZoomDefaultsKey)
 
         container.addSubview(webView)
+        // In normal-width mode the web view starts at the centered article's
+        // leading edge, leaving a native gutter between it and the split-view
+        // divider. Keep that gutter part of the page's scrolling surface.
+        container.scrollWheelTarget = webView.webView
 
 
         // Normal (centered) mode positions the web view in AppKit rather
@@ -644,6 +648,8 @@ final class ContentViewController: NSViewController {
 /// reads as a page.
 private final class DocumentBackgroundView: NSView {
 
+    weak var scrollWheelTarget: NSView?
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
@@ -670,5 +676,13 @@ private final class DocumentBackgroundView: NSView {
             return
         }
         layer?.backgroundColor = isDark ? nil : NSColor.white.cgColor
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let scrollWheelTarget else {
+            super.scrollWheel(with: event)
+            return
+        }
+        scrollWheelTarget.scrollWheel(with: event)
     }
 }


### PR DESCRIPTION
## Summary

- Forward scroll-wheel events from the native left gutter to the Markdown web view.
- Continue the WebKit toolbar backing color across that gutter, removing the visible seam at the leading edge of the web view.
- Preserve the centered AppKit layout and the native scrollbar at the window edge.

## Root cause

In Normal content-width mode, the `WKWebView` starts at the leading edge of the centered article column and extends to the right edge of the preview. The space between the sidebar and the article is therefore a native `DocumentBackgroundView`, while the text and right gutter belong to WebKit.

That produced two inconsistencies in the native left gutter:

1. Wheel gestures stopped there instead of reaching the document.
2. Beneath the toolbar it showed the document background, while the obscured toolbar strip in WebKit used its `underPageBackgroundColor`.

## Fix

- `DocumentBackgroundView` keeps a weak reference to the underlying `WKWebView` and forwards wheel events from the uncovered gutter.
- A non-interactive `PreviewToolbarGutterView` fills only the native gutter beneath the obscured toolbar and follows the active theme window background.
- The visual gutter returns `nil` from hit testing, preserving toolbar interaction and window dragging.
- In Full Width mode its width naturally collapses to zero.

## Validation

- `swift test --package-path tests/swift-tests` — 210 tests executed, 1 skipped, 0 failures.
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/markdown-preview-derived-system -scmProvider system CODE_SIGNING_ALLOWED=NO build` — succeeded.
- Manually verified scrolling over the text, right gutter, and previously inactive left gutter.
- Manually verified the toolbar in windowed and fullscreen dark mode. In the windowed screenshot, both sides of the former boundary measured RGB `30,30,30` beneath the toolbar and `41,41,41` in the document area.