### PR TITLE
Fix window drag under the transparent titlebar and move the edit/find bars below the tab bar

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		9A0209432FA10E6600092060 /* Exceptions for "md-preview" folder in "quick-look" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Helpers/ChromeStripClickThrough.swift,
 				Rendering/CodeFenceInfo.swift,
 				Rendering/DocumentFontSetting.swift,
 				Rendering/EscapingHTMLFormatter.swift,

--- a/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
+++ b/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
@@ -19,7 +19,7 @@ extension DocumentWindowController {
     /// and once on a window being created so it opens already floating.
     func applyAlwaysOnTopSetting() {
         applyAlwaysOnTopLevel(isFullScreen: documentWindow.styleMask.contains(.fullScreen))
-        alwaysOnTopItem?.setSelected(isAlwaysOnTop, at: 0)
+        alwaysOnTopButton?.state = isAlwaysOnTop ? .on : .off
     }
 
     /// The pin is intent, not the level itself: the level is recomputed on both

--- a/md-preview/Document/DocumentWindowController+EditMode.swift
+++ b/md-preview/Document/DocumentWindowController+EditMode.swift
@@ -41,35 +41,37 @@ extension DocumentWindowController {
         requestEndEditing(completion: completion)
     }
 
-    func makeEditSubitem() -> NSToolbarItem {
+    func makeEditItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
         let edit = NSLocalizedString("Edit", comment: "Edit toolbar item label")
         let image = NSImage(systemSymbolName: "highlighter",
                             accessibilityDescription: edit) ?? NSImage()
         image.isTemplate = true
 
-        let item = NSToolbarItem(itemIdentifier: .editDocument)
-        item.label = edit
-        item.toolTip = NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
-        item.image = image
-        item.target = self
-        item.action = #selector(toggleEditAction(_:))
+        let (item, button) = makeToggleButtonItem(identifier: .editDocument,
+                                                  image: image,
+                                                  label: edit,
+                                                  action: #selector(toggleEditAction(_:)))
         item.autovalidates = false
+
+        if willBeInsertedIntoToolbar {
+            editButton = button
+        }
+        applyEditToolbarState(to: button)
         return item
     }
 
     func updateEditToolbarItem() {
-        guard let editItem else { return }
-        applyEditToolbarState(to: editItem)
+        guard let editButton else { return }
+        applyEditToolbarState(to: editButton)
     }
 
-    func applyEditToolbarState(to item: NSToolbarItemGroup) {
+    private func applyEditToolbarState(to button: NSButton) {
         let editing = isEditing
-        item.setSelected(editing, at: 2)
-        let toolTip = editing
+        button.state = editing ? .on : .off
+        button.toolTip = editing
             ? NSLocalizedString("Stop editing and return to preview", comment: "Edit toolbar item tooltip while editing")
             : NSLocalizedString("Edit document", comment: "Edit toolbar item tooltip")
-        item.subitems[2].toolTip = toolTip
-        item.subitems[2].isEnabled = editing || currentMarkdown != nil
+        button.isEnabled = editing || currentMarkdown != nil
     }
 
     @objc private func toggleEditAction(_ sender: Any?) {

--- a/md-preview/Document/DocumentWindowController+EditSession.swift
+++ b/md-preview/Document/DocumentWindowController+EditSession.swift
@@ -451,7 +451,7 @@ extension DocumentWindowController {
             if !preserveUnsavedChanges {
                 self.hasUnsavedEditorChanges = false
             }
-            if self.editAccessory == nil {
+            if self.editBar == nil {
                 self.updateEditToolbarItem()
             }
             if rerender, let markdown = self.currentMarkdown {

--- a/md-preview/Document/DocumentWindowController+Find.swift
+++ b/md-preview/Document/DocumentWindowController+Find.swift
@@ -80,30 +80,50 @@ extension DocumentWindowController {
     }
 
     private func setFindBarVisible(_ visible: Bool) {
-        guard let accessory = findBarAccessory, accessory.isHidden == visible else { return }
-        accessory.isHidden = !visible
-        if #available(macOS 26.1, *) {
-            // Visible bar always gets the hard backdrop; hidden, the
-            // preference must not leak a backdrop over a themed titlebar.
-            accessory.preferredScrollEdgeEffectStyle =
-                visible || !activeSchemeThemed ? .hard : .automatic
-        }
+        guard let overlay = findBarOverlay, overlay.isHidden == visible else { return }
+        overlay.isHidden = !visible
+        // The editor pads its page below every visible overlay.
+        mainSplit?.findOverlayVisibilityChanged()
     }
 
+    /// A content overlay like the formatting bar, not a titlebar accessory:
+    /// AppKit pins the native tab bar below every accessory, so an
+    /// accessory find bar sat above the tabs and shoved them down on every
+    /// appearance. The overlay never reflows the layout — see
+    /// DocumentWindowController.editBar.
     func installFindBar() {
         let bar = FindBar(
             frame: NSRect(x: 0, y: 0, width: 600, height: FindBar.preferredHeight)
         )
-        bar.autoresizingMask = [.width]
         bar.onPrevious = { [weak self] in self?.findFromToolbar(backwards: true) }
         bar.onNext = { [weak self] in self?.findFromToolbar(backwards: false) }
         bar.onDone = { [weak self] in self?.dismissFindBar() }
         bar.onModeChanged = { [weak self] mode in self?.searchModeDidChange(mode) }
         self.findBar = bar
-        // No .hard here: a hidden accessory's scroll-edge preference still
-        // applies, painting an opaque backdrop over a themed window background.
-        // setFindBarVisible flips it while the bar is actually shown.
-        self.findBarAccessory = addBottomTitlebarAccessory(bar)
+
+        let container = EditAccessoryContainerView()
+        // The find bar shows over the preview, whose backdrop follows the
+        // window background, not the editor color.
+        container.prefersWindowBackground = true
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(bar)
+        let hairline = NSBox()
+        hairline.boxType = .separator
+        hairline.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(hairline)
+        NSLayoutConstraint.activate([
+            bar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            bar.topAnchor.constraint(equalTo: container.topAnchor),
+            bar.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            bar.heightAnchor.constraint(equalToConstant: FindBar.preferredHeight),
+            hairline.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hairline.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hairline.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        container.isHidden = true
+        mainSplit?.installFindOverlay(container)
+        findBarOverlay = container
     }
 
     private func dismissFindBar() {
@@ -149,7 +169,7 @@ extension DocumentWindowController {
     private func searchModeDidChange(_ mode: SearchMode) {
         guard mode != searchMode else { return }
         searchMode = mode
-        guard findBarAccessory?.isHidden == false,
+        guard findBarOverlay?.isHidden == false,
               let query = searchField?.stringValue, !query.isEmpty else { return }
         runFind(query: query)
     }

--- a/md-preview/Document/DocumentWindowController+FormattingBar.swift
+++ b/md-preview/Document/DocumentWindowController+FormattingBar.swift
@@ -11,9 +11,12 @@ extension DocumentWindowController {
     // MARK: Formatting bar
 
     /// Second toolbar row with common markdown actions, shown while
-    /// editing — like Preview's markup bar.
+    /// editing — like Preview's markup bar. Mounted in the content host,
+    /// not the titlebar: the native tab bar always renders below every
+    /// titlebar accessory, so an accessory bar would sit above the tabs
+    /// and shove the tab bar up and down on every edit-mode toggle.
     func showEditAccessory() {
-        guard editAccessory == nil else { return }
+        guard editBar == nil else { return }
 
         let symbolConfig = NSImage.SymbolConfiguration(pointSize: 12, weight: .medium)
         func formatButton(_ symbol: String, _ command: String, _ tip: String) -> NSButton {
@@ -86,14 +89,13 @@ extension DocumentWindowController {
             if index > 0 { stack.setCustomSpacing(8, after: views[index - 1]) }
             stack.setCustomSpacing(8, after: view)
         }
-        stack.edgeInsets = NSEdgeInsets(top: 4, left: 12, bottom: 6, right: 12)
+        stack.edgeInsets = NSEdgeInsets(top: 7, left: 12, bottom: 11, right: 12)
         stack.translatesAutoresizingMaskIntoConstraints = false
 
-        // Translucent like the main toolbar: nothing can render behind the
-        // bar (the editor scroller clips text at its hairline and the pocket
-        // ends at the toolbar), so the bar needs no opaque backing — the
-        // flat theme color shows through. Without a theme the .hard edge
-        // still paints the classic opaque bar.
+        // The container paints the editor page background itself (see
+        // EditAccessoryContainerView.draw): the editor scrolls its text
+        // under the bar, and the titlebar accessory this replaced hid that
+        // with the system chrome backdrop.
         let container = EditAccessoryContainerView()
         container.addSubview(stack)
         NSLayoutConstraint.activate([
@@ -111,24 +113,9 @@ extension DocumentWindowController {
             hairline.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             hairline.bottomAnchor.constraint(equalTo: container.bottomAnchor),
         ])
-        hairline.isHidden = !activeSchemeThemed
-        editAccessoryHairline = hairline
 
-        let accessory = NSTitlebarAccessoryViewController()
-        accessory.view = container
-        accessory.layoutAttribute = .bottom
-        accessory.fullScreenMinHeight = 34
-        // macOS 26 replaced the titlebar separator with scroll edge
-        // effects; hard = the classic line under the bar. With a themed
-        // window background the hard edge would paint an opaque system
-        // strip over the theme color, so the frosted automatic style is
-        // used instead.
-        if #available(macOS 26.1, *) {
-            accessory.preferredScrollEdgeEffectStyle =
-                activeSchemeThemed ? .automatic : .hard
-        }
-        documentWindow.addTitlebarAccessoryViewController(accessory)
-        editAccessory = accessory
+        mainSplit?.installFormattingBar(container)
+        editBar = container
     }
 
     private func separatorView() -> NSView {
@@ -140,9 +127,9 @@ extension DocumentWindowController {
     }
 
     private func hideEditAccessory() {
-        guard let accessory = editAccessory else { return }
-        accessory.removeFromParent()
-        editAccessory = nil
+        guard editBar != nil else { return }
+        mainSplit?.removeFormattingBar()
+        editBar = nil
     }
 
     /// Leaves edit-mode chrome as one operation: drops the formatting bar

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -44,8 +44,11 @@ extension DocumentWindowController {
             .navigation,
             .flexibleSpace,
             .openActions,
+            .space,
             .zoom,
             .inspector,
+            .share,
+            .editDocument,
             .search
         ]
     }
@@ -59,7 +62,9 @@ extension DocumentWindowController {
             .space,
             .openActions,
             .openWith,
+            .editDocument,
             .inspector,
+            .share,
             .search,
             .printDocument,
             .exportPDF,
@@ -85,10 +90,10 @@ extension DocumentWindowController {
         case .openInLLM:
             guard hasLLMTargetsAvailable else { return nil }
             return makeOpenInLLMItem()
-        case .editDocument: return nil
+        case .editDocument: return makeEditItem(willBeInsertedIntoToolbar: flag)
         case .inspector: return makeInspectorItem(willBeInsertedIntoToolbar: flag)
         case .alwaysOnTop: return makeAlwaysOnTopItem(willBeInsertedIntoToolbar: flag)
-        case .share: return nil
+        case .share: return makeShareItem()
         case .search: return makeSearchItem()
         case .printDocument: return makePrintItem()
         case .exportPDF: return makeExportPDFItem()
@@ -155,53 +160,60 @@ extension DocumentWindowController {
         item.subitems.last?.isEnabled = !forwardHistory.isEmpty
     }
 
-    private func makeInspectorItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
-        let inspector = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
-        let inspectorButton = NSToolbarItem(itemIdentifier: NSToolbarItem.Identifier("Inspector.Toggle"))
-        inspectorButton.label = inspector
-        inspectorButton.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
-        inspectorButton.image = inspectorImage()
-        inspectorButton.target = self
-        inspectorButton.action = #selector(toggleInspectorAction(_:))
+    /// A toggle as a plain NSButton hosted in a regular NSToolbarItem. On
+    /// macOS 26 AppKit merges adjacent button-type controls onto one piece
+    /// of glass but always gives an NSToolbarItemGroup its own, so a toggle
+    /// built as a single-item group can never share glass with its
+    /// neighbors. Built this way the toggles merge natively and stay
+    /// individually movable in the customize palette.
+    func makeToggleButtonItem(identifier: NSToolbarItem.Identifier,
+                              image: NSImage,
+                              label: String,
+                              action: Selector) -> (item: NSToolbarItem, button: NSButton) {
+        let item = NSToolbarItem(itemIdentifier: identifier)
+        let button = NSButton(image: image, target: self, action: action)
+        button.setButtonType(.pushOnPushOff)
+        button.isBordered = true
+        item.view = button
+        item.label = label
+        item.paletteLabel = label
+        return (item, button)
+    }
 
-        // Keep the real sharing toolbar item so AppKit can present its picker
-        // on mouse-down, while grouping all three actions into one native unit.
-        let item = NSToolbarItemGroup(itemIdentifier: .inspector)
-        item.label = NSLocalizedString("Inspector", comment: "Inspector toolbar item label")
+    private func makeInspectorItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
+        let (item, button) = makeToggleButtonItem(
+            identifier: .inspector,
+            image: inspectorImage(),
+            label: NSLocalizedString("Inspector", comment: "Inspector toolbar item label"),
+            action: #selector(toggleInspectorAction(_:))
+        )
         item.paletteLabel = NSLocalizedString("Get Info", comment: "Inspector toolbar palette label")
-        item.subitems = [inspectorButton, makeShareItem(), makeEditSubitem()]
-        item.controlRepresentation = .expanded
-        item.selectionMode = .selectAny
+        item.toolTip = NSLocalizedString("Show the inspector", comment: "Inspector toolbar item tooltip")
+        button.toolTip = item.toolTip
 
         if willBeInsertedIntoToolbar {
-            inspectorItem = item
-            editItem = item
+            inspectorButton = button
             refreshInspectorToggleItem()
-            updateEditToolbarItem()
         } else {
-            item.setSelected(isInspectorToggleSelected, at: 0)
-            applyEditToolbarState(to: item)
+            button.state = isInspectorToggleSelected ? .on : .off
         }
         return item
     }
 
     private func makeAlwaysOnTopItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
-        let alwaysOnTop = NSLocalizedString("Always on Top", comment: "Always on Top toolbar item label")
-        let item = NSToolbarItemGroup(itemIdentifier: .alwaysOnTop,
-                                      images: [alwaysOnTopImage()],
-                                      selectionMode: .selectAny,
-                                      labels: [alwaysOnTop],
-                                      target: self,
-                                      action: #selector(toggleAlwaysOnTop(_:)))
-        item.label = alwaysOnTop
-        item.paletteLabel = alwaysOnTop
+        let (item, button) = makeToggleButtonItem(
+            identifier: .alwaysOnTop,
+            image: alwaysOnTopImage(),
+            label: NSLocalizedString("Always on Top", comment: "Always on Top toolbar item label"),
+            action: #selector(toggleAlwaysOnTop(_:))
+        )
         item.toolTip = NSLocalizedString("Keep Markdown Preview windows in front of other apps",
                                          comment: "Always on Top toolbar item tooltip")
-        item.subitems.first?.toolTip = item.toolTip
-        item.setSelected(isAlwaysOnTop, at: 0)
+        button.toolTip = item.toolTip
+        button.state = isAlwaysOnTop ? .on : .off
 
         if willBeInsertedIntoToolbar {
-            alwaysOnTopItem = item
+            alwaysOnTopButton = button
         }
         return item
     }
@@ -377,7 +389,7 @@ extension DocumentWindowController {
 
     private func setInspectorToggleSelected(_ isSelected: Bool) {
         isInspectorToggleSelected = isSelected
-        inspectorItem?.setSelected(isSelected, at: 0)
+        inspectorButton?.state = isSelected ? .on : .off
     }
 
     func items(for pickerToolbarItem: NSSharingServicePickerToolbarItem) -> [Any] {

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -96,18 +96,23 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             updateWindowSubtitle()
         }
     }
-    weak var editAccessory: NSTitlebarAccessoryViewController?
-    /// The native-style line under the formatting bar while the window is
-    /// themed — the .hard scroll edge that normally draws it would paint an
-    /// opaque system strip over the theme color, so the line is drawn here
-    /// and the edge stays frosted.
-    weak var editAccessoryHairline: NSView?
+    /// The formatting bar shown while editing. Not a titlebar accessory:
+    /// AppKit pins the native tab bar to the bottom of the titlebar, below
+    /// every accessory, so a bar mounted there sits above the tabs and its
+    /// mount/unmount shoves the tab bar up and down. Instead the bar is an
+    /// overlay in the content host, pinned to the window's
+    /// contentLayoutGuide — always directly below the tab bar (or the
+    /// toolbar when no tabs are shown), and the tab bar never moves.
+    weak var editBar: NSView?
     weak var copyItem: NSToolbarItem?
     var copyFeedbackWork: DispatchWorkItem?
     weak var searchField: NSSearchField?
     weak var sidebarMenu: NSMenu?
     var findBar: FindBar?
-    var findBarAccessory: NSTitlebarAccessoryViewController?
+    /// Container for the find bar. A content overlay like editBar — not a
+    /// titlebar accessory — so showing it never pushes the tab bar down.
+    /// Mounted once at setup and toggled via isHidden.
+    weak var findBarOverlay: NSView?
     var searchMode: SearchMode = .contains
     var pendingFindWork: DispatchWorkItem?
     static let findDebounceDelay: TimeInterval = 0.10
@@ -204,10 +209,6 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         documentWindow.toolbar = toolbar
         documentWindow.toolbarStyle = .automatic
 
-        // After installFindBar: the theme pass styles the find bar's
-        // scroll-edge preference (the hidden accessory's .hard is what
-        // draws the classic opaque toolbar backdrop when unthemed), and
-        // with no patrol re-applying it, ordering is the only chance.
         installFindBar()
         applyWindowBackgroundTheme()
     }
@@ -219,6 +220,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     func applyThemeColorsSetting() {
         applyWindowBackgroundTheme()
         mainSplit?.applyThemeColors()
+        // The bars paint the page backgrounds; a theme edit changes those
+        // colors without an appearance flip, so force a redraw.
+        editBar?.needsDisplay = true
+        findBarOverlay?.needsDisplay = true
     }
 
     /// Whether the ACTIVE appearance scheme has a window background
@@ -257,17 +262,6 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         }
         let themed = activeSchemeThemed
             && !documentWindow.styleMask.contains(.fullScreen)
-        // A hidden accessory's scroll-edge preference still drives the
-        // titlebar backdrop, so the find bar's .hard must follow the theme
-        // while the bar is hidden — otherwise it paints an opaque strip over
-        // a themed background.
-        if #available(macOS 26.1, *) {
-            if let accessory = findBarAccessory, accessory.isHidden {
-                accessory.preferredScrollEdgeEffectStyle = themed ? .automatic : .hard
-            }
-            editAccessory?.preferredScrollEdgeEffectStyle = themed ? .automatic : .hard
-        }
-        editAccessoryHairline?.isHidden = !themed
         // Automatic resolves to a shadow under the toolbar; over the flat
         // theme color it renders as a clipped gray band between the toolbar
         // and the formatting bar. The themed chrome draws its own hairlines.
@@ -581,10 +575,61 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         }
     }
 
-    /// The formatting bar floats over the editor web view, whose cursor
-    /// tracking (I-beam over text, hand over links) otherwise fights the
-    /// bar's buttons. The bar region always shows the plain arrow.
+    /// The chrome-overlay container (formatting bar, find bar) floats over
+    /// the web views, whose cursor tracking (I-beam over text, hand over
+    /// links) otherwise fights the bar's buttons. The bar region always
+    /// shows the plain arrow.
+    ///
+    /// Opaque: the pages scroll their content under the bars, so a bar must
+    /// paint the page's own background to hide it — the titlebar accessory
+    /// it replaced got that backdrop from the system chrome for free.
     final class EditAccessoryContainerView: NSView {
+        /// The editor page's background, resolved per appearance and read
+        /// from the live theme on every draw. Mirrors
+        /// EditorViewController.updateUnderPageBackgroundColor.
+        private static let editorPageBackground = NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let scheme: ThemeColorScheme = isDark ? .dark : .light
+            let colors = ThemeColorsSetting.current
+            return colors.color(.editorBackground, scheme)
+                ?? colors.color(.windowBackground, scheme)
+                ?? ThemeColorsSetting.defaultColor(.editorBackground, scheme)
+        }
+
+        /// The preview's backdrop — the same chain the window background
+        /// and the preview's under-page color use. The find bar shows over
+        /// the preview, so it paints this instead of the editor color.
+        private static let windowPageBackground = NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let scheme: ThemeColorScheme = isDark ? .dark : .light
+            return ThemeColorsSetting.current.color(.windowBackground, scheme)
+                ?? .windowBackgroundColor
+        }
+
+        /// True for bars that overlay the preview (find bar); false for
+        /// bars that overlay the editor (formatting bar).
+        var prefersWindowBackground = false
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+            wantsLayer = true
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // Layer-backed instead of draw(_:): custom drawing above the
+        // WKWebView interfered with its compositing and blanked the page.
+        override var wantsUpdateLayer: Bool { true }
+
+        override func updateLayer() {
+            effectiveAppearance.performAsCurrentDrawingAppearance {
+                let color = prefersWindowBackground
+                    ? Self.windowPageBackground : Self.editorPageBackground
+                layer?.backgroundColor = color.cgColor
+            }
+        }
         override func resetCursorRects() {
             addCursorRect(bounds, cursor: .arrow)
         }
@@ -617,19 +662,6 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                 owner: self
             ))
         }
-    }
-
-    func addBottomTitlebarAccessory(
-        _ view: NSView,
-        configure: ((NSTitlebarAccessoryViewController) -> Void)? = nil
-    ) -> NSTitlebarAccessoryViewController {
-        let accessory = NSTitlebarAccessoryViewController()
-        accessory.layoutAttribute = .bottom
-        accessory.view = view
-        accessory.isHidden = true
-        configure?(accessory)
-        documentWindow.addTitlebarAccessoryViewController(accessory)
-        return accessory
     }
 
 }

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -61,9 +61,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     weak var openActionsItem: NSMenuToolbarItem?
     weak var openWithItem: NSMenuToolbarItem?
     weak var openInLLMItem: NSMenuToolbarItem?
-    weak var inspectorItem: NSToolbarItemGroup?
-    weak var alwaysOnTopItem: NSToolbarItemGroup?
-    weak var editItem: NSToolbarItemGroup?
+    weak var inspectorButton: NSButton?
+    weak var alwaysOnTopButton: NSButton?
+    weak var editButton: NSButton?
     var editorChangeRevision = 0
     /// In-memory source shown by preview before the user saves it.
     var editorDraftMarkdown: String?
@@ -281,6 +281,12 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         // (via obscuredContentInsets, in ContentViewController) which strip
         // the toolbar obscures so WebKit lays out below it and frosts
         // content that scrolls under.
+        //
+        // A transparent titlebar on macOS 26 re-dispatches clicks it did not
+        // handle (the padding between toolbar buttons) to the content view
+        // underneath instead of letting NSThemeFrame start the window drag.
+        // The web views give those clicks back — see
+        // NSView.declinesChromeStripClick(at:) in Helpers.
         documentWindow.titlebarAppearsTransparent = true
     }
 

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -9,6 +9,13 @@ final class MainSplitViewController: NSSplitViewController {
 
     private static let didSeedKey = "MainSplitView.didSeedInitialState"
 
+    /// How far the chrome overlays (formatting bar, find bar) tuck up into
+    /// the native tab bar's empty bottom margin, closing the visual gap
+    /// between tabs and bar. Applied only while a tab bar is visible; the
+    /// editor's page padding subtracts the same amount
+    /// (EditorViewController.fullChromeTopInset).
+    static let formattingBarTabBarOverlap: CGFloat = 6
+
     var onSelectFile: ((URL) -> Void)?
     var onOpenMarkdownLink: ((URL) -> Void)?
     var onToggleTaskCheckbox: ((Int, Bool) -> Void)?
@@ -285,6 +292,7 @@ final class MainSplitViewController: NSSplitViewController {
             editorVC.view.translatesAutoresizingMaskIntoConstraints = false
             editorVC.view.alphaValue = 0
             contentHost.installEditorOverlay(editorVC)
+            editorVC.findOverlay = findOverlayView
             cachedEditorViewController = editorVC
         }
 
@@ -329,6 +337,39 @@ final class MainSplitViewController: NSSplitViewController {
             self.revealEditorIfPrepared(editorVC)
         }
         return editorVC
+    }
+
+    /// Mounts the formatting bar as a content overlay directly below the
+    /// titlebar chrome. See DocumentWindowController.editBar for why it is
+    /// not a titlebar accessory (the native tab bar always renders below
+    /// accessories, and would jump on every edit-mode toggle).
+    func installFormattingBar(_ bar: NSView) {
+        layeredContentViewController?.installFormattingBar(bar)
+        // The editor pads its page below the chrome; the bar is part of
+        // that chrome now, so it must be measured alongside the titlebar.
+        cachedEditorViewController?.formattingBar = bar
+    }
+
+    func removeFormattingBar() {
+        layeredContentViewController?.removeFormattingBar()
+        cachedEditorViewController?.formattingBar = nil
+    }
+
+    private weak var findOverlayView: NSView?
+
+    /// Mounts the find bar the same way — see installFormattingBar. Stays
+    /// mounted for the window's lifetime; visibility toggles via isHidden.
+    func installFindOverlay(_ bar: NSView) {
+        layeredContentViewController?.installFindOverlay(bar)
+        findOverlayView = bar
+        cachedEditorViewController?.findOverlay = bar
+    }
+
+    /// The find bar sits above the formatting bar, so toggling it moves
+    /// the bar below and changes the editor's page padding.
+    func findOverlayVisibilityChanged() {
+        layeredContentViewController?.updateChromeOverlayLayout()
+        cachedEditorViewController?.chromeOverlaysDidChange()
     }
 
     private func revealEditorIfPrepared(_ editorVC: EditorViewController) {
@@ -495,5 +536,94 @@ private final class LayeredContentViewController: NSViewController {
             editorView.topAnchor.constraint(equalTo: view.topAnchor),
             editorView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    private weak var formattingBar: NSView?
+    private weak var findOverlay: NSView?
+    private var formattingBarTopConstraint: NSLayoutConstraint?
+    private var findOverlayTopConstraint: NSLayoutConstraint?
+    private var chromeObservation: NSKeyValueObservation?
+
+    /// The overlays top out at the window's contentLayoutGuide — the bottom
+    /// of all titlebar chrome, native tab bar included — so tabs appearing
+    /// or disappearing reposition them automatically. In full screen the
+    /// guide reaches the top of the screen and the revealed toolbar floats
+    /// over them, like it floats over the rest of the content.
+    func installFormattingBar(_ bar: NSView) {
+        guard bar.superview !== view else { return }
+        formattingBar = bar
+        formattingBarTopConstraint = installChromeOverlay(bar)
+        updateChromeOverlayLayout()
+    }
+
+    func removeFormattingBar() {
+        formattingBar?.removeFromSuperview()
+        formattingBar = nil
+        formattingBarTopConstraint = nil
+        updateChromeOverlayLayout()
+    }
+
+    /// The find bar stays mounted for the window's lifetime and toggles
+    /// via isHidden — an overlay never reflows the layout, so showing it
+    /// cannot move the tab bar the way a titlebar accessory did.
+    func installFindOverlay(_ bar: NSView) {
+        guard bar.superview !== view else { return }
+        findOverlay = bar
+        findOverlayTopConstraint = installChromeOverlay(bar)
+        updateChromeOverlayLayout()
+    }
+
+    private func installChromeOverlay(_ bar: NSView) -> NSLayoutConstraint? {
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bar)
+        var constraints = [
+            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ]
+        var top: NSLayoutConstraint?
+        if let window = view.window,
+           let guide = window.contentLayoutGuide as? NSLayoutGuide {
+            top = bar.topAnchor.constraint(equalTo: guide.topAnchor)
+            observeChromeIfNeeded(window)
+        } else {
+            top = bar.topAnchor.constraint(equalTo: view.topAnchor)
+        }
+        constraints.append(top!)
+        NSLayoutConstraint.activate(constraints)
+        return top
+    }
+
+    /// The tab bar can appear or leave while an overlay is mounted;
+    /// contentLayoutRect moves with it. Only state is read here — forcing
+    /// layout from this observation re-enters the pass that changed the
+    /// rect and breaks the edit-mode reveal machinery.
+    private func observeChromeIfNeeded(_ window: NSWindow) {
+        guard chromeObservation == nil else { return }
+        chromeObservation = window.observe(\.contentLayoutRect) { [weak self] _, _ in
+            MainActor.assumeIsolated {
+                self?.updateChromeOverlayLayout()
+            }
+        }
+    }
+
+    /// Positions the overlay stack. The find bar sits at the chrome
+    /// boundary (directly below the tab bar, tucked into its empty margin
+    /// when tabs show) and the formatting bar below it — formatting acts on
+    /// the text, so it stays adjacent to the document; find is a transient
+    /// chrome utility and inserts at the boundary, the way Apple's own
+    /// find bars do.
+    func updateChromeOverlayLayout() {
+        let overlap: CGFloat = (view.window?.tabGroup?.isTabBarVisible ?? false)
+            ? -MainSplitViewController.formattingBarTabBarOverlap : 0
+        if let top = findOverlayTopConstraint, top.constant != overlap {
+            top.constant = overlap
+        }
+        var editTop = overlap
+        if let find = findOverlay, find.superview === view, !find.isHidden {
+            editTop += find.fittingSize.height
+        }
+        if let top = formattingBarTopConstraint, top.constant != editTop {
+            top.constant = editTop
+        }
     }
 }

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -121,13 +121,55 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         // The chrome (toolbar, accessories) is final here; layout passes
         // before it attaches see a smaller contentLayoutRect.
         updateObscuredContentInsets()
+        observeWindowChrome()
     }
 
-    /// The whole obscured strip — titlebar, toolbar, and visible bottom
-    /// accessories. contentLayoutRect already excludes the accessories, so
-    /// the gap alone is the full chrome height; adding accessory heights on
-    /// top double-counted them and left a blank band below the formatting
-    /// bar.
+    /// The formatting bar overlaying this editor (a content-view sibling,
+    /// not a titlebar accessory — see DocumentWindowController.editBar).
+    /// The page padding must clear it like any other chrome.
+    weak var formattingBar: NSView? {
+        didSet {
+            guard formattingBar !== oldValue else { return }
+            updateObscuredContentInsets()
+        }
+    }
+
+    /// The find bar overlay (permanent, toggled by isHidden) — like the
+    /// formatting bar, it hangs below the titlebar over this editor.
+    weak var findOverlay: NSView?
+
+    /// Reapplies the page padding; the window controller calls this when
+    /// the find overlay is shown or hidden.
+    func chromeOverlaysDidChange() {
+        updateObscuredContentInsets()
+    }
+
+    private var contentLayoutObservation: NSKeyValueObservation?
+
+    /// Titlebar chrome can change without this view getting a layout pass —
+    /// the native tab bar appears when another document joins the window's
+    /// tab group — so the padding follows contentLayoutRect directly. The
+    /// observation only reads state and reapplies the page padding: forcing
+    /// layout from here re-enters the layout pass that changed the rect and
+    /// breaks the edit-mode reveal machinery.
+    private func observeWindowChrome() {
+        guard let window = view.window else {
+            contentLayoutObservation = nil
+            return
+        }
+        guard contentLayoutObservation == nil else { return }
+        contentLayoutObservation = window.observe(\.contentLayoutRect) { [weak self] _, _ in
+            MainActor.assumeIsolated {
+                self?.updateObscuredContentInsets()
+            }
+        }
+    }
+
+    /// The whole obscured strip — titlebar, toolbar, tab bar, visible
+    /// bottom accessories, and the formatting bar overlay.
+    /// contentLayoutRect already excludes the titlebar chrome, so the gap
+    /// alone is that chrome's height; adding accessory heights on top
+    /// double-counted them and left a blank band below the formatting bar.
     private var fullChromeTopInset: CGFloat {
         guard let window = view.window, let contentView = window.contentView else {
             return view.safeAreaInsets.top
@@ -143,6 +185,27 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             && accessory.view.window === window {
             let rect = contentView.convert(accessory.view.bounds, from: accessory.view)
             gap = max(gap, contentView.bounds.height - rect.minY)
+        }
+        // The formatting bar and find overlay are content-view chrome
+        // hanging directly below the titlebar, so contentLayoutRect never
+        // accounts for them. fittingSize instead of the frame: the frame is
+        // unresolved between install and the next layout pass, and forcing
+        // layout from here would re-enter the pass that called us. With a
+        // visible tab bar the stack tucks up into the tab bar's margin
+        // (MainSplitViewController.formattingBarTabBarOverlap), so that
+        // amount comes back off once.
+        var overlays: CGFloat = 0
+        if let bar = formattingBar, bar.window === window, !bar.isHidden {
+            overlays += bar.fittingSize.height
+        }
+        if let find = findOverlay, find.window === window, !find.isHidden {
+            overlays += find.fittingSize.height
+        }
+        if overlays > 0 {
+            gap += overlays
+            if window.tabGroup?.isTabBarVisible == true {
+                gap -= MainSplitViewController.formattingBarTabBarOverlap
+            }
         }
         return max(0, gap)
     }

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -41,7 +41,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(assetScheme, forURLScheme: MarkdownAssetScheme.scheme)
         config.userContentController.add(bridge, name: EditorBridge.name)
-        let webView = WKWebView(frame: .zero, configuration: config)
+        let webView = EditorWKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = self
         webView.underPageBackgroundColor = .windowBackgroundColor
         bridge.owner = self
@@ -1007,5 +1007,14 @@ private final class EditorBridge: NSObject, WKScriptMessageHandler {
                                didReceive message: WKScriptMessage) {
         guard message.name == EditorBridge.name else { return }
         owner?.handle(message: message.body)
+    }
+}
+
+private final class EditorWKWebView: WKWebView {
+    // Left clicks in the transparent titlebar strip stay native (window
+    // drag) instead of being consumed by WebKit — see ChromeStripClickThrough.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if declinesChromeStripClick(at: point) { return nil }
+        return super.hitTest(point)
     }
 }

--- a/md-preview/Features/Find/FindBar.swift
+++ b/md-preview/Features/Find/FindBar.swift
@@ -34,7 +34,6 @@ final class FindBar: NSView {
         target: nil,
         action: nil
     )
-    private let bottomSeparator = HairlineSeparator()
 
     private enum NavigationSegment: Int {
         case previous = 0
@@ -98,21 +97,10 @@ final class FindBar: NSView {
         trailingStack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(trailingStack)
 
-        // macOS 26 dropped the system-drawn separators around titlebar
-        // accessories, so we draw our own bottom rule. macOS 15 still draws
-        // them, so hiding ours avoids a doubled line there.
-        // NSBox(.separator) inside a bottom titlebar accessory triggers a macOS
-        // 26 layout regression that bypasses the window's contentMinSize and
-        // collapses the window to the toolbar's natural minimum width — use a
-        // plain NSView with a 1pt separator-colored layer instead.
-        let needsManualSeparator: Bool = {
-            if #available(macOS 26.0, *) { return true }
-            return false
-        }()
-
-        bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
-        bottomSeparator.isHidden = !needsManualSeparator
-        addSubview(bottomSeparator)
+        // No separator of its own: the bar lives in a chrome-overlay
+        // container (DocumentWindowController.installFindBar) that draws
+        // the same NSBox hairline the formatting bar uses — drawing one
+        // here as well doubled the line.
 
         NSLayoutConstraint.activate([
             leadingStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
@@ -120,11 +108,6 @@ final class FindBar: NSView {
 
             trailingStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             trailingStack.centerYAnchor.constraint(equalTo: centerYAnchor),
-
-            bottomSeparator.leadingAnchor.constraint(equalTo: leadingAnchor),
-            bottomSeparator.trailingAnchor.constraint(equalTo: trailingAnchor),
-            bottomSeparator.bottomAnchor.constraint(equalTo: bottomAnchor),
-            bottomSeparator.heightAnchor.constraint(equalToConstant: 1)
         ])
     }
 

--- a/md-preview/Helpers/ChromeStripClickThrough.swift
+++ b/md-preview/Helpers/ChromeStripClickThrough.swift
@@ -1,0 +1,37 @@
+//
+//  ChromeStripClickThrough.swift
+//  md-preview
+//
+//  Keeps window dragging alive under a transparent titlebar on macOS 26.
+//
+//  With `titlebarAppearsTransparent`, a left click on the toolbar's empty
+//  padding (between two buttons) is no longer handled by the titlebar:
+//  AppKit re-dispatches it to the view underneath — here a WKWebView, which
+//  consumes every mouseDown — so the click never reaches NSThemeFrame and
+//  the window stops being draggable there. The web views decline exactly
+//  those clicks from hitTest; the re-dispatch then lands on a plain
+//  container view whose responder chain ends at NSThemeFrame, which
+//  performs the native window drag. Scrolling, hover, and every other
+//  event over the toolbar keeps passing through to the page as before.
+//
+
+import AppKit
+
+extension NSView {
+    /// Whether a `hitTest(_:)` at `point` (superview coordinates, per the
+    /// hitTest convention) is a left-mouse click in the titlebar/toolbar
+    /// strip of a transparent-titlebar window, and should return nil so the
+    /// click keeps its native meaning (window drag, double-click zoom).
+    func declinesChromeStripClick(at point: NSPoint) -> Bool {
+        guard #available(macOS 26.0, *) else { return false }
+        guard let window, window.titlebarAppearsTransparent else { return false }
+        switch NSApp.currentEvent?.type {
+        case .leftMouseDown, .leftMouseDragged, .leftMouseUp: break
+        default: return false
+        }
+        // contentLayoutRect is in window coordinates; everything above its
+        // top edge is the titlebar-and-toolbar strip.
+        let windowPoint = superview?.convert(point, to: nil) ?? point
+        return windowPoint.y > window.contentLayoutRect.maxY
+    }
+}

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -1554,6 +1554,13 @@ private extension NSView {
 }
 
 private final class PreviewWKWebView: WKWebView {
+    // Left clicks in the transparent titlebar strip stay native (window
+    // drag) instead of being consumed by WebKit — see ChromeStripClickThrough.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if declinesChromeStripClick(at: point) { return nil }
+        return super.hitTest(point)
+    }
+
     override func keyDown(with event: NSEvent) {
         if forwardHeadingKey(event) { return }
         if isStandardScrollKey(event) {


### PR DESCRIPTION
## Summary

Two macOS 26 titlebar-chrome fixes on one branch:

1. **Window drag under the transparent titlebar** (first commit): clicks on the toolbar's empty padding re-dispatched to the web view instead of starting the native window drag; the web views now decline those clicks, and grouped document actions return as independent toolbar buttons.
2. **Edit and find bars below the native tab bar** (second commit): AppKit pins the window tab bar below every titlebar accessory — `NSWindow` keeps it in a private `_tabBarAccessoryViewController` slot with no ordering hook — so both bars sat above the tabs and shoved the tab bar up and down whenever they appeared. They are now content overlays pinned to `contentLayoutGuide`, the way Finder-style layouts place bars below the tabs:
   - Stack order: tab bar → find bar → formatting bar → document. Formatting stays adjacent to the text it acts on; find inserts at the chrome boundary.
   - The tab bar never moves when edit mode toggles or find opens.
   - Overlays tuck 6 pt into the tab bar's empty bottom margin so the rows read as one block (`MainSplitViewController.formattingBarTabBarOverlap`).
   - Layer-backed opaque containers paint the page background so text scrolling under the bars stays hidden; `draw(_:)` is avoided because custom drawing composited above a `WKWebView` blanks the page.
   - The editor's page padding follows the visible overlays via `fittingSize` plus a `contentLayoutRect` observation (no forced layout — re-entering the layout pass broke the edit-mode reveal).
   - FindBar's own macOS 26 bottom separator is removed; the shared container hairline replaces the doubled line.

## Test plan

- [ ] Drag the window by the toolbar gaps between buttons (macOS 26, themed and unthemed windows)
- [ ] Open several tabs; enter/exit edit mode — the tab bar must not move
- [ ] Edit → preview with pending changes → edit again — the editor content must render
- [ ] Type past one screen in edit mode — scrolled text hides behind the formatting bar, text starts at the hairline
- [ ] Find in preview: bar appears under the tab bar with a single thin hairline, tab bar still
- [ ] Find while editing: find bar above the formatting bar, document padding follows
- [ ] Themed window (Bear presets): bar backgrounds match the page colors in light and dark
- [ ] Full screen: bars pin to the top; the revealed toolbar floats over them

🤖 Generated with [Claude Code](https://claude.com/claude-code)