### PR TITLE
Require macOS 26 for themed titlebar chrome

### DIFF
--- a/md-preview/Document/DocumentWindowController+Find.swift
+++ b/md-preview/Document/DocumentWindowController+Find.swift
@@ -86,7 +86,7 @@ extension DocumentWindowController {
             // Visible bar always gets the hard backdrop; hidden, the
             // preference must not leak a backdrop over a themed titlebar.
             accessory.preferredScrollEdgeEffectStyle =
-                visible || !activeSchemeThemed ? .hard : .automatic
+                visible || !usesThemedChrome ? .hard : .automatic
         }
     }
 

--- a/md-preview/Document/DocumentWindowController+FormattingBar.swift
+++ b/md-preview/Document/DocumentWindowController+FormattingBar.swift
@@ -111,7 +111,7 @@ extension DocumentWindowController {
             hairline.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             hairline.bottomAnchor.constraint(equalTo: container.bottomAnchor),
         ])
-        hairline.isHidden = !activeSchemeThemed
+        hairline.isHidden = !usesThemedChrome
         editAccessoryHairline = hairline
 
         let accessory = NSTitlebarAccessoryViewController()
@@ -125,7 +125,7 @@ extension DocumentWindowController {
         // used instead.
         if #available(macOS 26.1, *) {
             accessory.preferredScrollEdgeEffectStyle =
-                activeSchemeThemed ? .automatic : .hard
+                usesThemedChrome ? .automatic : .hard
         }
         documentWindow.addTitlebarAccessoryViewController(accessory)
         editAccessory = accessory

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -221,11 +221,21 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         mainSplit?.applyThemeColors()
     }
 
-    /// Whether the ACTIVE appearance scheme has a window background
-    /// override. Chrome suppression without a matching tint exposes the
-    /// stock fills, so every chrome treatment gates on this, not on
-    /// "either scheme customized".
-    var activeSchemeThemed: Bool {
+    /// Whether this window wears the themed chrome: a window background
+    /// override on the ACTIVE appearance scheme, and an OS that can
+    /// complete the recipe. Chrome suppression without a matching tint
+    /// exposes the stock fills, so every chrome treatment gates on this —
+    /// not on "either scheme customized", and not on theme state alone.
+    ///
+    /// The macOS 26 floor is not a preference. The transparent titlebar
+    /// only reads correctly because WebKit is told which strip the toolbar
+    /// obscures, and `WKWebView.obscuredContentInsets` is macOS 26.0+ — so
+    /// pre-Tahoe the page would run under an unlined toolbar with no inset
+    /// and no frost. The chrome stays native there, the same retreat full
+    /// screen makes below. Keep this version in step with the gate in
+    /// `ContentViewController.updateObscuredContentInsets()`.
+    var usesThemedChrome: Bool {
+        guard #available(macOS 26.0, *) else { return false }
         let isDark = documentWindow.effectiveAppearance
             .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         return ThemeColorsSetting.current
@@ -255,7 +265,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                 .windowBackground, isDark ? .dark : .light
             ) ?? .windowBackgroundColor
         }
-        let themed = activeSchemeThemed
+        let themed = usesThemedChrome
             && !documentWindow.styleMask.contains(.fullScreen)
         // A hidden accessory's scroll-edge preference still drives the
         // titlebar backdrop, so the find bar's .hard must follow the theme


### PR DESCRIPTION
## Summary

Theme colors give the document window a transparent titlebar and let the page run underneath it, with a frosted toolbar strip on top. That recipe only holds together because WebKit is told which strip the toolbar obscures, and `WKWebView.obscuredContentInsets` is macOS 26.0+.

On macOS 15 there is no such API and no frost, so the same code path leaves the page running under an opaque, unlined toolbar. `activeSchemeThemed` gated only on "does the active appearance scheme have a window background override", never on whether the OS could complete the recipe.

This gates it on both. Pre-Tahoe windows keep native chrome — the same retreat the code already makes in full screen.

## What changed

`activeSchemeThemed` becomes `usesThemedChrome` and takes a `#available(macOS 26.0, *)` guard:

```swift
var usesThemedChrome: Bool {
    guard #available(macOS 26.0, *) else { return false }
    ...
}
```

The two call sites in `DocumentWindowController+Find.swift` and `DocumentWindowController+FormattingBar.swift` follow the rename. The rename is the point rather than tidying: the old name described theme state, and the property now answers a broader question, so a name that still said `activeSchemeThemed` would invite the next caller to reintroduce the bug.

The doc comment records the version dependency and points at the matching gate in `ContentViewController.updateObscuredContentInsets()`, so the two stay in step.

## Verification

`swift test --package-path tests/swift-tests` — 236 tests, 1 skipped, 0 failures.

That package compiles only the pure-Foundation helpers symlinked into it, none of the window chrome, so it is a regression check rather than evidence about this change.

`xcodebuild -scheme md-preview -configuration Debug build` compiles clean, but only with `CODE_SIGNING_ALLOWED=NO` — the project pins team `5P3TSMNV42`, which I have no certificate for. So this is a compile check, not a signed local build.

## Test plan

Run on macOS 15 (I am on 15.7.9) with a theme colour set:

- [ ] The document window wears native chrome — opaque titlebar, no transparent strip. <br>
- [ ] The find bar's backdrop is correct both shown and hidden. <br>
- [ ] The formatting bar's hairline is hidden. <br>
- [ ] Switching light/dark does not resurrect the themed treatment.

On macOS 26, nothing should change at all — every guard returns what it returned before:

- [ ] Themed chrome still renders, including the toolbar strip and the find-bar scroll-edge effect. <br>
- [ ] Full screen still drops to native chrome.

> [!NOTE]
> [#329 — keep the preview clear of the titlebar before macOS 26](https://github.com/pluk-inc/markdown-preview/pull/329) is stacked on this branch and carries this commit too. Merging this one first leaves that a single-commit diff.
