### PR TITLE
Restore the grouped document toolbar actions

### DIFF
--- a/md-preview/Document/DocumentWindowController+EditMode.swift
+++ b/md-preview/Document/DocumentWindowController+EditMode.swift
@@ -41,26 +41,19 @@ extension DocumentWindowController {
         requestEndEditing(completion: completion)
     }
 
-    func makeEditItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
+    func makeEditSubitem() -> NSToolbarItem {
         let edit = NSLocalizedString("Edit", comment: "Edit toolbar item label")
         let image = NSImage(systemSymbolName: "highlighter",
                             accessibilityDescription: edit) ?? NSImage()
         image.isTemplate = true
 
-        let item = NSToolbarItemGroup(itemIdentifier: .editDocument,
-                                      images: [image],
-                                      selectionMode: .selectAny,
-                                      labels: [edit],
-                                      target: self,
-                                      action: #selector(toggleEditAction(_:)))
+        let item = NSToolbarItem(itemIdentifier: .editDocument)
         item.label = edit
-        item.paletteLabel = edit
+        item.toolTip = NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
+        item.image = image
+        item.target = self
+        item.action = #selector(toggleEditAction(_:))
         item.autovalidates = false
-
-        if willBeInsertedIntoToolbar {
-            editItem = item
-        }
-        applyEditToolbarState(to: item)
         return item
     }
 
@@ -69,14 +62,14 @@ extension DocumentWindowController {
         applyEditToolbarState(to: editItem)
     }
 
-    private func applyEditToolbarState(to item: NSToolbarItemGroup) {
+    func applyEditToolbarState(to item: NSToolbarItemGroup) {
         let editing = isEditing
-        item.setSelected(editing, at: 0)
-        item.toolTip = editing
+        item.setSelected(editing, at: 2)
+        let toolTip = editing
             ? NSLocalizedString("Stop editing and return to preview", comment: "Edit toolbar item tooltip while editing")
             : NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
-        item.subitems.first?.toolTip = item.toolTip
-        item.isEnabled = editing || currentMarkdown != nil
+        item.subitems[2].toolTip = toolTip
+        item.subitems[2].isEnabled = editing || currentMarkdown != nil
     }
 
     @objc private func toggleEditAction(_ sender: Any?) {

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -44,11 +44,8 @@ extension DocumentWindowController {
             .navigation,
             .flexibleSpace,
             .openActions,
-            .space,
             .zoom,
             .inspector,
-            .share,
-            .editDocument,
             .search
         ]
     }
@@ -62,9 +59,7 @@ extension DocumentWindowController {
             .space,
             .openActions,
             .openWith,
-            .editDocument,
             .inspector,
-            .share,
             .search,
             .printDocument,
             .exportPDF,
@@ -90,10 +85,10 @@ extension DocumentWindowController {
         case .openInLLM:
             guard hasLLMTargetsAvailable else { return nil }
             return makeOpenInLLMItem()
-        case .editDocument: return makeEditItem(willBeInsertedIntoToolbar: flag)
+        case .editDocument: return nil
         case .inspector: return makeInspectorItem(willBeInsertedIntoToolbar: flag)
         case .alwaysOnTop: return makeAlwaysOnTopItem(willBeInsertedIntoToolbar: flag)
-        case .share: return makeShareItem()
+        case .share: return nil
         case .search: return makeSearchItem()
         case .printDocument: return makePrintItem()
         case .exportPDF: return makeExportPDFItem()
@@ -161,22 +156,31 @@ extension DocumentWindowController {
     }
 
     private func makeInspectorItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
-        let item = NSToolbarItemGroup(itemIdentifier: .inspector,
-                                      images: [inspectorImage()],
-                                      selectionMode: .selectAny,
-                                      labels: [NSLocalizedString("Inspector", comment: "Inspector toolbar item label")],
-                                      target: self,
-                                      action: #selector(toggleInspectorAction(_:)))
+        let inspector = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
+        let inspectorButton = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier("Inspector.Toggle"))
+        inspectorButton.label = inspector
+        inspectorButton.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
+        inspectorButton.image = inspectorImage()
+        inspectorButton.target = self
+        inspectorButton.action = #selector(toggleInspectorAction(_:))
+
+        // Keep the real sharing toolbar item so AppKit can present its picker
+        // on mouse-down, while grouping all three actions into one native unit.
+        let item = NSToolbarItemGroup(itemIdentifier: .inspector)
         item.label = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
         item.paletteLabel = NSLocalizedString("Get Info", comment: "Inspector toolbar palette label")
-        item.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
-        item.subitems.first?.toolTip = item.toolTip
+        item.subitems = [inspectorButton, makeShareItem(), makeEditSubitem()]
+        item.controlRepresentation = .expanded
+        item.selectionMode = .selectAny
 
         if willBeInsertedIntoToolbar {
             inspectorItem = item
+            editItem = item
             refreshInspectorToggleItem()
+            updateEditToolbarItem()
         } else {
             item.setSelected(isInspectorToggleSelected, at: 0)
+            applyEditToolbarState(to: item)
         }
         return item
     }


### PR DESCRIPTION
## Summary

- restore Inspector, Share, and Edit as one native AppKit toolbar group
- keep the real sharing picker toolbar item so the Share popover still opens correctly
- remove the explicit fixed spacer between Open and Zoom in the default toolbar
- prevent the former standalone Share and Edit items from duplicating saved default layouts

## Verification

- `swift test --package-path tests/swift-tests` (233 tests, 1 skipped, 0 failures)
- unsigned Debug app build with `xcodebuild`
- launched the exact built app and verified Inspector toggles, Share opens its picker, Edit enters edit mode, the three actions render as one group, and Open/Zoom no longer have the explicit spacer