### PR TITLE
Ease the chrome-overlay tuck under the full-screen tab bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@ A macOS app for previewing Markdown files. AppKit, sandboxed, ships with a Quick
 
 ## Project facts
 
-| Thing | Value |
-|---|---|
-| Bundle id | `doc.md-preview` |
-| Product name | `Markdown Preview` |
-| Scheme | `md-preview` |
-| Quick Look target | `quick-look` (embedded extension) |
-| Min macOS | 15.0 |
-| Sandboxed | yes — uses Sparkle XPC services for updates |
-| Auto-updater | Sparkle 2.x (Swift package) |
-| Distribution | Amore (managed) with custom domain `storage.md-preview.app` |
+| Thing             | Value                                                       |
+| ----------------- | ----------------------------------------------------------- |
+| Bundle id         | `doc.md-preview`                                            |
+| Product name      | `Markdown Preview`                                          |
+| Scheme            | `md-preview`                                                |
+| Quick Look target | `quick-look` (embedded extension)                           |
+| Min macOS         | 15.0                                                        |
+| Sandboxed         | yes — uses Sparkle XPC services for updates                 |
+| Auto-updater      | Sparkle 2.x (Swift package)                                 |
+| Distribution      | Amore (managed) with custom domain `storage.md-preview.app` |
 
 Version is managed centrally in `Version.xcconfig` (`MARKETING_VERSION`, `CURRENT_PROJECT_VERSION`). Both the app and the quick-look extension inherit from it.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Bump `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in `Version.xcconfig`, th
 
 Use `./scripts/rollback-release.sh` to revert the appcast pointer if a release misbehaves.
 
-## Contributing
+### Contributing
+
 
 Pull requests are welcome. For larger changes, please open an issue first to discuss what you'd like to change.
 

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -16,6 +16,19 @@ final class MainSplitViewController: NSSplitViewController {
     /// (EditorViewController.fullChromeTopInset).
     static let formattingBarTabBarOverlap: CGFloat = 6
 
+    /// Full screen draws the tab bar with a thinner bottom margin, so the
+    /// standard tuck overshoots and the bars crowd the tabs — back off.
+    static let formattingBarTabBarOverlapFullScreen: CGFloat = 2
+
+    /// The overlap currently in effect for `window`: zero without a
+    /// visible tab bar, reduced in full screen. The overlay constraints
+    /// and the editor's page padding must use the same value.
+    static func tabBarOverlap(for window: NSWindow?) -> CGFloat {
+        guard let window, window.tabGroup?.isTabBarVisible == true else { return 0 }
+        return window.styleMask.contains(.fullScreen)
+            ? formattingBarTabBarOverlapFullScreen : formattingBarTabBarOverlap
+    }
+
     var onSelectFile: ((URL) -> Void)?
     var onOpenMarkdownLink: ((URL) -> Void)?
     var onToggleTaskCheckbox: ((Int, Bool) -> Void)?
@@ -613,8 +626,7 @@ private final class LayeredContentViewController: NSViewController {
     /// chrome utility and inserts at the boundary, the way Apple's own
     /// find bars do.
     func updateChromeOverlayLayout() {
-        let overlap: CGFloat = (view.window?.tabGroup?.isTabBarVisible ?? false)
-            ? -MainSplitViewController.formattingBarTabBarOverlap : 0
+        let overlap = -MainSplitViewController.tabBarOverlap(for: view.window)
         if let top = findOverlayTopConstraint, top.constant != overlap {
             top.constant = overlap
         }

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -203,9 +203,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         }
         if overlays > 0 {
             gap += overlays
-            if window.tabGroup?.isTabBarVisible == true {
-                gap -= MainSplitViewController.formattingBarTabBarOverlap
-            }
+            gap -= MainSplitViewController.tabBarOverlap(for: window)
         }
         return max(0, gap)
     }


### PR DESCRIPTION
## Summary

Follow-up to #331.

- **Full-screen spacing**: full screen draws the tab bar with a thinner bottom margin, so the standard 6 pt tuck of the formatting/find bars overshot and the bars crowded the tabs. A shared `MainSplitViewController.tabBarOverlap(for:)` now resolves the effective overlap — 6 pt in normal windows, 2 pt in full screen, zero without a visible tab bar — and both the overlay constraints and the editor's page padding read it, so they cannot drift apart. Full-screen transitions re-evaluate it through the existing `contentLayoutRect` observation.
- **Docs**: AGENTS.md project-facts table reflowed, small README heading tweak.

## Test plan

- [ ] Full screen with tabs + edit mode: the bars sit slightly below the tabs instead of crowding them
- [ ] Normal window with tabs: spacing unchanged from #331 (6 pt tuck)
- [ ] Enter/leave full screen while editing: bar position and editor padding follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)