### PR TITLE
Fix escaped brackets in Markdown links

### DIFF
--- a/md-preview/Rendering/MarkdownHTML+Math.swift
+++ b/md-preview/Rendering/MarkdownHTML+Math.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Markdown
 
 // `nonisolated` matters: the targets default to MainActor isolation, and
 // rendering runs off the main actor.
@@ -32,6 +33,11 @@ nonisolated extension MarkdownHTML {
     private static let bracketedBlockMathRegex: NSRegularExpression = {
         // swiftlint:disable:next force_try
         try! NSRegularExpression(pattern: #"(?<!\\)\\\[([\s\S]+?)\\\]"#)
+    }()
+
+    private static let singleBackslashBracketRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"(?<!\\)\\(?:\[|\])"#)
     }()
 
     // Markdown authors sometimes double the delimiter backslashes so the
@@ -78,13 +84,21 @@ nonisolated extension MarkdownHTML {
         var inlines: [String] = []
         var protected: [String] = []
 
-        let nsMarkdown = markdown as NSString
-        let fenceMatches = codeFenceRegex.matches(
+        // In a valid Markdown link label, `\[` and `\]` are bracket escapes,
+        // not display-math delimiters. Protect those ranges before the math
+        // pass, then restore them for swift-markdown to parse normally.
+        let afterLinkLabels = protectEscapedBracketsInLinks(
             in: markdown,
+            protected: &protected
+        )
+
+        let nsMarkdown = afterLinkLabels as NSString
+        let fenceMatches = codeFenceRegex.matches(
+            in: afterLinkLabels,
             range: NSRange(location: 0, length: nsMarkdown.length)
         )
         var afterFences = ""
-        afterFences.reserveCapacity(markdown.count)
+        afterFences.reserveCapacity(afterLinkLabels.count)
         var fenceCursor = 0
         for match in fenceMatches {
             afterFences += nsMarkdown.substring(with: NSRange(
@@ -192,6 +206,41 @@ nonisolated extension MarkdownHTML {
         )
     }
 
+    private static func protectEscapedBracketsInLinks(
+        in markdown: String,
+        protected: inout [String]
+    ) -> String {
+        let nsMarkdown = markdown as NSString
+        let fullRange = NSRange(location: 0, length: nsMarkdown.length)
+        let candidates = singleBackslashBracketRegex.matches(in: markdown, range: fullRange)
+        guard !candidates.isEmpty else { return markdown }
+
+        var collector = MarkdownLinkRangeCollector(source: markdown)
+        collector.visit(Document(parsing: markdown))
+        let matches = candidates.filter { candidate in
+            collector.ranges.contains { linkRange in
+                candidate.range.location >= linkRange.location
+                    && NSMaxRange(candidate.range) <= NSMaxRange(linkRange)
+            }
+        }
+        guard !matches.isEmpty else { return markdown }
+
+        var result = ""
+        result.reserveCapacity(markdown.count)
+        var cursor = 0
+        for match in matches where match.range.location >= cursor {
+            result += nsMarkdown.substring(with: NSRange(
+                location: cursor,
+                length: match.range.location - cursor
+            ))
+            protected.append(nsMarkdown.substring(with: match.range))
+            result += "MdPreviewProtect\(protected.count - 1)Token"
+            cursor = match.range.location + match.range.length
+        }
+        result += nsMarkdown.substring(from: cursor)
+        return result
+    }
+
     static func renderMathBlocks(in html: String,
                                          with math: MathExtraction) -> MathRenderResult {
         guard !math.blocks.isEmpty || !math.inlines.isEmpty else {
@@ -249,5 +298,41 @@ nonisolated extension MarkdownHTML {
             with: "data-source-end=\"\(end)\"",
             options: .regularExpression
         )
+    }
+}
+
+nonisolated private struct MarkdownLinkRangeCollector: MarkupWalker {
+    let source: String
+    private let lineStartOffsets: [Int]
+    private(set) var ranges: [NSRange] = []
+
+    init(source: String) {
+        self.source = source
+        var offsets = [0]
+        for (offset, byte) in source.utf8.enumerated() where byte == 0x0A {
+            offsets.append(offset + 1)
+        }
+        lineStartOffsets = offsets
+    }
+
+    mutating func visitLink(_ link: Link) {
+        guard let sourceRange = link.range,
+              let lower = index(for: sourceRange.lowerBound),
+              let upper = index(for: sourceRange.upperBound),
+              lower <= upper else { return }
+        ranges.append(NSRange(lower..<upper, in: source))
+    }
+
+    private func index(for location: SourceLocation) -> String.Index? {
+        guard location.line > 0,
+              location.line <= lineStartOffsets.count,
+              location.column > 0 else { return nil }
+        let offset = lineStartOffsets[location.line - 1] + location.column - 1
+        guard let utf8Index = source.utf8.index(
+            source.utf8.startIndex,
+            offsetBy: offset,
+            limitedBy: source.utf8.endIndex
+        ) else { return nil }
+        return String.Index(utf8Index, within: source)
     }
 }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -1786,6 +1786,65 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         )
     }
 
+    func testEscapedBracketsInLinkTextRemainLinkText() {
+        let rendered = MarkdownHTML.render(
+            markdown: #"""
+            Citation [\[4\]][source].
+            Related [see \[5\] for context](https://example.com/related).
+
+            [source]: https://example.com
+            """#,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertFalse(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"Citation <a href="https://example.com">[4]</a>."#
+        ), rendered.articleHTML)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"Related <a href="https://example.com/related">see [5] for context</a>."#
+        ), rendered.articleHTML)
+        XCTAssertFalse(rendered.articleHTML.contains("class=\"math"))
+    }
+
+    func testEscapedLinkBracketsDoNotHideAdjacentDisplayMath() {
+        let rendered = MarkdownHTML.render(
+            markdown: #"""
+            Résumé ✨ [\[4\]][source].
+
+            \[
+            x^2
+            \]
+
+            [source]: https://example.com
+            """#,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertTrue(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"Résumé ✨ <a href="https://example.com">[4]</a>."#
+        ), rendered.articleHTML)
+        XCTAssertEqual(
+            rendered.articleHTML.components(separatedBy: "class=\"math math-display\"").count - 1,
+            1
+        )
+        XCTAssertTrue(rendered.articleHTML.contains("class=\"math math-display\">\nx^2\n</div>"))
+    }
+
+    func testEscapedBracketsInSeparateLinksCannotPairAsDisplayMath() {
+        let rendered = MarkdownHTML.render(
+            markdown: #"[open \[](https://a.example) prose [close \]](https://b.example)"#,
+            vendorLoading: .lazy
+        )
+
+        XCTAssertFalse(rendered.containsMath)
+        XCTAssertTrue(rendered.articleHTML.contains(
+            #"<a href="https://a.example">open [</a> prose <a href="https://b.example">close ]</a>"#
+        ), rendered.articleHTML)
+        XCTAssertFalse(rendered.articleHTML.contains("class=\"math"))
+    }
+
     func testLatexDelimitersInsideCodeRemainLiteral() {
         let rendered = MarkdownHTML.render(
             markdown: #"""


### PR DESCRIPTION
## Summary

- preserve escaped square brackets inside valid Markdown links before the math extraction pass
- prevent bracket escapes in separate links from pairing into a display-math block
- keep standalone and Markdown-escaped LaTeX delimiters working as before
- add renderer regressions for reference links, inline links, UTF-8 source ranges, and adjacent display math

## Validation

- `swift test --package-path tests/swift-tests` (233 tests, 1 skipped)
- `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath /tmp/md-preview-issue-322-build CODE_SIGNING_ALLOWED=NO build`
- exact Debug app runtime check: `[4]` renders as a clickable link while adjacent `x^2` still renders as display math
- `git diff --check origin/main...HEAD`

Fixes #322
