### PR TITLE
Fix window drag under transparent titlebar and restore independent toolbar buttons

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		9A0209432FA10E6600092060 /* Exceptions for "md-preview" folder in "quick-look" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Helpers/ChromeStripClickThrough.swift,
 				Rendering/CodeFenceInfo.swift,
 				Rendering/DocumentFontSetting.swift,
 				Rendering/EscapingHTMLFormatter.swift,

--- a/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
+++ b/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
@@ -19,7 +19,7 @@ extension DocumentWindowController {
     /// and once on a window being created so it opens already floating.
     func applyAlwaysOnTopSetting() {
         applyAlwaysOnTopLevel(isFullScreen: documentWindow.styleMask.contains(.fullScreen))
-        alwaysOnTopItem?.setSelected(isAlwaysOnTop, at: 0)
+        alwaysOnTopButton?.state = isAlwaysOnTop ? .on : .off
     }
 
     /// The pin is intent, not the level itself: the level is recomputed on both

--- a/md-preview/Document/DocumentWindowController+EditMode.swift
+++ b/md-preview/Document/DocumentWindowController+EditMode.swift
@@ -41,35 +41,37 @@ extension DocumentWindowController {
         requestEndEditing(completion: completion)
     }
 
-    func makeEditSubitem() -> NSToolbarItem {
+    func makeEditItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
         let edit = NSLocalizedString("Edit", comment: "Edit toolbar item label")
         let image = NSImage(systemSymbolName: "highlighter",
                             accessibilityDescription: edit) ?? NSImage()
         image.isTemplate = true
 
-        let item = NSToolbarItem(itemIdentifier: .editDocument)
-        item.label = edit
-        item.toolTip = NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
-        item.image = image
-        item.target = self
-        item.action = #selector(toggleEditAction(_:))
+        let (item, button) = makeToggleButtonItem(identifier: .editDocument,
+                                                  image: image,
+                                                  label: edit,
+                                                  action: #selector(toggleEditAction(_:)))
         item.autovalidates = false
+
+        if willBeInsertedIntoToolbar {
+            editButton = button
+        }
+        applyEditToolbarState(to: button)
         return item
     }
 
     func updateEditToolbarItem() {
-        guard let editItem else { return }
-        applyEditToolbarState(to: editItem)
+        guard let editButton else { return }
+        applyEditToolbarState(to: editButton)
     }
 
-    func applyEditToolbarState(to item: NSToolbarItemGroup) {
+    private func applyEditToolbarState(to button: NSButton) {
         let editing = isEditing
-        item.setSelected(editing, at: 2)
-        let toolTip = editing
+        button.state = editing ? .on : .off
+        button.toolTip = editing
             ? NSLocalizedString("Stop editing and return to preview", comment: "Edit toolbar item tooltip while editing")
             : NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
-        item.subitems[2].toolTip = toolTip
-        item.subitems[2].isEnabled = editing || currentMarkdown != nil
+        button.isEnabled = editing || currentMarkdown != nil
     }
 
     @objc private func toggleEditAction(_ sender: Any?) {

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -44,8 +44,11 @@ extension DocumentWindowController {
             .navigation,
             .flexibleSpace,
             .openActions,
+            .space,
             .zoom,
             .inspector,
+            .share,
+            .editDocument,
             .search
         ]
     }
@@ -59,7 +62,9 @@ extension DocumentWindowController {
             .space,
             .openActions,
             .openWith,
+            .editDocument,
             .inspector,
+            .share,
             .search,
             .printDocument,
             .exportPDF,
@@ -85,10 +90,10 @@ extension DocumentWindowController {
         case .openInLLM:
             guard hasLLMTargetsAvailable else { return nil }
             return makeOpenInLLMItem()
-        case .editDocument: return nil
+        case .editDocument: return makeEditItem(willBeInsertedIntoToolbar: flag)
         case .inspector: return makeInspectorItem(willBeInsertedIntoToolbar: flag)
         case .alwaysOnTop: return makeAlwaysOnTopItem(willBeInsertedIntoToolbar: flag)
-        case .share: return nil
+        case .share: return makeShareItem()
         case .search: return makeSearchItem()
         case .printDocument: return makePrintItem()
         case .exportPDF: return makeExportPDFItem()
@@ -155,53 +160,60 @@ extension DocumentWindowController {
         item.subitems.last?.isEnabled = !forwardHistory.isEmpty
     }
 
-    private func makeInspectorItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
-        let inspector = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
-        let inspectorButton = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier("Inspector.Toggle"))
-        inspectorButton.label = inspector
-        inspectorButton.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
-        inspectorButton.image = inspectorImage()
-        inspectorButton.target = self
-        inspectorButton.action = #selector(toggleInspectorAction(_:))
+    /// A toggle as a plain NSButton hosted in a regular NSToolbarItem. On
+    /// macOS 26 AppKit merges adjacent button-type controls onto one piece
+    /// of glass but always gives an NSToolbarItemGroup its own, so a toggle
+    /// built as a single-item group can never share glass with its
+    /// neighbors. Built this way the toggles merge natively and stay
+    /// individually movable in the customize palette.
+    func makeToggleButtonItem(identifier: NSToolbarItem.Identifier,
+                              image: NSImage,
+                              label: String,
+                              action: Selector) -> (item: NSToolbarItem, button: NSButton) {
+        let item = NSToolbarItem(itemIdentifier: identifier)
+        let button = NSButton(image: image, target: self, action: action)
+        button.setButtonType(.pushOnPushOff)
+        button.isBordered = true
+        item.view = button
+        item.label = label
+        item.paletteLabel = label
+        return (item, button)
+    }
 
-        // Keep the real sharing toolbar item so AppKit can present its picker
-        // on mouse-down, while grouping all three actions into one native unit.
-        let item = NSToolbarItemGroup(itemIdentifier: .inspector)
-        item.label = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
+    private func makeInspectorItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
+        let (item, button) = makeToggleButtonItem(
+            identifier: .inspector,
+            image: inspectorImage(),
+            label: NSLocalizedString("Inspector", comment: "Inspector toolbar item label"),
+            action: #selector(toggleInspectorAction(_:))
+        )
         item.paletteLabel = NSLocalizedString("Get Info", comment: "Inspector toolbar palette label")
-        item.subitems = [inspectorButton, makeShareItem(), makeEditSubitem()]
-        item.controlRepresentation = .expanded
-        item.selectionMode = .selectAny
+        item.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
+        button.toolTip = item.toolTip
 
         if willBeInsertedIntoToolbar {
-            inspectorItem = item
-            editItem = item
+            inspectorButton = button
             refreshInspectorToggleItem()
-            updateEditToolbarItem()
         } else {
-            item.setSelected(isInspectorToggleSelected, at: 0)
-            applyEditToolbarState(to: item)
+            button.state = isInspectorToggleSelected ? .on : .off
         }
         return item
     }
 
     private func makeAlwaysOnTopItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
-        let alwaysOnTop = NSLocalizedString("Always on Top", comment: "Always on Top toolbar item label")
-        let item = NSToolbarItemGroup(itemIdentifier: .alwaysOnTop,
-                                      images: [alwaysOnTopImage()],
-                                      selectionMode: .selectAny,
-                                      labels: [alwaysOnTop],
-                                      target: self,
-                                      action: #selector(toggleAlwaysOnTop(_:)))
-        item.label = alwaysOnTop
-        item.paletteLabel = alwaysOnTop
+        let (item, button) = makeToggleButtonItem(
+            identifier: .alwaysOnTop,
+            image: alwaysOnTopImage(),
+            label: NSLocalizedString("Always on Top", comment: "Always on Top toolbar item label"),
+            action: #selector(toggleAlwaysOnTop(_:))
+        )
         item.toolTip = NSLocalizedString("Keep Markdown Preview windows in front of other apps",
                                          comment: "Always on Top toolbar item tooltip")
-        item.subitems.first?.toolTip = item.toolTip
-        item.setSelected(isAlwaysOnTop, at: 0)
+        button.toolTip = item.toolTip
+        button.state = isAlwaysOnTop ? .on : .off
 
         if willBeInsertedIntoToolbar {
-            alwaysOnTopItem = item
+            alwaysOnTopButton = button
         }
         return item
     }
@@ -377,7 +389,7 @@ extension DocumentWindowController {
 
     private func setInspectorToggleSelected(_ isSelected: Bool) {
         isInspectorToggleSelected = isSelected
-        inspectorItem?.setSelected(isSelected, at: 0)
+        inspectorButton?.state = isSelected ? .on : .off
     }
 
     func items(for pickerToolbarItem: NSSharingServicePickerToolbarItem) -> [Any] {

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -61,9 +61,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     weak var openActionsItem: NSMenuToolbarItem?
     weak var openWithItem: NSMenuToolbarItem?
     weak var openInLLMItem: NSMenuToolbarItem?
-    weak var inspectorItem: NSToolbarItemGroup?
-    weak var alwaysOnTopItem: NSToolbarItemGroup?
-    weak var editItem: NSToolbarItemGroup?
+    weak var inspectorButton: NSButton?
+    weak var alwaysOnTopButton: NSButton?
+    weak var editButton: NSButton?
     var editorChangeRevision = 0
     /// In-memory source shown by preview before the user saves it.
     var editorDraftMarkdown: String?
@@ -281,6 +281,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         // (via obscuredContentInsets, in ContentViewController) which strip
         // the toolbar obscures so WebKit lays out below it and frosts
         // content that scrolls under.
+        //
+        // A transparent titlebar on macOS 26 re-dispatches clicks it did not
+        // handle (the padding between toolbar buttons) to the content view
+        // underneath instead of letting NSThemeFrame start the window drag.
+        // The web views give those clicks back — see
+        // NSView.declinesChromeStripClick(at:) in Helpers.
         documentWindow.titlebarAppearsTransparent = true
     }
 

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -41,7 +41,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(assetScheme, forURLScheme: MarkdownAssetScheme.scheme)
         config.userContentController.add(bridge, name: EditorBridge.name)
-        let webView = WKWebView(frame: .zero, configuration: config)
+        let webView = EditorWKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = self
         webView.underPageBackgroundColor = .windowBackgroundColor
         bridge.owner = self
@@ -1007,5 +1007,14 @@ private final class EditorBridge: NSObject, WKScriptMessageHandler {
                                didReceive message: WKScriptMessage) {
         guard message.name == EditorBridge.name else { return }
         owner?.handle(message: message.body)
+    }
+}
+
+private final class EditorWKWebView: WKWebView {
+    // Left clicks in the transparent titlebar strip stay native (window
+    // drag) instead of being consumed by WebKit — see ChromeStripClickThrough.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if declinesChromeStripClick(at: point) { return nil }
+        return super.hitTest(point)
     }
 }

--- a/md-preview/Helpers/ChromeStripClickThrough.swift
+++ b/md-preview/Helpers/ChromeStripClickThrough.swift
@@ -1,0 +1,37 @@
+//
+//  ChromeStripClickThrough.swift
+//  md-preview
+//
+//  Keeps window dragging alive under a transparent titlebar on macOS 26.
+//
+//  With `titlebarAppearsTransparent`, a left click on the toolbar's empty
+//  padding (between two buttons) is no longer handled by the titlebar:
+//  AppKit re-dispatches it to the view underneath — here a WKWebView, which
+//  consumes every mouseDown — so the click never reaches NSThemeFrame and
+//  the window stops being draggable there. The web views decline exactly
+//  those clicks from hitTest; the re-dispatch then lands on a plain
+//  container view whose responder chain ends at NSThemeFrame, which
+//  performs the native window drag. Scrolling, hover, and every other
+//  event over the toolbar keeps passing through to the page as before.
+//
+
+import AppKit
+
+extension NSView {
+    /// Whether a `hitTest(_:)` at `point` (superview coordinates, per the
+    /// hitTest convention) is a left-mouse click in the titlebar/toolbar
+    /// strip of a transparent-titlebar window, and should return nil so the
+    /// click keeps its native meaning (window drag, double-click zoom).
+    func declinesChromeStripClick(at point: NSPoint) -> Bool {
+        guard #available(macOS 26.0, *) else { return false }
+        guard let window, window.titlebarAppearsTransparent else { return false }
+        switch NSApp.currentEvent?.type {
+        case .leftMouseDown, .leftMouseDragged, .leftMouseUp: break
+        default: return false
+        }
+        // contentLayoutRect is in window coordinates; everything above its
+        // top edge is the titlebar-and-toolbar strip.
+        let windowPoint = superview?.convert(point, to: nil) ?? point
+        return windowPoint.y > window.contentLayoutRect.maxY
+    }
+}

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -1554,6 +1554,13 @@ private extension NSView {
 }
 
 private final class PreviewWKWebView: WKWebView {
+    // Left clicks in the transparent titlebar strip stay native (window
+    // drag) instead of being consumed by WebKit — see ChromeStripClickThrough.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if declinesChromeStripClick(at: point) { return nil }
+        return super.hitTest(point)
+    }
+
     override func keyDown(with event: NSEvent) {
         if forwardHeadingKey(event) { return }
         if isStandardScrollKey(event) {


### PR DESCRIPTION
## Summary

Two toolbar fixes for themed windows on macOS 26 (Tahoe):

**1. Window drag between toolbar buttons works again.**
With `titlebarAppearsTransparent`, macOS 26 re-dispatches clicks the titlebar did not handle (the padding between toolbar buttons) to the content view underneath, instead of letting `NSThemeFrame` start the window drag. Traced with lldb: the click climbs to `NSTitlebarContainerView`, is re-sent into the `WKWebView`, and WebKit consumes it. Themed windows therefore lost their toolbar drag surface, and the transparent titlebar cannot be dropped — without it the system paints its own dark material over the theme color.

Fix: a small `NSView` extension (`ChromeStripClickThrough.swift`). Both web views decline left-mouse hit tests inside the titlebar strip (`window.contentLayoutRect` based), so the re-dispatched click lands on a plain container and the responder chain reaches `NSThemeFrame`, which performs the **native** drag. No drag handlers, no `performDrag` calls. Scroll-over-toolbar, hover, and right clicks still pass through to the page unchanged.

**2. Inspector / Share / Edit are independent buttons that still share one glass.**
Reverts #324 (which welded the three into one fixed `NSToolbarItemGroup`) and rebuilds the toggles (Inspector, Edit, Always on Top) as `NSToolbarItem`s hosting a plain `NSButton` (`.pushOnPushOff`). AppKit only merges adjacent button-type controls onto one piece of glass and never merges an `NSToolbarItemGroup` — even a single-item one — so this keeps the one-pill look natively while each button stays individually movable in the customize palette. Toggle state still renders via the button state.

## Test plan

Verified on macOS 26.6 with a dark theme active, using synthetic mouse events plus lldb window-frame checks:

- [x] Drag between toolbar buttons moves the window by the exact drag delta (preview mode and edit mode)
- [x] Theme color still runs to the top edge; scroll-edge frost intact
- [x] Scrolling with the cursor over the toolbar still scrolls the page
- [x] Inspector / Share / Edit merge onto one glass pill natively and move independently in Customize Toolbar
- [x] Toggle states (Inspector, Edit, Always on Top) render as pressed buttons
- [x] App and quick-look targets build clean

Known native behavior (not a regression): the Share item's whole cell is pressable because `NSSharingServicePickerToolbarItem` opens its picker on mouse-down, so the few pixels beside the share icon open the picker rather than drag — same as stock apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)