### PR TITLE
Reading fonts, layout controls and a Customize Theme sheet

### DIFF
--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 				"Rendering/MarkdownHTML+Utils.swift",
 				Rendering/MarkdownWebView.swift,
 				Rendering/QuickLookAppearance.swift,
+				Rendering/ReaderLayoutSetting.swift,
 				Rendering/URLSchemeTaskCallbackGate.swift,
 			);
 			target = 9A02092C2FA10D4C00092060 /* quick-look */;

--- a/md-preview/App/AppDelegate.swift
+++ b/md-preview/App/AppDelegate.swift
@@ -83,6 +83,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
 
     private var settingsWindowController: SettingsWindowController?
+    /// Non-zero while `withCoalescedPreviewReloads` is holding reloads back.
+    private var coalescedReloadDepth = 0
+    private var needsCoalescedPreviewReload = false
 
     private weak var hideSidebarMenuItem: NSMenuItem?
     private weak var outlineMenuItem: NSMenuItem?
@@ -306,8 +309,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller.show()
     }
 
-    /// Opens Settings directly on a pane — the toolbar popover's Customize
-    /// button lands on Appearance.
+    /// Opens Settings directly on a pane.
     func showSettingsWindow(pane: SettingsPane) {
         SettingsModel.shared.refreshFromExternalSources()
         SettingsModel.shared.reloadOpenTargets()
@@ -337,6 +339,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applyDocumentFontSetting(_ setting: DocumentFontSetting) {
         guard setting != DocumentFontSetting.current else { return }
         DocumentFontSetting.current = setting
+        reloadDocumentPreviewsForSettingChange()
+    }
+
+    /// Applies reading layout chosen in Customize Theme (bold text and the
+    /// spacing sliders). Same shape as the font: store to the app group,
+    /// re-render open documents, and Quick Look picks it up on its next
+    /// preview.
+    func applyReaderLayoutSetting(_ setting: ReaderLayoutSetting) {
+        guard setting != ReaderLayoutSetting.current else { return }
+        ReaderLayoutSetting.current = setting
         reloadDocumentPreviewsForSettingChange()
     }
 
@@ -1038,10 +1050,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func reloadDocumentPreviewsForSettingChange() {
+        guard coalescedReloadDepth == 0 else {
+            needsCoalescedPreviewReload = true
+            return
+        }
         NSDocumentController.shared.documents
             .flatMap(\.windowControllers)
             .compactMap { $0 as? DocumentWindowController }
             .forEach { $0.reloadPreviewForSettingChange() }
+    }
+
+    /// Runs `body` with preview reloads held back, then issues at most one.
+    /// Applying a theme preset changes colors, appearance, the reading face
+    /// and the body weight, and each of those would otherwise re-render
+    /// every open document on its own.
+    func withCoalescedPreviewReloads(_ body: () -> Void) {
+        coalescedReloadDepth += 1
+        body()
+        coalescedReloadDepth -= 1
+        guard coalescedReloadDepth == 0, needsCoalescedPreviewReload else { return }
+        needsCoalescedPreviewReload = false
+        reloadDocumentPreviewsForSettingChange()
     }
 
     private func installAppMenuItemIcons() {

--- a/md-preview/App/AppDelegate.swift
+++ b/md-preview/App/AppDelegate.swift
@@ -306,6 +306,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller.show()
     }
 
+    /// Opens Settings directly on a pane — the toolbar popover's Customize
+    /// button lands on Appearance.
+    func showSettingsWindow(pane: SettingsPane) {
+        SettingsModel.shared.refreshFromExternalSources()
+        SettingsModel.shared.reloadOpenTargets()
+        let controller = settingsWindowController ?? SettingsWindowController()
+        settingsWindowController = controller
+        controller.show(pane: pane)
+    }
+
     /// Applies an appearance chosen in Settings, keeping the View menu's check
     /// marks and every open preview in step.
     func applyAppearanceSetting(_ mode: AppearanceMode) {

--- a/md-preview/App/AppDelegate.swift
+++ b/md-preview/App/AppDelegate.swift
@@ -343,13 +343,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Applies reading layout chosen in Customize Theme (bold text and the
-    /// spacing sliders). Same shape as the font: store to the app group,
-    /// re-render open documents, and Quick Look picks it up on its next
-    /// preview.
+    /// spacing sliders). The values are CSS custom properties, so open pages
+    /// are restyled in place rather than re-rendered — cheap enough to run on
+    /// every slider tick, which is what makes the document itself the
+    /// preview. Quick Look reads the stored value on its next preview.
     func applyReaderLayoutSetting(_ setting: ReaderLayoutSetting) {
         guard setting != ReaderLayoutSetting.current else { return }
         ReaderLayoutSetting.current = setting
-        reloadDocumentPreviewsForSettingChange()
+        documentWindowControllers.forEach { $0.applyReaderLayoutSetting() }
     }
 
     /// Pushes a text size chosen in Settings into every open document. The

--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -368,6 +368,10 @@ final class ContentViewController: NSViewController {
     /// Repaints the native page background and restyles the loaded preview
     /// page after a theme color change in Settings.
 
+    func applyReaderLayout() {
+        webView.applyReaderLayout()
+    }
+
     func applyThemeColors() {
         view.needsDisplay = true
         toolbarGutterView.needsDisplay = true

--- a/md-preview/Document/DocumentWindowController+Sidebar.swift
+++ b/md-preview/Document/DocumentWindowController+Sidebar.swift
@@ -90,6 +90,11 @@ extension DocumentWindowController {
         currentSidebarMenuState()
     }
 
+    func applyReaderLayoutSetting() {
+        (documentWindow.contentViewController as? MainSplitViewController)?
+            .applyReaderLayout()
+    }
+
     func reloadPreviewForSettingChange() {
         (documentWindow.contentViewController as? MainSplitViewController)?
             .reloadPreviewForSettingChange()

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import SwiftUI
 
 extension NSToolbarItem.Identifier {
     static let openActions = NSToolbarItem.Identifier("OpenActions")
@@ -20,6 +21,7 @@ extension NSToolbarItem.Identifier {
     static let exportPDF = NSToolbarItem.Identifier("ExportPDF")
     static let copyMarkdown = NSToolbarItem.Identifier("CopyMarkdown")
     static let zoom = NSToolbarItem.Identifier("Zoom")
+    static let themesAndSettings = NSToolbarItem.Identifier("ThemesAndSettings")
     static let editDocument = NSToolbarItem.Identifier("EditDocument")
     static let navigation = NSToolbarItem.Identifier("Navigation")
     static let alwaysOnTop = NSToolbarItem.Identifier("AlwaysOnTop")
@@ -45,7 +47,7 @@ extension DocumentWindowController {
             .flexibleSpace,
             .openActions,
             .space,
-            .zoom,
+            .themesAndSettings,
             .inspector,
             .share,
             .editDocument,
@@ -70,6 +72,7 @@ extension DocumentWindowController {
             .exportPDF,
             .exportDocument,
             .copyMarkdown,
+            .themesAndSettings,
             .zoom,
             .alwaysOnTop
         ]
@@ -100,6 +103,7 @@ extension DocumentWindowController {
         case .exportDocument: return makeExportItem()
         case .copyMarkdown: return makeCopyItem()
         case .zoom: return makeZoomItem()
+        case .themesAndSettings: return makeThemesAndSettingsItem()
         default: return nil
         }
     }
@@ -366,6 +370,75 @@ extension DocumentWindowController {
         case 1: split.zoomInDocument(sender)
         default: break
         }
+    }
+
+    /// The "aA" button that replaced the zoom pair in the default set. It
+    /// opens a popover with text size, appearance, and the theme preset
+    /// gallery; Customize inside it leads to the Appearance settings pane.
+    /// A plain NSButton for the same reason as makeToggleButtonItem: on
+    /// macOS 26 it shares glass with its neighbors.
+    private func makeThemesAndSettingsItem() -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: .themesAndSettings)
+        let label = NSLocalizedString("Themes & Settings",
+                                      comment: "Themes & Settings toolbar item label")
+        let image = NSImage(systemSymbolName: "textformat.size",
+                            accessibilityDescription: label) ?? NSImage()
+        let button = NSButton(image: image, target: self,
+                              action: #selector(showThemesPopover(_:)))
+        button.setButtonType(.momentaryPushIn)
+        button.isBordered = true
+        button.toolTip = NSLocalizedString("Text size, appearance, and themes",
+                                           comment: "Themes & Settings toolbar item tooltip")
+        item.view = button
+        item.label = label
+        item.paletteLabel = label
+        item.toolTip = button.toolTip
+        return item
+    }
+
+    @objc private func showThemesPopover(_ sender: NSButton) {
+        if let popover = themesPopover, popover.isShown {
+            popover.close()
+            return
+        }
+        let host = NSHostingController(rootView: ThemesPopoverView(
+            decreaseTextSize: { [weak self] in
+                (self?.documentWindow.contentViewController as? MainSplitViewController)?
+                    .zoomOutDocument(nil)
+            },
+            increaseTextSize: { [weak self] in
+                (self?.documentWindow.contentViewController as? MainSplitViewController)?
+                    .zoomInDocument(nil)
+            },
+            openCustomize: { [weak self] in
+                self?.themesPopover?.close()
+                (NSApp.delegate as? AppDelegate)?.showSettingsWindow(pane: .theme)
+            }
+        ))
+        host.sizingOptions = .preferredContentSize
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentViewController = host
+        themesPopover = popover
+        popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+    }
+
+    /// One-time swap for toolbars restored from an autosaved configuration
+    /// that predates the Themes & Settings item: the zoom pair gives its
+    /// place to the popover button. Guarded by a defaults flag so a user
+    /// who rearranges things in Customize Toolbar afterwards keeps their
+    /// layout on the next launch.
+    private static let didReplaceZoomItemKey = "Toolbar.DidReplaceZoomWithThemesAndSettings"
+
+    func replaceZoomToolbarItemIfNeeded(in toolbar: NSToolbar) {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.didReplaceZoomItemKey) else { return }
+        defaults.set(true, forKey: Self.didReplaceZoomItemKey)
+        guard !toolbar.items.contains(where: { $0.itemIdentifier == .themesAndSettings }),
+              let zoomIndex = toolbar.items.firstIndex(where: { $0.itemIdentifier == .zoom })
+        else { return }
+        toolbar.removeItem(at: zoomIndex)
+        toolbar.insertItem(withItemIdentifier: .themesAndSettings, at: zoomIndex)
     }
 
     private func inspectorImage() -> NSImage {

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -48,6 +48,7 @@ extension DocumentWindowController {
             .openActions,
             .space,
             .themesAndSettings,
+            .space,
             .inspector,
             .share,
             .editDocument,
@@ -410,18 +411,43 @@ extension DocumentWindowController {
                 (self?.documentWindow.contentViewController as? MainSplitViewController)?
                     .zoomInDocument(nil)
             },
+            currentZoom: { [weak self] in
+                (self?.documentWindow.contentViewController as? MainSplitViewController)?
+                    .documentPageZoom ?? 1.0
+            },
             openCustomize: { [weak self] in
                 self?.themesPopover?.close()
-                (NSApp.delegate as? AppDelegate)?.showSettingsWindow(pane: .theme)
+                guard let window = self?.documentWindow else { return }
+                // Presented after the popover has actually gone: closing it is
+                // not synchronous, and a sheet raised while the popover's
+                // window still holds key arrives inactive.
+                DispatchQueue.main.async { CustomizeThemeSheet.present(on: window) }
             }
         ))
         host.sizingOptions = .preferredContentSize
         let popover = NSPopover()
         popover.behavior = .transient
         popover.contentViewController = host
+        popover.delegate = self
         themesPopover = popover
         popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+        themesPopoverEscapeMonitor.start { [weak self] in
+            guard let popover = self?.themesPopover, popover.isShown else { return false }
+            popover.close()
+            return true
+        }
     }
+
+    /// However the popover went away — Escape, an outside click, the toolbar
+    /// button again, or Customize — the key monitor goes with it.
+    func popoverDidClose(_ notification: Notification) {
+        themesPopoverEscapeMonitor.stop()
+        // Dropped rather than kept for reuse: holding it retains the hosting
+        // controller and the whole card gallery for the window's lifetime,
+        // and the next press builds a fresh one anyway.
+        themesPopover = nil
+    }
+
 
     /// One-time swap for toolbars restored from an autosaved configuration
     /// that predates the Themes & Settings item: the zoom pair gives its
@@ -442,7 +468,7 @@ extension DocumentWindowController {
     }
 
     private func inspectorImage() -> NSImage {
-        let image = NSImage(systemSymbolName: "info.circle",
+        let image = NSImage(systemSymbolName: "info",
                             accessibilityDescription: NSLocalizedString("Inspector", comment: "Inspector toolbar image")) ?? NSImage()
         image.isTemplate = true
         return image

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -13,7 +13,7 @@ import UniformTypeIdentifiers
 // reachable from AppKit through an @objc entry point, and `NSWindowController` has
 // no such method to override, so without this conformance the implementation below
 // is never called: no menu item ever gets its state, and the failure is silent.
-final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate, NSSearchFieldDelegate, NSMenuDelegate, NSMenuItemValidation {
+final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSToolbarDelegate, NSSharingServicePickerToolbarItemDelegate, NSSearchFieldDelegate, NSMenuDelegate, NSMenuItemValidation, NSPopoverDelegate {
 
     enum NavigationIntent {
         case normal
@@ -108,6 +108,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     var copyFeedbackWork: DispatchWorkItem?
     /// The Themes & Settings popover while it is on screen.
     var themesPopover: NSPopover?
+    /// Armed only while the themes popover is open.
+    let themesPopoverEscapeMonitor = EscapeKeyMonitor()
     weak var searchField: NSSearchField?
     weak var sidebarMenu: NSMenu?
     var findBar: FindBar?
@@ -337,6 +339,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     func windowWillClose(_ notification: Notification) {
         fileWatcher?.cancel()
         fileWatcher = nil
+        themesPopoverEscapeMonitor.stop()
         stopAutoSaveTimer()
         autoSaveFeedbackResetWork?.cancel()
         autoSaveFeedbackResetWork = nil

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -106,6 +106,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     weak var editBar: NSView?
     weak var copyItem: NSToolbarItem?
     var copyFeedbackWork: DispatchWorkItem?
+    /// The Themes & Settings popover while it is on screen.
+    var themesPopover: NSPopover?
     weak var searchField: NSSearchField?
     weak var sidebarMenu: NSMenu?
     var findBar: FindBar?
@@ -208,6 +210,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         toolbar.autosavesConfiguration = true
         documentWindow.toolbar = toolbar
         documentWindow.toolbarStyle = .automatic
+        replaceZoomToolbarItemIfNeeded(in: toolbar)
 
         installFindBar()
         applyWindowBackgroundTheme()

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -221,6 +221,10 @@ final class MainSplitViewController: NSSplitViewController {
         sidebarViewController?.setMode(mode)
     }
 
+    func applyReaderLayout() {
+        contentViewController?.applyReaderLayout()
+    }
+
     func reloadPreviewForSettingChange() {
         contentViewController?.reloadPreviewForSettingChange()
     }

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -146,6 +146,12 @@ final class MainSplitViewController: NSSplitViewController {
         contentViewController?.exportPDF()
     }
 
+    /// The document's current page zoom, for the toolbar popover's text-size
+    /// scale. 1.0 when there is no content view yet — the default stop.
+    var documentPageZoom: CGFloat {
+        contentViewController?.pageZoom ?? 1.0
+    }
+
     @IBAction func zoomInDocument(_ sender: Any?) {
         contentViewController?.zoomIn()
     }

--- a/md-preview/Features/Settings/CustomizeThemeView.swift
+++ b/md-preview/Features/Settings/CustomizeThemeView.swift
@@ -13,11 +13,11 @@
 //  control changes what that document looks like, and the reader needs the
 //  page it belongs to still on screen behind it.
 //
-//  Font picks apply through SettingsModel immediately. Slider moves edit a
-//  local draft so the preview tracks the drag, and commit on release —
-//  every commit re-renders the open documents, which is too heavy per tick.
-//  Every change is live, so the header's ✗ restores the values the sheet
-//  opened with and ✓ keeps them.
+//  Every control writes straight through SettingsModel, so the document
+//  behind the sheet is the preview — including mid-drag, because reader
+//  layout is delivered as CSS custom properties that the page restyles in
+//  place rather than re-rendering. The header's ✗ restores the values the
+//  sheet opened with and ✓ keeps them.
 //
 
 import SwiftUI
@@ -26,7 +26,6 @@ struct CustomizeThemeView: View {
     @Bindable private var model = SettingsModel.shared
     @Environment(\.colorScheme) private var colorScheme
     @State private var showsFontList = false
-    @State private var draft = ReaderLayoutSetting.current
     /// What to put back if the reader cancels, as it stood when the sheet
     /// was built.
     private let snapshot: Snapshot
@@ -64,32 +63,30 @@ struct CustomizeThemeView: View {
                             fontRow(setting)
                         }
                     }
-                    Toggle(isOn: $draft.boldText) {
+                    Toggle(isOn: $model.readerLayout.boldText) {
                         Label(L("Bold Text"), systemImage: "bold")
                     }
-                    .onChange(of: draft.boldText) { commit() }
                 }
 
                 Section(L("Accessibility & Layout Options")) {
-                    Toggle(L("Customize"), isOn: $draft.isCustomized)
-                        .onChange(of: draft.isCustomized) { commit() }
-                    if draft.isCustomized {
+                    Toggle(L("Customize"), isOn: $model.readerLayout.isCustomized)
+                    if model.readerLayout.isCustomized {
                         sliderRow(L("Line Spacing"),
                                   systemImage: "arrow.up.and.down.text.horizontal",
-                                  value: $draft.lineSpacing,
+                                  value: $model.readerLayout.lineSpacing,
                                   range: ReaderLayoutSetting.lineSpacingRange,
                                   display: { String(format: "%.2f", $0) })
                         sliderRow(L("Character Spacing"),
                                   systemImage: "arrow.left.and.right.text.vertical",
-                                  value: $draft.characterSpacingPercent,
+                                  value: $model.readerLayout.characterSpacingPercent,
                                   range: ReaderLayoutSetting.characterSpacingRange)
                         sliderRow(L("Word Spacing"),
                                   systemImage: "text.word.spacing",
-                                  value: $draft.wordSpacingPercent,
+                                  value: $model.readerLayout.wordSpacingPercent,
                                   range: ReaderLayoutSetting.wordSpacingRange)
                         sliderRow(L("Margins"),
                                   systemImage: "inset.filled.center.rectangle",
-                                  value: $draft.marginsPercent,
+                                  value: $model.readerLayout.marginsPercent,
                                   range: ReaderLayoutSetting.marginsRange)
                     }
                 }
@@ -131,18 +128,7 @@ struct CustomizeThemeView: View {
         .frame(width: Self.contentSize.width, height: Self.contentSize.height)
         .onAppear {
             model.refreshFromExternalSources()
-            draft = model.readerLayout
         }
-        .onChange(of: model.readerLayout) {
-            // Skipped when this is the echo of our own commit: assigning an
-            // equal value still costs a whole body pass.
-            guard draft != model.readerLayout else { return }
-            draft = model.readerLayout
-        }
-    }
-
-    private func commit() {
-        model.readerLayout = draft
     }
 
     /// Restores what the sheet opened with and closes it. The ✗ button and
@@ -236,12 +222,12 @@ struct CustomizeThemeView: View {
             ?? ThemeColorsSetting.defaultColor(.windowBackground, scheme))
         let text = Color(nsColor: model.themeColors.color(.textColor, scheme)
             ?? ThemeColorsSetting.defaultColor(.textColor, scheme))
-        let weight: Font.Weight = draft.boldText ? .semibold : .regular
+        let weight: Font.Weight = model.readerLayout.boldText ? .semibold : .regular
         let bodySize: CGFloat = 13
         // Approximations of the page CSS: SwiftUI lineSpacing is the extra
         // points between lines, kerning maps the percent to points. Word
         // spacing has no SwiftUI counterpart; the documents show it.
-        let applied = draft.effective
+        let applied = model.readerLayout.effective
         let extraLeading = bodySize * CGFloat(applied.lineSpacing - 1.0)
         let kerning = bodySize * CGFloat(applied.characterSpacingPercent / 100)
         let marginInset = 28 + CGFloat(applied.pageInset)
@@ -251,7 +237,7 @@ struct CustomizeThemeView: View {
             header
             Text(verbatim: "Aa")
                 .font(model.documentFont.font(size: 34))
-                .fontWeight(draft.boldText ? .bold : .medium)
+                .fontWeight(model.readerLayout.boldText ? .bold : .medium)
                 .foregroundStyle(text)
                 .padding(.horizontal, 28)
             Text(L("Markdown reads the way you set it here — this paragraph previews the font, weight and spacing your documents will use."))
@@ -380,9 +366,7 @@ struct CustomizeThemeView: View {
                 Image(systemName: systemImage)
                     .frame(width: 20)
                     .foregroundStyle(.secondary)
-                Slider(value: value, in: range) { editing in
-                    if !editing { commit() }
-                }
+                Slider(value: value, in: range)
                 Text(display(value.wrappedValue))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)

--- a/md-preview/Features/Settings/CustomizeThemeView.swift
+++ b/md-preview/Features/Settings/CustomizeThemeView.swift
@@ -1,0 +1,441 @@
+//
+//  CustomizeThemeView.swift
+//  md-preview
+//
+//  The Customize Theme sheet behind the toolbar popover's Customize button,
+//  modeled on Apple Books: a live preview in the current theme colors, the
+//  reading font list, a Bold Text switch, and — behind an explicit
+//  Customize gate — line spacing, character spacing, word spacing and
+//  margin sliders. It also carries the per-surface color wells, which is
+//  where they moved when the Appearance settings pane went away.
+//
+//  A sheet on the document window rather than a separate window: every
+//  control changes what that document looks like, and the reader needs the
+//  page it belongs to still on screen behind it.
+//
+//  Font picks apply through SettingsModel immediately. Slider moves edit a
+//  local draft so the preview tracks the drag, and commit on release —
+//  every commit re-renders the open documents, which is too heavy per tick.
+//  Every change is live, so the header's ✗ restores the values the sheet
+//  opened with and ✓ keeps them.
+//
+
+import SwiftUI
+
+struct CustomizeThemeView: View {
+    @Bindable private var model = SettingsModel.shared
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var showsFontList = false
+    @State private var draft = ReaderLayoutSetting.current
+    /// What to put back if the reader cancels, as it stood when the sheet
+    /// was built.
+    private let snapshot: Snapshot
+
+    /// The sheet's fixed size, shared with the hosting controller so it does
+    /// not have to measure the content itself.
+    static let contentSize = CGSize(width: 660, height: 680)
+
+    private let dismiss: () -> Void
+
+    init(dismiss: @escaping () -> Void) {
+        self.dismiss = dismiss
+        let model = SettingsModel.shared
+        snapshot = Snapshot(readerLayout: model.readerLayout,
+                            documentFont: model.documentFont,
+                            themeColors: model.themeColors)
+    }
+
+    /// Everything the sheet can change, as it stood when the sheet opened.
+    private struct Snapshot {
+        let readerLayout: ReaderLayoutSetting
+        let documentFont: DocumentFontSetting
+        let themeColors: ThemeColorsSetting
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            previewPane
+            Divider()
+            Form {
+                Section(L("Text")) {
+                    fontHeaderRow
+                    if showsFontList {
+                        ForEach(DocumentFontSetting.allCases, id: \.self) { setting in
+                            fontRow(setting)
+                        }
+                    }
+                    Toggle(isOn: $draft.boldText) {
+                        Label(L("Bold Text"), systemImage: "bold")
+                    }
+                    .onChange(of: draft.boldText) { commit() }
+                }
+
+                Section(L("Accessibility & Layout Options")) {
+                    Toggle(L("Customize"), isOn: $draft.isCustomized)
+                        .onChange(of: draft.isCustomized) { commit() }
+                    if draft.isCustomized {
+                        sliderRow(L("Line Spacing"),
+                                  systemImage: "arrow.up.and.down.text.horizontal",
+                                  value: $draft.lineSpacing,
+                                  range: ReaderLayoutSetting.lineSpacingRange,
+                                  display: { String(format: "%.2f", $0) })
+                        sliderRow(L("Character Spacing"),
+                                  systemImage: "arrow.left.and.right.text.vertical",
+                                  value: $draft.characterSpacingPercent,
+                                  range: ReaderLayoutSetting.characterSpacingRange)
+                        sliderRow(L("Word Spacing"),
+                                  systemImage: "text.word.spacing",
+                                  value: $draft.wordSpacingPercent,
+                                  range: ReaderLayoutSetting.wordSpacingRange)
+                        sliderRow(L("Margins"),
+                                  systemImage: "inset.filled.center.rectangle",
+                                  value: $draft.marginsPercent,
+                                  range: ReaderLayoutSetting.marginsRange)
+                    }
+                }
+
+                // The colors the popover's preset cards write, exposed one
+                // surface at a time. The presets live in the popover; this is
+                // where a reader adjusts what a preset filled in.
+                Section {
+                    colorRow(L("Window background"), slot: .windowBackground)
+                    colorRow(L("Code block background"), slot: .codeBlockBackground)
+                    colorRow(L("Text"), slot: .textColor)
+                    colorRow(L("Link"), slot: .linkColor)
+                } header: {
+                    Text(L("Colors"))
+                } footer: {
+                    Text(model.appearance == .automatic
+                        ? L("Each color has a separate value for the Light and Dark appearance. Picking the default color removes the override.")
+                        : L("Colors apply to the current appearance. Choose the Automatic appearance to set Light and Dark separately."))
+                }
+
+                // A full-width destructive row rather than a trailing button:
+                // it resets the whole look — theme, reading face and spacing —
+                // not just the colors above it.
+                Section {
+                    Button {
+                        model.resetReadingLook()
+                    } label: {
+                        Text(L("Reset Theme"))
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!model.isReadingLookCustomized)
+                }
+            }
+            .formStyle(.grouped)
+        }
+        .frame(width: Self.contentSize.width, height: Self.contentSize.height)
+        .onAppear {
+            model.refreshFromExternalSources()
+            draft = model.readerLayout
+        }
+        .onChange(of: model.readerLayout) {
+            // Skipped when this is the echo of our own commit: assigning an
+            // equal value still costs a whole body pass.
+            guard draft != model.readerLayout else { return }
+            draft = model.readerLayout
+        }
+    }
+
+    private func commit() {
+        model.readerLayout = draft
+    }
+
+    /// Restores what the sheet opened with and closes it. The ✗ button and
+    /// Escape (via the hosting controller's `cancelOperation`) both land here.
+    func cancel() {
+        model.readerLayout = snapshot.readerLayout
+        model.documentFont = snapshot.documentFont
+        model.themeColors = snapshot.themeColors
+        dismiss()
+    }
+
+    // MARK: - Header
+
+    /// Books' header: cancel on the left, the title centered, done on the
+    /// right. Both buttons close the sheet; only ✗ puts the old values back.
+    private var header: some View {
+        ZStack {
+            Text(L("Customize Theme"))
+                .font(.system(size: 13, weight: .semibold))
+            HStack {
+                circleButton("xmark", prominent: false,
+                             title: L("Cancel"), action: cancel)
+                Spacer()
+                circleButton("checkmark", prominent: true,
+                             title: L("Done"), action: dismiss)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 16)
+    }
+
+    /// Liquid Glass circles on macOS 26 — Done takes the prominent, accent
+    /// tinted variant, Cancel the clear one — falling back to drawn circles
+    /// on macOS 15, which has no glass button style.
+    private func circleButton(_ symbol: String,
+                              prominent: Bool,
+                              title: String,
+                              action: @escaping () -> Void) -> some View {
+        styledCircleButton(symbol, prominent: prominent, action: action)
+            .help(title)
+            .accessibilityLabel(title)
+    }
+
+    @ViewBuilder
+    private func styledCircleButton(_ symbol: String,
+                                    prominent: Bool,
+                                    action: @escaping () -> Void) -> some View {
+        if #available(macOS 26.0, *) {
+            Group {
+                if prominent {
+                    Button(action: action) { glyph(symbol) }
+                        .buttonStyle(.glassProminent)
+                } else {
+                    Button(action: action) { glyph(symbol) }
+                        .buttonStyle(.glass)
+                }
+            }
+            .buttonBorderShape(.circle)
+        } else {
+            Button(action: action) {
+                glyph(symbol)
+                    // The filled circle inverts with the appearance, so the
+                    // glyph has to take the page color rather than white.
+                    .foregroundStyle(prominent
+                                     ? Color(nsColor: .textBackgroundColor)
+                                     : Color.primary)
+                    .background(
+                        Circle().fill(prominent
+                                      ? AnyShapeStyle(Color.primary.opacity(0.85))
+                                      : AnyShapeStyle(Color.primary.opacity(0.08)))
+                    )
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func glyph(_ symbol: String) -> some View {
+        Image(systemName: symbol)
+            .font(.system(size: 13, weight: .semibold))
+            .frame(width: 26, height: 26)
+    }
+
+    // MARK: - Preview
+
+    private var previewPane: some View {
+        let scheme: ThemeColorScheme = colorScheme == .dark ? .dark : .light
+        // Same fallback the colour wells below use, so with no overrides
+        // stored the preview shows what the page actually renders.
+        let page = Color(nsColor: model.themeColors.color(.windowBackground, scheme)
+            ?? ThemeColorsSetting.defaultColor(.windowBackground, scheme))
+        let text = Color(nsColor: model.themeColors.color(.textColor, scheme)
+            ?? ThemeColorsSetting.defaultColor(.textColor, scheme))
+        let weight: Font.Weight = draft.boldText ? .semibold : .regular
+        let bodySize: CGFloat = 13
+        // Approximations of the page CSS: SwiftUI lineSpacing is the extra
+        // points between lines, kerning maps the percent to points. Word
+        // spacing has no SwiftUI counterpart; the documents show it.
+        let applied = draft.effective
+        let extraLeading = bodySize * CGFloat(applied.lineSpacing - 1.0)
+        let kerning = bodySize * CGFloat(applied.characterSpacingPercent / 100)
+        let marginInset = 28 + CGFloat(applied.pageInset)
+        // The header rides on the page color rather than a chrome strip of
+        // its own, the way Books runs the sample page up under its buttons.
+        return VStack(alignment: .leading, spacing: 14) {
+            header
+            Text(verbatim: "Aa")
+                .font(model.documentFont.font(size: 34))
+                .fontWeight(draft.boldText ? .bold : .medium)
+                .foregroundStyle(text)
+                .padding(.horizontal, 28)
+            Text(L("Markdown reads the way you set it here — this paragraph previews the font, weight and spacing your documents will use."))
+                .font(model.documentFont.font(size: bodySize))
+                .fontWeight(weight)
+                .kerning(kerning)
+                .lineSpacing(extraLeading)
+                .foregroundStyle(text)
+                .padding(.horizontal, marginInset)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, 24)
+        .background(page)
+    }
+
+    // MARK: - Font list
+
+    private var fontHeaderRow: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) { showsFontList.toggle() }
+        } label: {
+            HStack {
+                Label(L("Font"), systemImage: "textformat")
+                Spacer()
+                Text(model.documentFont.title)
+                    .foregroundStyle(.secondary)
+                Image(systemName: showsFontList ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func fontRow(_ setting: DocumentFontSetting) -> some View {
+        Button {
+            model.documentFont = setting
+        } label: {
+            HStack {
+                Text(setting.title)
+                    .font(setting.font(size: 14))
+                Spacer()
+                if model.documentFont == setting {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+            }
+            .padding(.leading, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(model.documentFont == setting ? .isSelected : [])
+    }
+
+    // MARK: - Colors
+
+    /// One well while the appearance is pinned (it edits the look on screen);
+    /// separate labeled Light/Dark wells only in Automatic, where both
+    /// schemes are reachable. Two always-visible wells confused more than
+    /// they helped.
+    private func colorRow(_ title: String, slot: ThemeColorSlot) -> some View {
+        LabeledContent {
+            HStack(spacing: 16) {
+                switch model.appearance {
+                case .light:
+                    colorWell(L("Light"), slot: slot, scheme: .light, showsLabel: false)
+                case .dark:
+                    colorWell(L("Dark"), slot: slot, scheme: .dark, showsLabel: false)
+                case .automatic:
+                    colorWell(L("Light"), slot: slot, scheme: .light)
+                    colorWell(L("Dark"), slot: slot, scheme: .dark)
+                }
+            }
+        } label: {
+            Text(title)
+        }
+    }
+
+    private func colorWell(_ label: String,
+                           slot: ThemeColorSlot,
+                           scheme: ThemeColorScheme,
+                           showsLabel: Bool = true) -> some View {
+        HStack(spacing: 6) {
+            if showsLabel {
+                Text(label)
+                    .foregroundStyle(.secondary)
+            }
+            ColorPicker(label, selection: colorBinding(slot: slot, scheme: scheme),
+                        supportsOpacity: false)
+                .labelsHidden()
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func colorBinding(slot: ThemeColorSlot,
+                              scheme: ThemeColorScheme) -> Binding<Color> {
+        Binding(
+            get: {
+                let model = SettingsModel.shared
+                let nsColor = model.themeColors.color(slot, scheme)
+                    ?? ThemeColorsSetting.defaultColor(slot, scheme)
+                return Color(nsColor: nsColor)
+            },
+            set: { newValue in
+                SettingsModel.shared.setThemeColor(
+                    NSColor(newValue), slot: slot, scheme: scheme
+                )
+            }
+        )
+    }
+
+    // MARK: - Sliders
+
+    private func sliderRow(_ title: String,
+                           systemImage: String,
+                           value: Binding<Double>,
+                           range: ClosedRange<Double>,
+                           display: @escaping (Double) -> String = { "\(Int($0))%" })
+        -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title.uppercased(with: .current))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .frame(width: 20)
+                    .foregroundStyle(.secondary)
+                Slider(value: value, in: range) { editing in
+                    if !editing { commit() }
+                }
+                Text(display(value.wrappedValue))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .frame(width: 46, alignment: .trailing)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(title))
+    }
+}
+
+/// Escape reaches a sheet through `cancelOperation(_:)`, so the hosting
+/// controller forwards it to the view's own cancel — no key monitor needed.
+private final class SheetHostingController: NSHostingController<CustomizeThemeView> {
+    var cancelHandler: (() -> Void)?
+
+    override func cancelOperation(_ sender: Any?) {
+        cancelHandler?()
+    }
+}
+
+// MARK: - Presentation
+
+@MainActor
+enum CustomizeThemeSheet {
+
+    /// Presents the sheet on `window`, or brings the sheet it already has to
+    /// the front. AppKit owns the card's chrome, so the view draws only its
+    /// own header.
+    static func present(on window: NSWindow) {
+        // Only our own sheet counts as "already open": any other sheet (a
+        // save panel, an alert) would otherwise make the button a silent
+        // no-op that re-keys something unrelated.
+        if let existing = window.attachedSheet,
+           existing.contentViewController is SheetHostingController {
+            existing.makeKeyAndOrderFront(nil)
+            return
+        }
+        guard window.attachedSheet == nil else { return }
+        guard let host = window.contentViewController else { return }
+        // The controller is built first and its root view replaced after, so
+        // the dismiss closure can capture it weakly. Handing the closure a
+        // captured local `var controller` instead would retain the hosting
+        // controller through its own root view — a cycle that leaks the
+        // whole sheet, view tree and colour snapshot on every open.
+        let hosting = SheetHostingController(rootView: CustomizeThemeView(dismiss: {}))
+        hosting.rootView = CustomizeThemeView { [weak hosting] in
+            hosting?.dismiss(nil)
+        }
+        hosting.cancelHandler = { [weak hosting] in hosting?.rootView.cancel() }
+        // Size set directly rather than through `sizingOptions`, which runs a
+        // measuring layout pass before the view has a window.
+        hosting.preferredContentSize = CustomizeThemeView.contentSize
+        host.presentAsSheet(hosting)
+    }
+}

--- a/md-preview/Features/Settings/CustomizeThemeView.swift
+++ b/md-preview/Features/Settings/CustomizeThemeView.swift
@@ -9,15 +9,10 @@
 //  margin sliders. It also carries the per-surface color wells, which is
 //  where they moved when the Appearance settings pane went away.
 //
-//  A sheet on the document window rather than a separate window: every
-//  control changes what that document looks like, and the reader needs the
-//  page it belongs to still on screen behind it.
-//
-//  Every control writes straight through SettingsModel, so the document
-//  behind the sheet is the preview — including mid-drag, because reader
-//  layout is delivered as CSS custom properties that the page restyles in
-//  place rather than re-rendering. The header's ✗ restores the values the
-//  sheet opened with and ✓ keeps them.
+//  Every control edits a local draft, and the sample at the top of the
+//  sheet is what shows it — the open documents are left alone until ✓
+//  applies the draft in one step. ✗ and Escape simply close, so a reader
+//  can try faces and spacings without touching what they were reading.
 //
 
 import SwiftUI
@@ -26,29 +21,27 @@ struct CustomizeThemeView: View {
     @Bindable private var model = SettingsModel.shared
     @Environment(\.colorScheme) private var colorScheme
     @State private var showsFontList = false
-    /// What to put back if the reader cancels, as it stood when the sheet
-    /// was built.
-    private let snapshot: Snapshot
+    /// Everything the sheet can change, held locally until ✓.
+    @State private var draft: Draft
 
     /// The sheet's fixed size, shared with the hosting controller so it does
     /// not have to measure the content itself.
-    static let contentSize = CGSize(width: 660, height: 680)
+    static let contentSize = CGSize(width: 660, height: 760)
 
     private let dismiss: () -> Void
 
     init(dismiss: @escaping () -> Void) {
         self.dismiss = dismiss
         let model = SettingsModel.shared
-        snapshot = Snapshot(readerLayout: model.readerLayout,
-                            documentFont: model.documentFont,
-                            themeColors: model.themeColors)
+        _draft = State(initialValue: Draft(readerLayout: model.readerLayout,
+                                           documentFont: model.documentFont,
+                                           themeColors: model.themeColors))
     }
 
-    /// Everything the sheet can change, as it stood when the sheet opened.
-    private struct Snapshot {
-        let readerLayout: ReaderLayoutSetting
-        let documentFont: DocumentFontSetting
-        let themeColors: ThemeColorsSetting
+    struct Draft: Equatable {
+        var readerLayout: ReaderLayoutSetting
+        var documentFont: DocumentFontSetting
+        var themeColors: ThemeColorsSetting
     }
 
     var body: some View {
@@ -63,30 +56,30 @@ struct CustomizeThemeView: View {
                             fontRow(setting)
                         }
                     }
-                    Toggle(isOn: $model.readerLayout.boldText) {
+                    Toggle(isOn: $draft.readerLayout.boldText) {
                         Label(L("Bold Text"), systemImage: "bold")
                     }
                 }
 
                 Section(L("Accessibility & Layout Options")) {
-                    Toggle(L("Customize"), isOn: $model.readerLayout.isCustomized)
-                    if model.readerLayout.isCustomized {
+                    Toggle(L("Customize"), isOn: $draft.readerLayout.isCustomized)
+                    if draft.readerLayout.isCustomized {
                         sliderRow(L("Line Spacing"),
                                   systemImage: "arrow.up.and.down.text.horizontal",
-                                  value: $model.readerLayout.lineSpacing,
+                                  value: $draft.readerLayout.lineSpacing,
                                   range: ReaderLayoutSetting.lineSpacingRange,
                                   display: { String(format: "%.2f", $0) })
                         sliderRow(L("Character Spacing"),
                                   systemImage: "arrow.left.and.right.text.vertical",
-                                  value: $model.readerLayout.characterSpacingPercent,
+                                  value: $draft.readerLayout.characterSpacingPercent,
                                   range: ReaderLayoutSetting.characterSpacingRange)
                         sliderRow(L("Word Spacing"),
                                   systemImage: "text.word.spacing",
-                                  value: $model.readerLayout.wordSpacingPercent,
+                                  value: $draft.readerLayout.wordSpacingPercent,
                                   range: ReaderLayoutSetting.wordSpacingRange)
                         sliderRow(L("Margins"),
                                   systemImage: "inset.filled.center.rectangle",
-                                  value: $model.readerLayout.marginsPercent,
+                                  value: $draft.readerLayout.marginsPercent,
                                   range: ReaderLayoutSetting.marginsRange)
                     }
                 }
@@ -112,7 +105,7 @@ struct CustomizeThemeView: View {
                 // not just the colors above it.
                 Section {
                     Button {
-                        model.resetReadingLook()
+                        draft = Self.defaultDraft()
                     } label: {
                         Text(L("Reset Theme"))
                             .foregroundStyle(.red)
@@ -120,23 +113,35 @@ struct CustomizeThemeView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .disabled(!model.isReadingLookCustomized)
+                    .disabled(draft == Self.defaultDraft())
                 }
             }
             .formStyle(.grouped)
         }
         .frame(width: Self.contentSize.width, height: Self.contentSize.height)
-        .onAppear {
-            model.refreshFromExternalSources()
-        }
     }
 
-    /// Restores what the sheet opened with and closes it. The ✗ button and
-    /// Escape (via the hosting controller's `cancelOperation`) both land here.
+    /// The applied theme's look, which Reset Theme returns the draft to.
+    private static func defaultDraft() -> Draft {
+        let base = SettingsModel.shared.appliedPreset
+        return Draft(readerLayout: ReaderLayoutSetting(boldText: base.boldText),
+                     documentFont: base.font,
+                     themeColors: base.setting)
+    }
+
+    /// Closes without touching the documents — nothing was applied. The ✗
+    /// button and Escape (via the hosting controller's `cancelOperation`)
+    /// both land here.
     func cancel() {
-        model.readerLayout = snapshot.readerLayout
-        model.documentFont = snapshot.documentFont
-        model.themeColors = snapshot.themeColors
+        dismiss()
+    }
+
+    /// Writes the draft through in one step, so the open documents re-style
+    /// once rather than once per control.
+    private func save() {
+        model.applyReadingLook(themeColors: draft.themeColors,
+                               documentFont: draft.documentFont,
+                               readerLayout: draft.readerLayout)
         dismiss()
     }
 
@@ -153,7 +158,7 @@ struct CustomizeThemeView: View {
                              title: L("Cancel"), action: cancel)
                 Spacer()
                 circleButton("checkmark", prominent: true,
-                             title: L("Done"), action: dismiss)
+                             title: L("Done"), action: save)
             }
         }
         .padding(.horizontal, 18)
@@ -218,40 +223,83 @@ struct CustomizeThemeView: View {
         let scheme: ThemeColorScheme = colorScheme == .dark ? .dark : .light
         // Same fallback the colour wells below use, so with no overrides
         // stored the preview shows what the page actually renders.
-        let page = Color(nsColor: model.themeColors.color(.windowBackground, scheme)
+        let page = Color(nsColor: draft.themeColors.color(.windowBackground, scheme)
             ?? ThemeColorsSetting.defaultColor(.windowBackground, scheme))
-        let text = Color(nsColor: model.themeColors.color(.textColor, scheme)
+        let text = Color(nsColor: draft.themeColors.color(.textColor, scheme)
             ?? ThemeColorsSetting.defaultColor(.textColor, scheme))
-        let weight: Font.Weight = model.readerLayout.boldText ? .semibold : .regular
-        let bodySize: CGFloat = 13
-        // Approximations of the page CSS: SwiftUI lineSpacing is the extra
-        // points between lines, kerning maps the percent to points. Word
-        // spacing has no SwiftUI counterpart; the documents show it.
-        let applied = model.readerLayout.effective
-        let extraLeading = bodySize * CGFloat(applied.lineSpacing - 1.0)
-        let kerning = bodySize * CGFloat(applied.characterSpacingPercent / 100)
-        let marginInset = 28 + CGFloat(applied.pageInset)
         // The header rides on the page color rather than a chrome strip of
         // its own, the way Books runs the sample page up under its buttons.
-        return VStack(alignment: .leading, spacing: 14) {
+        return VStack(alignment: .leading, spacing: 16) {
             header
             Text(verbatim: "Aa")
-                .font(model.documentFont.font(size: 34))
-                .fontWeight(model.readerLayout.boldText ? .bold : .medium)
+                .font(draft.documentFont.font(size: Self.sampleTitleSize))
+                .fontWeight(draft.readerLayout.boldText ? .bold : .medium)
                 .foregroundStyle(text)
                 .padding(.horizontal, 28)
-            Text(L("Markdown reads the way you set it here — this paragraph previews the font, weight and spacing your documents will use."))
-                .font(model.documentFont.font(size: bodySize))
-                .fontWeight(weight)
-                .kerning(kerning)
-                .lineSpacing(extraLeading)
-                .foregroundStyle(text)
-                .padding(.horizontal, marginInset)
+            sampleColumns(text: text)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.bottom, 24)
         .background(page)
     }
+
+    /// Two columns of prose, cut off by a fade at the bottom: reading size,
+    /// wrapped over enough lines that line spacing, word spacing and the
+    /// margins read as themselves. The page continues past the fade the way
+    /// a real page would.
+    private func sampleColumns(text: Color) -> some View {
+        let applied = draft.readerLayout.effective
+        let size = Self.sampleBodySize
+        let extraLeading = size * CGFloat(applied.lineSpacing - 1.0)
+        let kerning = size * CGFloat(applied.characterSpacingPercent / 100)
+        let inset = 28 + CGFloat(applied.pageInset)
+        return HStack(alignment: .top, spacing: 24) {
+            ForEach(Array(Self.sampleColumns.enumerated()), id: \.offset) { column in
+                Text(column.element)
+                    .font(draft.documentFont.font(size: size))
+                    .fontWeight(draft.readerLayout.boldText ? .semibold : .regular)
+                    .kerning(kerning)
+                    .lineSpacing(extraLeading)
+                    .foregroundStyle(text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, inset)
+        .frame(height: Self.sampleHeight, alignment: .top)
+        .clipped()
+        .mask(
+            LinearGradient(stops: [.init(color: .black, location: 0),
+                                   .init(color: .black, location: 0.55),
+                                   .init(color: .clear, location: 1)],
+                           startPoint: .top,
+                           endPoint: .bottom)
+        )
+    }
+
+    private static let sampleTitleSize: CGFloat = 40
+    private static let sampleBodySize: CGFloat = 18
+    private static let sampleHeight: CGFloat = 250
+
+    /// Reading prose rather than a description of the sheet: the point is to
+    /// judge a face and a spacing, which needs ordinary sentences.
+    private static let sampleColumns: [String] = [
+        L("""
+        The team looking after our recommendation system has been spiking out \
+        some new algorithms, and the results are promising enough that we are \
+        planning to put them in front of readers next month. Long paragraphs \
+        are what make a reading face show its character: the rhythm of the \
+        lines, how the spacing settles, where the eye lands when it returns \
+        from the end of one line to the start of the next.
+        """),
+        L("""
+        Nothing you change here reaches your open documents until you tap the \
+        check mark, so try a few faces and spacings, then close with the cross \
+        to leave everything exactly as you found it. The sample keeps going \
+        past the bottom of this panel, the way a page would, so the measure \
+        and the margins have somewhere to show themselves before you commit \
+        to them.
+        """)
+    ]
 
     // MARK: - Font list
 
@@ -262,7 +310,7 @@ struct CustomizeThemeView: View {
             HStack {
                 Label(L("Font"), systemImage: "textformat")
                 Spacer()
-                Text(model.documentFont.title)
+                Text(draft.documentFont.title)
                     .foregroundStyle(.secondary)
                 Image(systemName: showsFontList ? "chevron.down" : "chevron.right")
                     .font(.system(size: 10, weight: .semibold))
@@ -275,13 +323,13 @@ struct CustomizeThemeView: View {
 
     private func fontRow(_ setting: DocumentFontSetting) -> some View {
         Button {
-            model.documentFont = setting
+            draft.documentFont = setting
         } label: {
             HStack {
                 Text(setting.title)
                     .font(setting.font(size: 14))
                 Spacer()
-                if model.documentFont == setting {
+                if draft.documentFont == setting {
                     Image(systemName: "checkmark")
                         .font(.system(size: 12, weight: .semibold))
                 }
@@ -290,7 +338,7 @@ struct CustomizeThemeView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityAddTraits(model.documentFont == setting ? .isSelected : [])
+        .accessibilityAddTraits(draft.documentFont == setting ? .isSelected : [])
     }
 
     // MARK: - Colors
@@ -337,18 +385,16 @@ struct CustomizeThemeView: View {
                               scheme: ThemeColorScheme) -> Binding<Color> {
         Binding(
             get: {
-                let model = SettingsModel.shared
-                let nsColor = model.themeColors.color(slot, scheme)
+                let nsColor = draft.themeColors.color(slot, scheme)
                     ?? ThemeColorsSetting.defaultColor(slot, scheme)
                 return Color(nsColor: nsColor)
             },
             set: { newValue in
-                SettingsModel.shared.setThemeColor(
-                    NSColor(newValue), slot: slot, scheme: scheme
-                )
+                draft.themeColors.setColor(NSColor(newValue), slot, scheme)
             }
         )
     }
+
 
     // MARK: - Sliders
 

--- a/md-preview/Features/Settings/CustomizeThemeView.swift
+++ b/md-preview/Features/Settings/CustomizeThemeView.swift
@@ -394,10 +394,33 @@ struct CustomizeThemeView: View {
     }
 }
 
-/// Escape reaches a sheet through `cancelOperation(_:)`, so the hosting
-/// controller forwards it to the view's own cancel — no key monitor needed.
+/// Escape cancels the sheet.
+///
+/// `cancelOperation(_:)` is the mechanism AppKit routes Escape through, but it
+/// starts at the first responder: once a control inside the SwiftUI content
+/// holds focus — a slider, a font row, a colour well — the keystroke can be
+/// swallowed before it reaches this controller. A key monitor scoped to this
+/// sheet's own window catches those, and `NSApp.keyWindow` identity keeps
+/// Escape typed into any other window out of it.
 private final class SheetHostingController: NSHostingController<CustomizeThemeView> {
     var cancelHandler: (() -> Void)?
+    private let escapeMonitor = EscapeKeyMonitor()
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        escapeMonitor.start { [weak self] in
+            guard let self, let window = view.window, NSApp.keyWindow === window else {
+                return false
+            }
+            cancelHandler?()
+            return true
+        }
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        escapeMonitor.stop()
+    }
 
     override func cancelOperation(_ sender: Any?) {
         cancelHandler?()

--- a/md-preview/Features/Settings/DocumentFontSetting+Font.swift
+++ b/md-preview/Features/Settings/DocumentFontSetting+Font.swift
@@ -1,0 +1,34 @@
+//
+//  DocumentFontSetting+Font.swift
+//  md-preview
+//
+//  SwiftUI font for each reading face, so the pickers and the theme cards
+//  render every option in the face it applies. Kept out of
+//  DocumentFontSetting itself: that file is shared with the Quick Look
+//  extension and the Foundation-only test package, and it carries CSS font
+//  stacks rather than AppKit faces.
+//
+//  Each case names the same first family its CSS stack does; the two must
+//  move together, or the previews stop matching the rendered page.
+//
+
+import SwiftUI
+
+extension DocumentFontSetting {
+    func font(size: CGFloat) -> Font {
+        switch self {
+        case .system: .system(size: size)
+        case .athelas: .custom("Athelas", size: size)
+        case .avenirNext: .custom("Avenir Next", size: size)
+        case .charter: .custom("Charter", size: size)
+        case .georgia: .custom("Georgia", size: size)
+        case .iowan: .custom("Iowan Old Style", size: size)
+        case .newYork: .system(size: size, design: .serif)
+        case .palatino: .custom("Palatino", size: size)
+        case .rounded: .system(size: size, design: .rounded)
+        case .seravek: .custom("Seravek", size: size)
+        case .timesNewRoman: .custom("Times New Roman", size: size)
+        case .monospace: .system(size: size, design: .monospaced)
+        }
+    }
+}

--- a/md-preview/Features/Settings/GeneralSettingsView.swift
+++ b/md-preview/Features/Settings/GeneralSettingsView.swift
@@ -13,12 +13,6 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Picker(L("Font"), selection: $model.documentFont) {
-                    ForEach(DocumentFontSetting.allCases, id: \.self) { setting in
-                        Text(setting.title).tag(setting)
-                    }
-                }
-
                 LabeledContent {
                     TextSizePicker(selection: $model.textSize)
                 } label: {
@@ -34,7 +28,7 @@ struct GeneralSettingsView: View {
             } header: {
                 Text(L("Reading"))
             } footer: {
-                Text(L("The font also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes the text size."))
+                Text(L("Text size also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes it too. Fonts and reading layout live in Appearance settings."))
             }
 
             Section {

--- a/md-preview/Features/Settings/SettingsModel.swift
+++ b/md-preview/Features/Settings/SettingsModel.swift
@@ -119,6 +119,18 @@ final class SettingsModel {
         applyPreset(.defaultPreset)
     }
 
+    /// The preset the stored colors correspond to. Colors that were never
+    /// customized count as the default preset — the app treats "no
+    /// overrides" as the default theme, so preset galleries always mark an
+    /// active card. Hand-edited colors that match no preset return nil
+    /// ("Custom colors").
+    var selectedPreset: ThemePreset? {
+        if let match = ThemePreset.builtIn.first(where: { themeColors == $0.setting }) {
+            return match
+        }
+        return themeColors.isCustomized ? nil : .defaultPreset
+    }
+
     /// Applies a preset: writes its palette into every slot for both
     /// schemes and switches the app appearance to the preset's flavor so
     /// the native chrome matches. A `.system` preset keeps the Automatic

--- a/md-preview/Features/Settings/SettingsModel.swift
+++ b/md-preview/Features/Settings/SettingsModel.swift
@@ -133,8 +133,15 @@ final class SettingsModel {
     private static let appliedPresetKey = "MarkdownPreview.theme.appliedPreset"
 
     var appliedPreset: ThemePreset {
-        let name = UserDefaults.standard.string(forKey: Self.appliedPresetKey)
-        return ThemePreset.builtIn.first { $0.name == name } ?? .defaultPreset
+        if let name = UserDefaults.standard.string(forKey: Self.appliedPresetKey),
+           let stored = ThemePreset.builtIn.first(where: { $0.name == name }) {
+            return stored
+        }
+        // No name recorded — the reader upgraded from a build that never
+        // wrote one. Fall back to whichever preset their stored colors
+        // match, so Reset returns them to the theme they are actually
+        // reading in rather than to the default one.
+        return selectedPreset ?? .defaultPreset
     }
 
     /// Applies a whole reading look at once — what the Customize Theme sheet

--- a/md-preview/Features/Settings/SettingsModel.swift
+++ b/md-preview/Features/Settings/SettingsModel.swift
@@ -137,25 +137,19 @@ final class SettingsModel {
         return ThemePreset.builtIn.first { $0.name == name } ?? .defaultPreset
     }
 
-    /// True while anything the Customize Theme sheet can change differs from
-    /// the applied theme — colors, the reading face, or the layout sliders.
-    var isReadingLookCustomized: Bool {
-        let base = appliedPreset
-        return themeColors != base.setting
-            || documentFont != base.font
-            || readerLayout != ReaderLayoutSetting(boldText: base.boldText)
-    }
-
-    /// Restores the applied theme's colors, face and weight and clears the
-    /// layout sliders, as a single document re-render.
-    func resetReadingLook() {
-        let base = appliedPreset
-        let reset = {
-            self.applyPresetValues(base)
-            self.readerLayout = ReaderLayoutSetting(boldText: base.boldText)
+    /// Applies a whole reading look at once — what the Customize Theme sheet
+    /// hands over when the reader saves. Coalesced, so the open documents
+    /// update once rather than once per dimension.
+    func applyReadingLook(themeColors newColors: ThemeColorsSetting,
+                          documentFont newFont: DocumentFontSetting,
+                          readerLayout newLayout: ReaderLayoutSetting) {
+        let apply = {
+            self.themeColors = newColors
+            self.documentFont = newFont
+            self.readerLayout = newLayout
         }
-        guard let appDelegate else { return reset() }
-        appDelegate.withCoalescedPreviewReloads(reset)
+        guard let appDelegate else { return apply() }
+        appDelegate.withCoalescedPreviewReloads(apply)
     }
 
     /// The preset the stored colors correspond to. Colors that were never

--- a/md-preview/Features/Settings/SettingsModel.swift
+++ b/md-preview/Features/Settings/SettingsModel.swift
@@ -37,6 +37,13 @@ final class SettingsModel {
         }
     }
 
+    var readerLayout: ReaderLayoutSetting {
+        didSet {
+            guard !isRestoringExternalValues, readerLayout != oldValue else { return }
+            appDelegate?.applyReaderLayoutSetting(readerLayout)
+        }
+    }
+
     var contentWidth: ContentWidthSetting {
         didSet {
             guard !isRestoringExternalValues, contentWidth != oldValue else { return }
@@ -119,6 +126,38 @@ final class SettingsModel {
         applyPreset(.defaultPreset)
     }
 
+    /// The theme the reader last applied from a gallery. Remembered so Reset
+    /// puts *that* theme back — hand-edited colors, a swapped face or moved
+    /// sliders undo to the theme they were built on, rather than dropping the
+    /// reader onto the default one.
+    private static let appliedPresetKey = "MarkdownPreview.theme.appliedPreset"
+
+    var appliedPreset: ThemePreset {
+        let name = UserDefaults.standard.string(forKey: Self.appliedPresetKey)
+        return ThemePreset.builtIn.first { $0.name == name } ?? .defaultPreset
+    }
+
+    /// True while anything the Customize Theme sheet can change differs from
+    /// the applied theme — colors, the reading face, or the layout sliders.
+    var isReadingLookCustomized: Bool {
+        let base = appliedPreset
+        return themeColors != base.setting
+            || documentFont != base.font
+            || readerLayout != ReaderLayoutSetting(boldText: base.boldText)
+    }
+
+    /// Restores the applied theme's colors, face and weight and clears the
+    /// layout sliders, as a single document re-render.
+    func resetReadingLook() {
+        let base = appliedPreset
+        let reset = {
+            self.applyPresetValues(base)
+            self.readerLayout = ReaderLayoutSetting(boldText: base.boldText)
+        }
+        guard let appDelegate else { return reset() }
+        appDelegate.withCoalescedPreviewReloads(reset)
+    }
+
     /// The preset the stored colors correspond to. Colors that were never
     /// customized count as the default preset — the app treats "no
     /// overrides" as the default theme, so preset galleries always mark an
@@ -136,12 +175,24 @@ final class SettingsModel {
     /// the native chrome matches. A `.system` preset keeps the Automatic
     /// appearance instead — its palettes carry both schemes.
     func applyPreset(_ preset: ThemePreset) {
+        guard let appDelegate else { return applyPresetValues(preset) }
+        // One re-render for the whole look rather than one per dimension.
+        appDelegate.withCoalescedPreviewReloads { applyPresetValues(preset) }
+    }
+
+    private func applyPresetValues(_ preset: ThemePreset) {
+        UserDefaults.standard.set(preset.name, forKey: Self.appliedPresetKey)
         themeColors = preset.setting
         switch preset.flavor {
         case .light: appearance = .light
         case .dark: appearance = .dark
         case .system: appearance = .automatic
         }
+        // A preset is a whole reading look, so it carries the face and the
+        // body weight with it. The spacing sliders are the reader's own and
+        // survive a preset change.
+        documentFont = preset.font
+        readerLayout.boldText = preset.boldText
     }
 
     var checksForUpdatesAutomatically: Bool {
@@ -195,6 +246,7 @@ final class SettingsModel {
         autoSaveIntervalMinutes = AutoSaveSetting.currentMinutes
         textSize = TextSizeSetting.current
         documentFont = DocumentFontSetting.current
+        readerLayout = ReaderLayoutSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         opensDocumentsInTabs = TabOpeningPolicy.isEnabled
         sendsCrashReports = CrashReporter.isEnabled
@@ -248,6 +300,7 @@ final class SettingsModel {
         autoSaveIntervalMinutes = AutoSaveSetting.currentMinutes
         textSize = TextSizeSetting.current
         documentFont = DocumentFontSetting.current
+        readerLayout = ReaderLayoutSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         opensDocumentsInTabs = TabOpeningPolicy.isEnabled
         sendsCrashReports = CrashReporter.isEnabled

--- a/md-preview/Features/Settings/ThemePresetCard.swift
+++ b/md-preview/Features/Settings/ThemePresetCard.swift
@@ -1,0 +1,81 @@
+//
+//  ThemePresetCard.swift
+//  md-preview
+//
+//  One card in the theme gallery: "Aa" in the preset's own page color, ink
+//  and reading face, with the name below it. Shared by the toolbar popover
+//  and the Appearance settings pane so the two galleries stay identical —
+//  the pane is the way in for anyone who removed the toolbar button.
+//
+
+import SwiftUI
+
+struct ThemePresetCard: View {
+    let preset: ThemePreset
+    let isSelected: Bool
+    let action: () -> Void
+
+    /// Fixed so a card reads the same in the popover's 3-column grid and the
+    /// wider settings pane.
+    static let height: CGFloat = 70
+    private static let cornerRadius: CGFloat = 16
+
+    var body: some View {
+        let page = Self.color(hex: preset.palette.pageBackground)
+        let text = Self.color(hex: preset.palette.text)
+
+        return Button(action: action) {
+            VStack(spacing: 4) {
+                Text(verbatim: "Aa")
+                    // The preset's own reading face, so the gallery shows
+                    // the typeface each theme applies.
+                    .font(preset.font.font(size: 24))
+                    .fontWeight(preset.boldText ? .heavy : .semibold)
+                    .foregroundStyle(text)
+                Text(L(preset.name))
+                    .font(.system(size: 11))
+                    .foregroundStyle(text.opacity(0.8))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .padding(.horizontal, 4)
+            .frame(maxWidth: .infinity)
+            .frame(height: Self.height)
+            .background(
+                RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                    .fill(page)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor : Color.primary.opacity(0.12),
+                            lineWidth: isSelected ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(L(preset.name)))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    /// Palette colours resolved once for the whole gallery. Parsing a hex
+    /// string compiles a regex, and a body pass would otherwise do it twice
+    /// per card — 18 times for the built-in set, on every text-size tap.
+    private static let resolved: [String: Color] = {
+        let hexes = ThemePreset.builtIn.flatMap { preset -> [String] in
+            let palettes = [preset.palette, preset.darkPalette].compactMap { $0 }
+            return palettes.flatMap { [$0.pageBackground, $0.text] }
+        }
+        return Dictionary(hexes.map { ($0, parse(hex: $0)) },
+                          uniquingKeysWith: { first, _ in first })
+    }()
+
+    private static func color(hex: String) -> Color {
+        resolved[hex] ?? parse(hex: hex)
+    }
+
+    private static func parse(hex: String) -> Color {
+        guard let nsColor = ThemeColorsSetting.color(fromHex: hex) else {
+            return .primary
+        }
+        return Color(nsColor: nsColor)
+    }
+}

--- a/md-preview/Features/Settings/ThemePresetGallery.swift
+++ b/md-preview/Features/Settings/ThemePresetGallery.swift
@@ -1,0 +1,34 @@
+//
+//  ThemePresetGallery.swift
+//  md-preview
+//
+//  The theme gallery: the built-in presets as a grid of ThemePresetCards.
+//  Both the toolbar popover and the Appearance settings pane show it, so
+//  selection and the apply call live here rather than being written twice.
+//
+
+import SwiftUI
+
+struct ThemePresetGallery: View {
+    /// Gap between cards. The popover runs tighter than the settings pane.
+    var spacing: CGFloat = 10
+    /// Inset applied to each card inside its grid cell, so the cards read as
+    /// tiles rather than a wall-to-wall grid.
+    var cardInset: CGFloat = 0
+
+    @Bindable private var model = SettingsModel.shared
+
+    var body: some View {
+        let selected = model.selectedPreset
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: spacing),
+                                 count: 3),
+                  spacing: spacing) {
+            ForEach(ThemePreset.builtIn) { preset in
+                ThemePresetCard(preset: preset, isSelected: selected == preset) {
+                    model.applyPreset(preset)
+                }
+                .padding(.horizontal, cardInset)
+            }
+        }
+    }
+}

--- a/md-preview/Features/Settings/ThemeSettingsView.swift
+++ b/md-preview/Features/Settings/ThemeSettingsView.swift
@@ -2,20 +2,22 @@
 //  ThemeSettingsView.swift
 //  md-preview
 //
+//  The Appearance pane: light/dark choice and the theme gallery, with
+//  Customize leading to the same Customize Theme sheet the toolbar popover
+//  opens. It carries no controls of its own beyond that — everything here
+//  is a second way to reach what the popover offers, for readers who took
+//  the "aA" item out of the toolbar in Customize Toolbar.
+//
+//  The gallery uses ThemePresetCard, the popover's own card, so the two
+//  surfaces cannot drift apart.
+//
 
 import SwiftUI
 
-// MARK: - Theme
-
-/// Color overrides, one row per surface with a Light and a Dark well. A
-/// deliberately small first set — presets and more surfaces come later on
-/// the same storage.
 struct ThemeSettingsView: View {
     @Bindable private var model = SettingsModel.shared
 
     var body: some View {
-        // Resolved once per pass: the footer, the Reset button, and every
-        // card compare against it.
         let selected = model.selectedPreset
         Form {
             Section {
@@ -48,46 +50,26 @@ struct ThemeSettingsView: View {
             }
 
             Section {
-                LazyVGrid(columns: [GridItem(.flexible(), spacing: 12),
-                                    GridItem(.flexible(), spacing: 12)],
-                          spacing: 12) {
-                    ForEach(ThemePreset.builtIn) { preset in
-                        presetCard(preset, isSelected: selected == preset)
-                    }
-                }
-                .padding(.vertical, 4)
+                ThemePresetGallery()
+                    .padding(.vertical, 4)
             } header: {
-                Text(L("Presets"))
+                Text(L("Themes"))
             } footer: {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(String(format: L("Current theme: %@"),
                                 selected.map { L($0.name) } ?? L("Custom colors")))
-                    Text(L("A preset fills every color and switches the app to its light or dark look. Adjust individual colors below afterwards."))
+                    Text(L("A theme fills every color, picks a reading face, and switches the app to its light or dark look."))
                 }
             }
 
             Section {
-                colorRow(L("Window background"), slot: .windowBackground)
-                colorRow(L("Code block background"), slot: .codeBlockBackground)
-                colorRow(L("Text"), slot: .textColor)
-                colorRow(L("Link"), slot: .linkColor)
-            } header: {
-                Text(L("Colors"))
-            } footer: {
-                Text(model.appearance == .automatic
-                    ? L("Each color has a separate value for the Light and Dark appearance. Picking the default color removes the override.")
-                    : L("Colors apply to the current appearance. Choose the Automatic appearance to set Light and Dark separately."))
-            }
-
-            Section {
-                LabeledContent(L("Custom colors")) {
-                    Button(L("Reset Colors")) {
-                        model.resetThemeColors()
+                LabeledContent(L("Fonts, spacing and colors")) {
+                    Button(L("Customize…")) {
+                        openCustomizeSheet()
                     }
-                    .disabled(selected == ThemePreset.defaultPreset)
                 }
             } footer: {
-                Text(L("Restores the default Normal theme."))
+                Text(L("The same panel the toolbar's Themes & Settings button opens, with a Reset for the whole look."))
             }
         }
         .formStyle(.grouped)
@@ -96,115 +78,11 @@ struct ThemeSettingsView: View {
         }
     }
 
-    private func presetCard(_ preset: ThemePreset, isSelected: Bool) -> some View {
-        let page = Self.color(hex: preset.palette.pageBackground)
-        let text = Self.color(hex: preset.palette.text)
-        let accent = Self.color(hex: preset.palette.accent)
-        let badge: (symbol: String, color: Color) = switch preset.flavor {
-        case .light: ("sun.max.fill", .orange)
-        case .dark: ("moon.fill", .indigo)
-        case .system: ("circle.lefthalf.filled", .secondary)
-        }
-        return Button {
-            model.applyPreset(preset)
-        } label: {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .top) {
-                    Text(L(preset.name))
-                        .font(.system(size: 13, weight: .bold))
-                        .foregroundStyle(text)
-                    Spacer(minLength: 4)
-                    Image(systemName: badge.symbol)
-                        .font(.system(size: 9))
-                        .foregroundStyle(badge.color)
-                }
-                (Text("Lorem ipsum ").foregroundStyle(text.opacity(0.85))
-                    + Text("dolor").bold().foregroundStyle(text)
-                    + Text(" sit amet, ").foregroundStyle(text.opacity(0.85))
-                    + Text("semper").foregroundStyle(accent)
-                    + Text(" pharetra.").foregroundStyle(text.opacity(0.85)))
-                    .font(.system(size: 11))
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-            }
-            .padding(10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(page)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(isSelected ? Color.accentColor : Color.primary.opacity(0.12),
-                            lineWidth: isSelected ? 2 : 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(L(preset.name)))
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    private static func color(hex: String) -> Color {
-        guard let nsColor = ThemeColorsSetting.color(fromHex: hex) else {
-            return .primary
-        }
-        return Color(nsColor: nsColor)
-    }
-
-    /// One well while the appearance is pinned (it edits the look on
-    /// screen); separate labeled Light/Dark wells only in Automatic, where
-    /// both schemes are reachable. Two always-visible wells confused more
-    /// than they helped.
-    private func colorRow(_ title: String, slot: ThemeColorSlot) -> some View {
-        LabeledContent {
-            HStack(spacing: 16) {
-                switch model.appearance {
-                case .light:
-                    colorWell(L("Light"), slot: slot, scheme: .light,
-                              showsLabel: false)
-                case .dark:
-                    colorWell(L("Dark"), slot: slot, scheme: .dark,
-                              showsLabel: false)
-                case .automatic:
-                    colorWell(L("Light"), slot: slot, scheme: .light)
-                    colorWell(L("Dark"), slot: slot, scheme: .dark)
-                }
-            }
-        } label: {
-            Text(title)
-        }
-    }
-
-    private func colorWell(_ label: String,
-                           slot: ThemeColorSlot,
-                           scheme: ThemeColorScheme,
-                           showsLabel: Bool = true) -> some View {
-        HStack(spacing: 6) {
-            if showsLabel {
-                Text(label)
-                    .foregroundStyle(.secondary)
-            }
-            ColorPicker(label, selection: colorBinding(slot: slot, scheme: scheme),
-                        supportsOpacity: false)
-                .labelsHidden()
-        }
-        .accessibilityElement(children: .combine)
-    }
-
-    private func colorBinding(slot: ThemeColorSlot,
-                              scheme: ThemeColorScheme) -> Binding<Color> {
-        Binding(
-            get: {
-                let model = SettingsModel.shared
-                let nsColor = model.themeColors.color(slot, scheme)
-                    ?? ThemeColorsSetting.defaultColor(slot, scheme)
-                return Color(nsColor: nsColor)
-            },
-            set: { newValue in
-                SettingsModel.shared.setThemeColor(
-                    NSColor(newValue), slot: slot, scheme: scheme
-                )
-            }
-        )
+    /// The sheet needs a host window. Settings is the one on screen when this
+    /// pane is visible, so it hosts the sheet rather than a document window
+    /// that may not exist.
+    private func openCustomizeSheet() {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return }
+        CustomizeThemeSheet.present(on: window)
     }
 }

--- a/md-preview/Features/Settings/ThemeSettingsView.swift
+++ b/md-preview/Features/Settings/ThemeSettingsView.swift
@@ -16,7 +16,7 @@ struct ThemeSettingsView: View {
     var body: some View {
         // Resolved once per pass: the footer, the Reset button, and every
         // card compare against it.
-        let selected = selectedPreset
+        let selected = model.selectedPreset
         Form {
             Section {
                 HStack(alignment: .top) {
@@ -94,18 +94,6 @@ struct ThemeSettingsView: View {
         .onAppear {
             model.refreshFromExternalSources()
         }
-    }
-
-    /// The preset the stored colors correspond to. Colors that were never
-    /// customized count as the default preset — the app treats "no
-    /// overrides" as the default theme, so the gallery always marks an
-    /// active card. Hand-edited colors that match no preset return nil
-    /// ("Custom colors").
-    private var selectedPreset: ThemePreset? {
-        if let match = ThemePreset.builtIn.first(where: { model.themeColors == $0.setting }) {
-            return match
-        }
-        return model.themeColors.isCustomized ? nil : .defaultPreset
     }
 
     private func presetCard(_ preset: ThemePreset, isSelected: Bool) -> some View {

--- a/md-preview/Features/Settings/ThemesPopoverView.swift
+++ b/md-preview/Features/Settings/ThemesPopoverView.swift
@@ -3,10 +3,10 @@
 //  md-preview
 //
 //  Content of the toolbar's "aA" popover: text size, appearance, and the
-//  theme preset gallery in one place, with Customize leading to the full
-//  Appearance settings pane. A compact mirror of ThemeSettingsView driven
-//  by the same SettingsModel, so a preset or appearance picked here reaches
-//  every open window exactly like a change made in the Settings window.
+//  theme preset gallery in one place, with Customize leading to the
+//  Customize Theme panel (fonts and reading layout). Driven by the shared
+//  SettingsModel, so a preset or appearance picked here reaches every open
+//  window exactly like a change made in the Settings window.
 //
 
 import SwiftUI
@@ -16,53 +16,82 @@ struct ThemesPopoverView: View {
 
     private let decreaseTextSize: () -> Void
     private let increaseTextSize: () -> Void
+    private let currentZoom: () -> CGFloat
     private let openCustomize: () -> Void
+
+    /// Where the document sits on the zoom scale, and whether the scale is
+    /// on screen. It appears on a text-size tap and hides itself again, so
+    /// it reads as feedback for the tap rather than permanent chrome.
+    @State private var zoomStep = 0
+    @State private var showsScale = false
+    @State private var hideScaleTask: Task<Void, Never>?
+
+    private static let scaleVisibleSeconds: Double = 2
 
     init(decreaseTextSize: @escaping () -> Void,
          increaseTextSize: @escaping () -> Void,
+         currentZoom: @escaping () -> CGFloat,
          openCustomize: @escaping () -> Void) {
         self.decreaseTextSize = decreaseTextSize
         self.increaseTextSize = increaseTextSize
+        self.currentZoom = currentZoom
         self.openCustomize = openCustomize
     }
 
     var body: some View {
-        let selected = model.selectedPreset
-        VStack(spacing: 12) {
+        // Spacing is set per gap rather than by one stack value: the scale
+        // needs the same small gap below it that it has above, while the
+        // rest of the popover keeps the wider 12pt rhythm.
+        VStack(spacing: 0) {
             Text(L("Themes & Settings"))
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
 
             Divider()
+                .padding(.top, 12)
 
-            HStack(spacing: 8) {
-                textSizeControl
+            // The scale belongs to the text-size control, so it sits in a
+            // column with it and takes its width — the appearance button
+            // stays top-aligned beside the capsule rather than centering
+            // against the taller column.
+            HStack(alignment: .top, spacing: 8) {
+                VStack(spacing: 6) {
+                    textSizeControl
+                    zoomScale
+                }
                 appearanceButton
             }
+            .padding(.top, 12)
 
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8),
-                                     count: 3),
-                      spacing: 8) {
-                ForEach(ThemePreset.builtIn) { preset in
-                    presetCard(preset, isSelected: selected == preset)
-                }
-            }
+            ThemePresetGallery(spacing: 8, cardInset: 2)
+            .padding(.top, 6)
 
             Button(action: openCustomize) {
                 Label(L("Customize"), systemImage: "gearshape")
                     .font(.system(size: 13, weight: .medium))
                     .frame(maxWidth: .infinity)
-                    .frame(height: 34)
+                    .frame(height: 46)
                     .contentShape(Capsule())
             }
             .buttonStyle(.plain)
             .background(Capsule().fill(Color.primary.opacity(0.06)))
             .accessibilityLabel(L("Customize"))
+            .padding(.top, 12)
         }
-        .padding(14)
-        .frame(width: 312)
+        // Generous side padding, with the popover's own width fixed — the
+        // cards absorb it rather than the popover growing.
+        .padding(.horizontal, 28)
+        .padding(.top, 14)
+        .padding(.bottom, 20)
+        .frame(width: 286)
         .onAppear {
             model.refreshFromExternalSources()
+            // Known before the first tap so the scale is already correct
+            // when it appears, rather than filling in a step late.
+            zoomStep = MarkdownWebView.zoomStepIndex(for: currentZoom())
+        }
+        .onDisappear {
+            hideScaleTask?.cancel()
         }
     }
 
@@ -80,14 +109,52 @@ struct ThemesPopoverView: View {
                            action: increaseTextSize)
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 36)
+        .frame(height: 48)
         .background(Capsule().fill(Color.primary.opacity(0.06)))
+    }
+
+    /// One dot per zoom stop, filled up to the document's current stop —
+    /// the scale Books shows under its text-size control. Centered on that
+    /// control, and the row holds its height whether or not the dots are
+    /// showing, so revealing them never moves anything.
+    private var zoomScale: some View {
+        HStack(spacing: 5) {
+            ForEach(MarkdownWebView.zoomSteps.indices, id: \.self) { index in
+                Circle()
+                    .fill(index <= zoomStep
+                          ? Color.primary.opacity(0.75)
+                          : Color.primary.opacity(0.15))
+                    .frame(width: 5, height: 5)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        // Exactly the dot diameter: no slack to make one gap read larger.
+        .frame(height: 5)
+        .opacity(showsScale ? 1 : 0)
+        .animation(.easeInOut(duration: 0.18), value: showsScale)
+        .accessibilityHidden(true)
+    }
+
+    /// Applies a text-size step, then shows the scale and restarts the
+    /// countdown that hides it.
+    private func changeTextSize(_ action: () -> Void) {
+        action()
+        zoomStep = MarkdownWebView.zoomStepIndex(for: currentZoom())
+        showsScale = true
+        hideScaleTask?.cancel()
+        hideScaleTask = Task {
+            try? await Task.sleep(for: .seconds(Self.scaleVisibleSeconds))
+            guard !Task.isCancelled else { return }
+            showsScale = false
+        }
     }
 
     private func textSizeButton(sampleSize: CGFloat,
                                 title: String,
                                 action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+        Button {
+            changeTextSize(action)
+        } label: {
             Text(verbatim: "A")
                 .font(.system(size: sampleSize, weight: .medium))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -109,7 +176,7 @@ struct ThemesPopoverView: View {
         return Button(action: cycleAppearance) {
             Image(systemName: appearanceSymbol)
                 .font(.system(size: 14, weight: .medium))
-                .frame(width: 56, height: 36)
+                .frame(width: 56, height: 48)
                 .contentShape(Capsule())
         }
         .buttonStyle(.plain)
@@ -132,46 +199,4 @@ struct ThemesPopoverView: View {
         model.appearance = modes[(index + 1) % modes.count]
     }
 
-    // MARK: - Presets
-
-    private func presetCard(_ preset: ThemePreset, isSelected: Bool) -> some View {
-        let page = Self.color(hex: preset.palette.pageBackground)
-        let text = Self.color(hex: preset.palette.text)
-        return Button {
-            model.applyPreset(preset)
-        } label: {
-            VStack(spacing: 2) {
-                Text(verbatim: "Aa")
-                    .font(.system(size: 21, weight: .semibold))
-                    .foregroundStyle(text)
-                Text(L(preset.name))
-                    .font(.system(size: 10))
-                    .foregroundStyle(text.opacity(0.8))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
-            .padding(.horizontal, 4)
-            .frame(maxWidth: .infinity)
-            .frame(height: 62)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(page)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .stroke(isSelected ? Color.accentColor : Color.primary.opacity(0.12),
-                            lineWidth: isSelected ? 2 : 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(L(preset.name)))
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    private static func color(hex: String) -> Color {
-        guard let nsColor = ThemeColorsSetting.color(fromHex: hex) else {
-            return .primary
-        }
-        return Color(nsColor: nsColor)
-    }
 }

--- a/md-preview/Features/Settings/ThemesPopoverView.swift
+++ b/md-preview/Features/Settings/ThemesPopoverView.swift
@@ -1,0 +1,177 @@
+//
+//  ThemesPopoverView.swift
+//  md-preview
+//
+//  Content of the toolbar's "aA" popover: text size, appearance, and the
+//  theme preset gallery in one place, with Customize leading to the full
+//  Appearance settings pane. A compact mirror of ThemeSettingsView driven
+//  by the same SettingsModel, so a preset or appearance picked here reaches
+//  every open window exactly like a change made in the Settings window.
+//
+
+import SwiftUI
+
+struct ThemesPopoverView: View {
+    @Bindable private var model = SettingsModel.shared
+
+    private let decreaseTextSize: () -> Void
+    private let increaseTextSize: () -> Void
+    private let openCustomize: () -> Void
+
+    init(decreaseTextSize: @escaping () -> Void,
+         increaseTextSize: @escaping () -> Void,
+         openCustomize: @escaping () -> Void) {
+        self.decreaseTextSize = decreaseTextSize
+        self.increaseTextSize = increaseTextSize
+        self.openCustomize = openCustomize
+    }
+
+    var body: some View {
+        let selected = model.selectedPreset
+        VStack(spacing: 12) {
+            Text(L("Themes & Settings"))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            HStack(spacing: 8) {
+                textSizeControl
+                appearanceButton
+            }
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8),
+                                     count: 3),
+                      spacing: 8) {
+                ForEach(ThemePreset.builtIn) { preset in
+                    presetCard(preset, isSelected: selected == preset)
+                }
+            }
+
+            Button(action: openCustomize) {
+                Label(L("Customize"), systemImage: "gearshape")
+                    .font(.system(size: 13, weight: .medium))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 34)
+                    .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .background(Capsule().fill(Color.primary.opacity(0.06)))
+            .accessibilityLabel(L("Customize"))
+        }
+        .padding(14)
+        .frame(width: 312)
+        .onAppear {
+            model.refreshFromExternalSources()
+        }
+    }
+
+    // MARK: - Text size
+
+    /// The old toolbar zoom pair, relocated: a smaller and a larger "A"
+    /// driving the same document zoom actions.
+    private var textSizeControl: some View {
+        HStack(spacing: 0) {
+            textSizeButton(sampleSize: 12, title: L("Zoom Out"),
+                           action: decreaseTextSize)
+            Divider()
+                .padding(.vertical, 9)
+            textSizeButton(sampleSize: 17, title: L("Zoom In"),
+                           action: increaseTextSize)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 36)
+        .background(Capsule().fill(Color.primary.opacity(0.06)))
+    }
+
+    private func textSizeButton(sampleSize: CGFloat,
+                                title: String,
+                                action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(verbatim: "A")
+                .font(.system(size: sampleSize, weight: .medium))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(title)
+        .accessibilityLabel(title)
+    }
+
+    // MARK: - Appearance
+
+    /// One button cycling Automatic → Light → Dark, shown as the current
+    /// mode's symbol. The three-thumbnail picker stays in Settings; the
+    /// popover only needs the quick flip.
+    private var appearanceButton: some View {
+        let title = String(format: L("Appearance: %@"),
+                           model.appearance.settingsTitle)
+        return Button(action: cycleAppearance) {
+            Image(systemName: appearanceSymbol)
+                .font(.system(size: 14, weight: .medium))
+                .frame(width: 56, height: 36)
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .background(Capsule().fill(Color.primary.opacity(0.06)))
+        .help(title)
+        .accessibilityLabel(title)
+    }
+
+    private var appearanceSymbol: String {
+        switch model.appearance {
+        case .automatic: "circle.lefthalf.filled"
+        case .light: "sun.max"
+        case .dark: "moon"
+        }
+    }
+
+    private func cycleAppearance() {
+        let modes = AppearanceMode.allCases
+        guard let index = modes.firstIndex(of: model.appearance) else { return }
+        model.appearance = modes[(index + 1) % modes.count]
+    }
+
+    // MARK: - Presets
+
+    private func presetCard(_ preset: ThemePreset, isSelected: Bool) -> some View {
+        let page = Self.color(hex: preset.palette.pageBackground)
+        let text = Self.color(hex: preset.palette.text)
+        return Button {
+            model.applyPreset(preset)
+        } label: {
+            VStack(spacing: 2) {
+                Text(verbatim: "Aa")
+                    .font(.system(size: 21, weight: .semibold))
+                    .foregroundStyle(text)
+                Text(L(preset.name))
+                    .font(.system(size: 10))
+                    .foregroundStyle(text.opacity(0.8))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .padding(.horizontal, 4)
+            .frame(maxWidth: .infinity)
+            .frame(height: 62)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(page)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor : Color.primary.opacity(0.12),
+                            lineWidth: isSelected ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(L(preset.name)))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private static func color(hex: String) -> Color {
+        guard let nsColor = ThemeColorsSetting.color(fromHex: hex) else {
+            return .primary
+        }
+        return Color(nsColor: nsColor)
+    }
+}

--- a/md-preview/Helpers/EscapeKeyMonitor.swift
+++ b/md-preview/Helpers/EscapeKeyMonitor.swift
@@ -1,0 +1,40 @@
+//
+//  EscapeKeyMonitor.swift
+//  md-preview
+//
+//  Escape handling for surfaces AppKit does not route `cancelOperation(_:)`
+//  to. A transient popover dismisses on an outside click by itself, but its
+//  SwiftUI content never takes key focus, so nothing in the responder chain
+//  ever sees the keystroke — a local key monitor does.
+//
+//  Sheets and windows do not need this: they are key, so overriding
+//  `cancelOperation(_:)` is the right mechanism there.
+//
+
+import Cocoa
+
+@MainActor
+final class EscapeKeyMonitor {
+    private static let escapeKeyCode: UInt16 = 53
+    private var monitor: Any?
+
+    /// Starts watching for Escape. `handler` returns true when it consumed
+    /// the keystroke, which stops the event going any further.
+    func start(_ handler: @escaping @MainActor () -> Bool) {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == Self.escapeKeyCode else { return event }
+            // The monitor runs on the main thread; NSEvent simply is not
+            // Sendable, so the isolation has to be asserted rather than
+            // inferred across the closure boundary.
+            let consumed = MainActor.assumeIsolated { handler() }
+            return consumed ? nil : event
+        }
+    }
+
+    func stop() {
+        guard let monitor else { return }
+        NSEvent.removeMonitor(monitor)
+        self.monitor = nil
+    }
+}

--- a/md-preview/Rendering/DocumentFontSetting.swift
+++ b/md-preview/Rendering/DocumentFontSetting.swift
@@ -4,14 +4,14 @@
 //
 //  Typeface for rendered Markdown, persisted across launches.
 //
-//  Four named faces rather than a picker of every installed font. The page's
-//  vertical rhythm is *derived*: paragraph spacing, the blank-line gap and the
-//  heading scale are all computed from one body size and tuned against one
-//  x-height, and the column width is tuned to a comfortable line length at that
-//  face. Those numbers survive a swap between faces in the same metric
-//  neighbourhood; they do not survive a condensed face, a display face, or a
-//  variable weight axis at 15px. A short list is also a list every option of
-//  which has actually been looked at.
+//  A curated list of reading faces in the Apple Books style rather than a
+//  picker of every installed font. The page's vertical rhythm is *derived*:
+//  paragraph spacing, the blank-line gap and the heading scale are all
+//  computed from one body size and tuned against one x-height, and the column
+//  width is tuned to a comfortable line length at that face. Every face here
+//  ships with macOS and sits in the same metric neighbourhood; condensed
+//  faces, display faces and variable weight axes at 15px stay out. A short
+//  list is also a list every option of which has actually been looked at.
 //
 //  Stored in the app group rather than `UserDefaults.standard`, so Quick Look
 //  renders in the chosen face too — it is a reading surface as much as the
@@ -23,8 +23,16 @@ import Foundation
 
 nonisolated enum DocumentFontSetting: String, CaseIterable, Sendable {
     case system
-    case serif
+    case athelas
+    case avenirNext
+    case charter
+    case georgia
+    case iowan
+    case newYork
+    case palatino
     case rounded
+    case seravek
+    case timesNewRoman
     case monospace
 
     static let defaultsKey = "MarkdownPreview.documentFont"
@@ -35,9 +43,29 @@ nonisolated enum DocumentFontSetting: String, CaseIterable, Sendable {
     var fontFamily: String {
         switch self {
         case .system: return MarkdownHTML.bodyFontFamily
-        case .serif: return "ui-serif, \"New York\", \"Iowan Old Style\", Georgia, serif"
+        case .athelas: return "Athelas, ui-serif, Georgia, serif"
+        case .avenirNext: return "\"Avenir Next\", Avenir, -apple-system, system-ui, sans-serif"
+        case .charter: return "Charter, ui-serif, Georgia, serif"
+        case .georgia: return "Georgia, ui-serif, serif"
+        case .iowan: return "\"Iowan Old Style\", ui-serif, Georgia, serif"
+        case .newYork: return "ui-serif, \"New York\", \"Iowan Old Style\", Georgia, serif"
+        case .palatino: return "Palatino, \"Palatino Linotype\", ui-serif, Georgia, serif"
         case .rounded: return "ui-rounded, \"SF Pro Rounded\", -apple-system, system-ui, sans-serif"
+        case .seravek: return "Seravek, -apple-system, system-ui, sans-serif"
+        case .timesNewRoman: return "\"Times New Roman\", Times, serif"
         case .monospace: return MarkdownHTML.codeFontFamily
+        }
+    }
+
+    /// Whether the face reads as a serif. Drives the code-size correction and
+    /// lets UI group the list the way Apple Books does.
+    var isSerif: Bool {
+        switch self {
+        case .athelas, .charter, .georgia, .iowan, .newYork, .palatino,
+             .timesNewRoman:
+            return true
+        case .system, .avenirNext, .rounded, .seravek, .monospace:
+            return false
         }
     }
 
@@ -51,19 +79,28 @@ nonisolated enum DocumentFontSetting: String, CaseIterable, Sendable {
     /// the background chip is what marks it as code there.
     var codeFontSize: String {
         switch self {
-        case .system, .rounded: return "0.88em"
-        case .serif: return "0.84em"
         case .monospace: return "1em"
+        default: return isSerif ? "0.84em" : "0.88em"
         }
     }
 
-    /// Named for the reading character, not the face: the stack is a fallback
-    /// chain, so naming a font would promise one that may not be installed.
+    /// Display names in the Apple Books style. "Original" is the app's own
+    /// default look; the generic entries (SF Rounded, Monospace) keep a
+    /// character name because their stack is a fallback chain, not a promise
+    /// of one installed font.
     var title: String {
         switch self {
-        case .system: return NSLocalizedString("System", comment: "Document font")
-        case .serif: return NSLocalizedString("Serif", comment: "Document font")
-        case .rounded: return NSLocalizedString("Rounded", comment: "Document font")
+        case .system: return NSLocalizedString("Original", comment: "Document font")
+        case .athelas: return NSLocalizedString("Athelas", comment: "Document font")
+        case .avenirNext: return NSLocalizedString("Avenir Next", comment: "Document font")
+        case .charter: return NSLocalizedString("Charter", comment: "Document font")
+        case .georgia: return NSLocalizedString("Georgia", comment: "Document font")
+        case .iowan: return NSLocalizedString("Iowan", comment: "Document font")
+        case .newYork: return NSLocalizedString("New York", comment: "Document font")
+        case .palatino: return NSLocalizedString("Palatino", comment: "Document font")
+        case .rounded: return NSLocalizedString("SF Rounded", comment: "Document font")
+        case .seravek: return NSLocalizedString("Seravek", comment: "Document font")
+        case .timesNewRoman: return NSLocalizedString("Times New Roman", comment: "Document font")
         case .monospace: return NSLocalizedString("Monospace", comment: "Document font")
         }
     }
@@ -74,9 +111,11 @@ nonisolated enum DocumentFontSetting: String, CaseIterable, Sendable {
     }
 
     static func read(from defaults: UserDefaults?) -> Self {
-        guard let rawValue = defaults?.string(forKey: defaultsKey),
-              let setting = Self(rawValue: rawValue) else { return defaultSetting }
-        return setting
+        guard let rawValue = defaults?.string(forKey: defaultsKey) else { return defaultSetting }
+        // The pre-list "Serif" option used the New York stack; a stored value
+        // from that era maps onto its named successor.
+        if rawValue == "serif" { return .newYork }
+        return Self(rawValue: rawValue) ?? defaultSetting
     }
 
     static func write(_ setting: Self, to defaults: UserDefaults?) {

--- a/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
+++ b/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
@@ -116,17 +116,29 @@ nonisolated extension MarkdownHTML {
     body {
         font-family: var(--mdp-doc-font, \(bodyFontFamily));
         font-size: \(bodyFontSize)px;
-        line-height: \(bodyLineHeight);
+        font-weight: var(--mdp-body-weight, 400);
+        line-height: var(--mdp-line-height, \(bodyLineHeight));
+        letter-spacing: var(--mdp-letter-spacing, normal);
+        word-spacing: var(--mdp-word-spacing, normal);
         color: var(--text);
         background: transparent;
         padding: \(pagePaddingTop)px \(pagePaddingHorizontal)px \(pagePaddingBottom)px;
         -webkit-font-smoothing: antialiased;
+    }
+    /* Reader spacing tweaks stop at code — whitespace fidelity wins. */
+    pre, code {
+        letter-spacing: normal;
+        word-spacing: normal;
     }
 
     article.markdown-body {
         max-width: \(contentColumnWidth)px;
         margin-left: auto;
         margin-right: auto;
+        /* Reader margins: symmetric padding inside the column, so they hold
+           in every content-width mode instead of fighting max-width. */
+        padding-left: var(--mdp-page-inset, 0);
+        padding-right: var(--mdp-page-inset, 0);
     }
     article.markdown-body > *:first-child { margin-top: 0 !important; }
     .md-inline-tab {

--- a/md-preview/Rendering/MarkdownHTML.swift
+++ b/md-preview/Rendering/MarkdownHTML.swift
@@ -251,13 +251,15 @@ nonisolated enum MarkdownHTML {
                          assetBaseHref: String? = nil,
                          vendorLoading: VendorLoading = .inline,
                          colorScheme: ColorScheme? = nil,
-                         documentFont: DocumentFontSetting = .current) -> String {
+                         documentFont: DocumentFontSetting = .current,
+                         readerLayout: ReaderLayoutSetting = .current) -> String {
         render(markdown: markdown,
                allowsScroll: allowsScroll,
                assetBaseHref: assetBaseHref,
                vendorLoading: vendorLoading,
                colorScheme: colorScheme,
-               documentFont: documentFont).html
+               documentFont: documentFont,
+               readerLayout: readerLayout).html
     }
 
     static func render(markdown: String,
@@ -268,6 +270,7 @@ nonisolated enum MarkdownHTML {
                        colorScheme: ColorScheme? = nil,
                        themeOverrides: ThemeOverrides? = nil,
                        documentFont: DocumentFontSetting = .current,
+                       readerLayout: ReaderLayoutSetting = .current,
                        warmup: Bool = false) -> RenderedHTML {
         let frontmatter = MarkdownFrontmatter.split(markdown)
         let body = frontmatter.body
@@ -341,11 +344,18 @@ nonisolated enum MarkdownHTML {
         // ratio off the body em, tuned against one x-height, so keeping system
         // headings over a serif body would silently change how big each step
         // looks. Code keeps its own face and takes only a size correction.
+        // Reader layout rides along in the same :root block: bold text and
+        // the Customize Theme sliders emit CSS variables only when they
+        // differ from the stylesheet's tuned defaults.
+        let readerLayoutVariables = readerLayout.cssVariables
+        let readerLayoutBlock = readerLayoutVariables.isEmpty
+            ? ""
+            : "\n    \(readerLayoutVariables)"
         let documentFontOverride = """
         <style>
         :root {
             --mdp-doc-font: \(documentFont.fontFamily);
-            --mdp-code-font-size: \(documentFont.codeFontSize);
+            --mdp-code-font-size: \(documentFont.codeFontSize);\(readerLayoutBlock)
         }
         </style>
         """

--- a/md-preview/Rendering/MarkdownHTML.swift
+++ b/md-preview/Rendering/MarkdownHTML.swift
@@ -67,6 +67,10 @@ nonisolated enum MarkdownHTML {
     /// render time and rewritten in place by the host when the user edits a
     /// color, so a live page restyles without a reload.
     static let themeStyleElementID = "mdp-theme-overrides"
+    /// Reader layout lives in its own element, rewritten in place when the
+    /// Customize Theme sliders move — the same trick the theme colors use, so
+    /// a drag restyles the loaded page instead of re-rendering it.
+    static let readerLayoutStyleElementID = "mdp-reader-layout"
 
     /// User color overrides injected after the stylesheet. Values are
     /// sanitized hex colors — anything else is dropped, never emitted —
@@ -344,20 +348,19 @@ nonisolated enum MarkdownHTML {
         // ratio off the body em, tuned against one x-height, so keeping system
         // headings over a serif body would silently change how big each step
         // looks. Code keeps its own face and takes only a size correction.
-        // Reader layout rides along in the same :root block: bold text and
-        // the Customize Theme sliders emit CSS variables only when they
-        // differ from the stylesheet's tuned defaults.
-        let readerLayoutVariables = readerLayout.cssVariables
-        let readerLayoutBlock = readerLayoutVariables.isEmpty
-            ? ""
-            : "\n    \(readerLayoutVariables)"
         let documentFontOverride = """
         <style>
         :root {
             --mdp-doc-font: \(documentFont.fontFamily);
-            --mdp-code-font-size: \(documentFont.codeFontSize);\(readerLayoutBlock)
+            --mdp-code-font-size: \(documentFont.codeFontSize);
         }
         </style>
+        """
+        // Always emitted, possibly empty, and last of the style blocks: a
+        // live rewrite has a stable element to target and wins the cascade
+        // against the blocks above it.
+        let readerLayoutBlock = """
+        <style id="\(readerLayoutStyleElementID)">\(readerLayout.pageCSS)</style>
         """
 
         // The href may carry a real folder path (percent-encoded, but `&`
@@ -421,6 +424,7 @@ nonisolated enum MarkdownHTML {
         \(scrollOverride)
         \(contentWidthOverride)
         \(documentFontOverride)
+        \(readerLayoutBlock)
         \(sanitizerBlock)
         \(morphBlock)
         \(hostBridgeScript)

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -703,10 +703,18 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
         webView.evaluateJavaScript(script) { _, _ in }
     }
 
-    // Discrete zoom stops, mirroring Safari's ⌘+/⌘− cadence.
-    private static let zoomSteps: [CGFloat] = [
+    // Discrete zoom stops, mirroring Safari's ⌘+/⌘− cadence. Not private:
+    // the toolbar popover draws one dot per stop to show where the current
+    // text size sits on the scale.
+    static let zoomSteps: [CGFloat] = [
         0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0
     ]
+
+    /// Which stop `zoom` sits at, for the popover's scale. Values between
+    /// stops (a trackpad pinch can leave one) round to the nearest.
+    static func zoomStepIndex(for zoom: CGFloat) -> Int {
+        zoomSteps.indices.min { abs(zoomSteps[$0] - zoom) < abs(zoomSteps[$1] - zoom) } ?? 0
+    }
 
     var pageZoom: CGFloat { webView.pageZoom }
 

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -512,6 +512,14 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     /// Rewrites the theme override `<style>` in the loaded page so a color
     /// edited in Settings restyles the preview live, without a reload. Fresh
     /// renders embed the same CSS via `currentThemeOverrides`.
+    /// Restyles the loaded page for a reader-layout change without a reload,
+    /// the same way `applyThemeColors` handles a color edit.
+    func applyReaderLayout() {
+        webView.evaluateJavaScript(
+            ReaderLayoutSetting.styleUpdateScript(css: ReaderLayoutSetting.current.pageCSS)
+        ) { _, _ in }
+    }
+
     func applyThemeColors() {
         let css = Self.currentThemeOverrides()?.css ?? ""
         webView.evaluateJavaScript(

--- a/md-preview/Rendering/ReaderLayoutSetting.swift
+++ b/md-preview/Rendering/ReaderLayoutSetting.swift
@@ -74,6 +74,32 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
         return lines.joined(separator: "\n    ")
     }
 
+    /// The whole `:root` rule for the page's reader-layout element, empty
+    /// when nothing differs from the stylesheet's tuned defaults.
+    var pageCSS: String {
+        let variables = cssVariables
+        guard !variables.isEmpty else { return "" }
+        return ":root {\n    \(variables)\n}"
+    }
+
+    /// Rewrites the page's reader-layout element in place. Cheap enough to
+    /// run on every slider tick, which is what makes the document itself the
+    /// preview rather than the sheet's approximation of it.
+    static func styleUpdateScript(css: String) -> String {
+        let literal = MarkdownHTML.javaScriptStringLiteral(css)
+        return """
+        (function () {
+            var el = document.getElementById('\(MarkdownHTML.readerLayoutStyleElementID)');
+            if (!el) {
+                el = document.createElement('style');
+                el.id = '\(MarkdownHTML.readerLayoutStyleElementID)';
+                document.head.appendChild(el);
+            }
+            el.textContent = \(literal);
+        })();
+        """
+    }
+
     private static func format(_ value: Double) -> String {
         String(format: "%.3f", locale: Locale(identifier: "en_US_POSIX"), value)
     }

--- a/md-preview/Rendering/ReaderLayoutSetting.swift
+++ b/md-preview/Rendering/ReaderLayoutSetting.swift
@@ -1,0 +1,145 @@
+//
+//  ReaderLayoutSetting.swift
+//  md-preview
+//
+//  Reading-layout preferences from the Customize Theme panel: bold body
+//  text, and — behind an explicit Customize switch, the way Apple Books
+//  gates them — line spacing, character spacing, word spacing and margins.
+//
+//  Stored in the app group next to DocumentFontSetting so Quick Look reads
+//  with the same layout the document windows do. Values at their defaults
+//  are removed from storage; a fresh install stores nothing.
+//
+
+import Foundation
+
+nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
+
+    var boldText = false
+    /// The Books-style gate: sliders only take effect while this is on, and
+    /// switching it off restores the tuned defaults without losing the
+    /// slider positions.
+    var isCustomized = false
+    var lineSpacing = defaultLineSpacing
+    var characterSpacingPercent = 0.0
+    var wordSpacingPercent = 0.0
+    var marginsPercent = 0.0
+
+    /// The stylesheet's own tuned value; the slider starts here.
+    static let defaultLineSpacing = Double(MarkdownHTML.bodyLineHeight)
+    static let lineSpacingRange = 1.0...2.0
+    static let characterSpacingRange = -5.0...12.0
+    static let wordSpacingRange = -10.0...25.0
+    static let marginsRange = 0.0...100.0
+
+    // MARK: - Effective values
+
+    /// What the page actually renders: the sliders only count while the
+    /// Customize switch is on, so their positions persist without applying.
+    /// Bold text is not gated — it is its own switch.
+    var effective: Self {
+        isCustomized ? self : Self(boldText: boldText)
+    }
+
+    /// Symmetric inset added inside the reading column, in points. Applied as
+    /// padding rather than by shrinking `max-width`: the column measure is
+    /// `ContentWidthSetting`'s to own, and a `max-width` here would do
+    /// nothing in Full Width and sit off-centre in the app's normal mode,
+    /// where the article is host-centered with `margin-left: 0`.
+    var pageInset: Int {
+        Int(0.9 * effective.marginsPercent)
+    }
+
+    /// CSS custom-property declarations for the page `:root`. Only values
+    /// that differ from the stylesheet's defaults are emitted — an empty
+    /// string means the page renders exactly as before this setting existed.
+    var cssVariables: String {
+        let applied = effective
+        var lines: [String] = []
+        if applied.boldText {
+            lines.append("--mdp-body-weight: 600;")
+        }
+        if applied.lineSpacing != Self.defaultLineSpacing {
+            lines.append("--mdp-line-height: \(Self.format(applied.lineSpacing));")
+        }
+        if applied.characterSpacingPercent != 0 {
+            lines.append("--mdp-letter-spacing: \(Self.format(applied.characterSpacingPercent / 100))em;")
+        }
+        if applied.wordSpacingPercent != 0 {
+            lines.append("--mdp-word-spacing: \(Self.format(applied.wordSpacingPercent / 100))em;")
+        }
+        if applied.marginsPercent != 0 {
+            lines.append("--mdp-page-inset: \(pageInset)px;")
+        }
+        return lines.joined(separator: "\n    ")
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.3f", locale: Locale(identifier: "en_US_POSIX"), value)
+    }
+
+    // MARK: - Storage
+
+    private enum Key {
+        static let boldText = "MarkdownPreview.readerLayout.boldText"
+        static let isCustomized = "MarkdownPreview.readerLayout.customized"
+        static let lineSpacing = "MarkdownPreview.readerLayout.lineSpacing"
+        static let characterSpacing = "MarkdownPreview.readerLayout.characterSpacing"
+        static let wordSpacing = "MarkdownPreview.readerLayout.wordSpacing"
+        static let margins = "MarkdownPreview.readerLayout.margins"
+    }
+
+    static var current: Self {
+        get { read(from: AppearanceMode.sharedDefaults()) }
+        set { write(newValue, to: AppearanceMode.sharedDefaults()) }
+    }
+
+    /// The numeric settings, each with the key it persists under, its
+    /// default and its range. `read` and `write` loop over this rather than
+    /// naming every field twice more.
+    private static var numericFields: [(key: String,
+                                       path: WritableKeyPath<Self, Double>,
+                                       defaultValue: Double,
+                                       range: ClosedRange<Double>)] {
+        [
+            (Key.lineSpacing, \.lineSpacing, defaultLineSpacing, lineSpacingRange),
+            (Key.characterSpacing, \.characterSpacingPercent, 0, characterSpacingRange),
+            (Key.wordSpacing, \.wordSpacingPercent, 0, wordSpacingRange),
+            (Key.margins, \.marginsPercent, 0, marginsRange)
+        ]
+    }
+
+    static func read(from defaults: UserDefaults?) -> Self {
+        guard let defaults else { return Self() }
+        var setting = Self()
+        setting.boldText = defaults.bool(forKey: Key.boldText)
+        setting.isCustomized = defaults.bool(forKey: Key.isCustomized)
+        for field in numericFields {
+            guard let stored = defaults.object(forKey: field.key) as? NSNumber else { continue }
+            setting[keyPath: field.path] = clamp(stored.doubleValue, to: field.range)
+        }
+        return setting
+    }
+
+    static func write(_ setting: Self, to defaults: UserDefaults?) {
+        guard let defaults else { return }
+        store(setting.boldText ? true : nil, forKey: Key.boldText, in: defaults)
+        store(setting.isCustomized ? true : nil, forKey: Key.isCustomized, in: defaults)
+        for field in numericFields {
+            let value = setting[keyPath: field.path]
+            store(value == field.defaultValue ? nil : value, forKey: field.key, in: defaults)
+        }
+    }
+
+    private static func store(_ value: Any?, forKey key: String, in defaults: UserDefaults) {
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    private static func clamp(_ value: Double, to range: ClosedRange<Double>) -> Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+}

--- a/md-preview/Theme/ThemePreset.swift
+++ b/md-preview/Theme/ThemePreset.swift
@@ -39,6 +39,13 @@ nonisolated struct ThemePreset: Identifiable, Equatable, Sendable {
     /// Display name; also the localization key.
     let name: String
     let flavor: Flavor
+    /// The reading face the preset applies. A preset is a whole reading
+    /// look, not only a palette — Books' themes carry a typeface too, and
+    /// the gallery card draws its "Aa" in this face so the cards differ the
+    /// way the pages will.
+    let font: DocumentFontSetting
+    /// Whether the preset reads in a heavier body weight.
+    let boldText: Bool
     /// The palette; for a `.system` preset, the light-scheme palette.
     let palette: Palette
     /// Dark-scheme palette for `.system` presets. Nil reuses `palette`,
@@ -49,9 +56,12 @@ nonisolated struct ThemePreset: Identifiable, Equatable, Sendable {
     /// update, and expansion sanitizes each value through a regex.
     let setting: ThemeColorsSetting
 
-    init(name: String, flavor: Flavor, palette: Palette, darkPalette: Palette? = nil) {
+    init(name: String, flavor: Flavor, palette: Palette, darkPalette: Palette? = nil,
+         font: DocumentFontSetting = .system, boldText: Bool = false) {
         self.name = name
         self.flavor = flavor
+        self.font = font
+        self.boldText = boldText
         self.palette = palette
         self.darkPalette = darkPalette
         var setting = ThemeColorsSetting()
@@ -75,40 +85,64 @@ nonisolated struct ThemePreset: Identifiable, Equatable, Sendable {
     /// gallery.
     static var defaultPreset: ThemePreset { builtIn[0] }
 
-    /// The built-in starter set, in gallery order: light themes in the
-    /// left column, their dark counterparts on the right. Normal leads —
-    /// it is the default theme.
+    /// The built-in starter set, in gallery order — three rows of three:
+    /// the Apple Books set (Original, Quiet, Paper / Bold, Calm, Focus)
+    /// first, then the remaining dark themes. Original leads — it is the
+    /// default theme.
     ///
-    /// All palettes except Normal are sampled from Bear's themes of the
-    /// same name (editor page, inline-code pill, body text, link color)
-    /// so the two apps render the same look side by side.
+    /// Display names are single evocative words in the Apple Books style.
+    /// Quiet, Paper, Bold, and Focus are sampled from Apple Books' theme
+    /// cards; the entries marked "Bear" are sampled from Bear's themes
+    /// (editor page, inline-code pill, body text, link color) so the two
+    /// apps render the same look side by side.
     static let builtIn: [ThemePreset] = [
         // The default: native macOS blue accents (light systemBlue
         // #007AFF, dark #0A84FF) on plain white / near-black pages. The
         // values are deliberately pinned — not derived from the stock
         // stylesheet — and follow the system appearance, so Reset returns
         // to the system look.
-        ThemePreset(name: "Normal", flavor: .system,
+        ThemePreset(name: "Original", flavor: .system,
                     palette: Palette(pageBackground: "#FFFFFF", codeBackground: "#F2F2F2",
                                      text: "#000000", accent: "#007AFF"),
                     darkPalette: Palette(pageBackground: "#1E1E1E", codeBackground: "#2A2828",
                                          text: "#F5F5F7", accent: "#0A84FF")),
-        ThemePreset(name: "Charcoal", flavor: .dark,
-                    palette: Palette(pageBackground: "#2E3235", codeBackground: "#3F4347",
-                                     text: "#A7A7A6", accent: "#99B7C4")),
-        ThemePreset(name: "Red Graphite", flavor: .light,
-                    palette: Palette(pageBackground: "#FFFFFF", codeBackground: "#F3F5F7",
-                                     text: "#434343", accent: "#DE4A4F")),
-        ThemePreset(name: "Dark Graphite", flavor: .dark,
+        // Apple Books "Quiet": soft dark gray with bright ink — sampled from
+        // a reading page, not from the gallery card, whose label is muted.
+        ThemePreset(name: "Quiet", flavor: .dark,
+                    palette: Palette(pageBackground: "#4A4A4D", codeBackground: "#59595D",
+                                     text: "#EBEBF4", accent: "#99B7C4")),
+        // Apple Books "Paper": neutral light gray, softened ink, serif.
+        ThemePreset(name: "Paper", flavor: .light,
+                    palette: Palette(pageBackground: "#EEEDED", codeBackground: "#E3E1E1",
+                                     text: "#262626", accent: "#DE4A4F"),
+                    font: .charter),
+        // Apple Books "Bold": plain white with heavy near-black text.
+        ThemePreset(name: "Bold", flavor: .light,
+                    palette: Palette(pageBackground: "#FFFFFF", codeBackground: "#F2F2F2",
+                                     text: "#1C1C1E", accent: "#007AFF"),
+                    boldText: true),
+        // Bear "Solarized Light", with Books' serif reading face.
+        ThemePreset(name: "Calm", flavor: .light,
+                    palette: Palette(pageBackground: "#FDF6E3", codeBackground: "#F6EDDB",
+                                     text: "#313D45", accent: "#A0630F"),
+                    font: .georgia),
+        // Apple Books "Focus": warm cream, high-contrast ink, serif.
+        ThemePreset(name: "Focus", flavor: .light,
+                    palette: Palette(pageBackground: "#FFFCF5", codeBackground: "#F5F1E4",
+                                     text: "#14120B", accent: "#A0630F"),
+                    font: .newYork),
+        // Bear "Dark Graphite"
+        ThemePreset(name: "Graphite", flavor: .dark,
                     palette: Palette(pageBackground: "#1D1E1F", codeBackground: "#2E2F30",
                                      text: "#E0E1E0", accent: "#42A2E6")),
-        ThemePreset(name: "Solarized Light", flavor: .light,
-                    palette: Palette(pageBackground: "#FDF6E3", codeBackground: "#F6EDDB",
-                                     text: "#313D45", accent: "#A0630F")),
-        ThemePreset(name: "Solarized Dark", flavor: .dark,
+        // Bear "Solarized Dark", with the body text lifted from Bear's own
+        // #9BA7A4: that reads at about 4.8:1 on this page, the one theme
+        // here below 7:1. #C3CFCC keeps the Solarized cast at ~7.9:1.
+        ThemePreset(name: "Dusk", flavor: .dark,
                     palette: Palette(pageBackground: "#0C3742", codeBackground: "#103E49",
-                                     text: "#9BA7A4", accent: "#299385")),
-        ThemePreset(name: "Dracula", flavor: .dark,
+                                     text: "#C3CFCC", accent: "#299385")),
+        // Bear "Dracula"
+        ThemePreset(name: "Midnight", flavor: .dark,
                     palette: Palette(pageBackground: "#363846", codeBackground: "#313343",
                                      text: "#FFFFFF", accent: "#8BE9FD")),
     ]

--- a/tests/swift-tests/Sources/MarkdownHelpers/ReaderLayoutSetting.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/ReaderLayoutSetting.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/Rendering/ReaderLayoutSetting.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/DocumentFontSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/DocumentFontSettingTests.swift
@@ -14,6 +14,17 @@ final class DocumentFontSettingTests: XCTestCase {
         XCTAssertEqual(DocumentFontSetting.read(from: defaults), .system)
     }
 
+    // The pre-list "Serif" option was the New York stack. A reader who chose
+    // it keeps the same face across the rename rather than snapping back to
+    // the system one.
+    func testTheLegacySerifValueMigratesToNewYork() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("serif", forKey: DocumentFontSetting.defaultsKey)
+        XCTAssertEqual(DocumentFontSetting.read(from: defaults), .newYork)
+    }
+
     func testEveryFaceRoundTripsAndTheDefaultClearsItsKey() throws {
         let (defaults, suiteName) = try makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -54,17 +65,20 @@ final class DocumentFontSettingTests: XCTestCase {
     func testCodeSizeIsCorrectedPerFace() {
         XCTAssertEqual(DocumentFontSetting.system.codeFontSize, "0.88em")
         XCTAssertEqual(DocumentFontSetting.rounded.codeFontSize, "0.88em")
-        XCTAssertNotEqual(DocumentFontSetting.serif.codeFontSize,
-                          DocumentFontSetting.system.codeFontSize)
         XCTAssertEqual(DocumentFontSetting.monospace.codeFontSize, "1em")
+        for setting in DocumentFontSetting.allCases where setting.isSerif {
+            XCTAssertNotEqual(setting.codeFontSize,
+                              DocumentFontSetting.system.codeFontSize,
+                              "\(setting) reuses the sans correction")
+        }
     }
 
     func testRenderedHTMLCarriesTheChosenFace() {
         let html = MarkdownHTML.makeHTML(from: "# Title\n\nBody `code`.",
-                                         documentFont: .serif)
-        XCTAssertTrue(html.contains("--mdp-doc-font: \(DocumentFontSetting.serif.fontFamily);"),
+                                         documentFont: .newYork)
+        XCTAssertTrue(html.contains("--mdp-doc-font: \(DocumentFontSetting.newYork.fontFamily);"),
                       "the document font custom property is missing")
-        XCTAssertTrue(html.contains("--mdp-code-font-size: \(DocumentFontSetting.serif.codeFontSize);"),
+        XCTAssertTrue(html.contains("--mdp-code-font-size: \(DocumentFontSetting.newYork.codeFontSize);"),
                       "the code size correction is missing")
     }
 

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
@@ -103,6 +103,40 @@ final class ReaderLayoutSettingTests: XCTestCase {
         XCTAssertFalse(setting.cssVariables.contains(","))
     }
 
+    // The rewritable element is what makes a slider drag restyle the loaded
+    // page instead of re-rendering it, so it is always emitted — empty at the
+    // defaults — and the update script has to target that same id.
+    func testTheLayoutStyleElementIsAlwaysEmittedAndScriptable() {
+        let plain = MarkdownHTML.makeHTML(from: "Body.", readerLayout: ReaderLayoutSetting())
+        XCTAssertTrue(plain.contains("<style id=\"\(MarkdownHTML.readerLayoutStyleElementID)\"></style>"),
+                      "the element must exist even with nothing to override")
+        XCTAssertEqual(ReaderLayoutSetting().pageCSS, "")
+
+        var setting = ReaderLayoutSetting()
+        setting.isCustomized = true
+        setting.lineSpacing = 1.7
+        XCTAssertTrue(setting.pageCSS.contains(":root {"))
+        XCTAssertTrue(setting.pageCSS.contains("--mdp-line-height: 1.700;"))
+
+        let script = ReaderLayoutSetting.styleUpdateScript(css: setting.pageCSS)
+        XCTAssertTrue(script.contains(MarkdownHTML.readerLayoutStyleElementID))
+        XCTAssertTrue(script.contains("--mdp-line-height: 1.700;"))
+    }
+
+    // The element sits after the font block, so a live rewrite of it wins the
+    // cascade against the values rendered into the page.
+    func testTheLayoutElementComesAfterTheFontBlock() {
+        let html = MarkdownHTML.makeHTML(from: "Body.", documentFont: .georgia)
+        let fontRange = try? XCTUnwrap(html.range(of: "--mdp-doc-font"))
+        let layoutRange = try? XCTUnwrap(
+            html.range(of: "id=\"\(MarkdownHTML.readerLayoutStyleElementID)\"")
+        )
+        guard let fontRange = fontRange ?? nil, let layoutRange = layoutRange ?? nil else {
+            return XCTFail("expected both blocks in the rendered head")
+        }
+        XCTAssertLessThan(fontRange.lowerBound, layoutRange.lowerBound)
+    }
+
     func testRenderedHTMLCarriesTheLayoutVariables() {
         var setting = ReaderLayoutSetting()
         setting.boldText = true

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import XCTest
+@testable import MarkdownHelpers
+
+final class ReaderLayoutSettingTests: XCTestCase {
+
+    // A fresh install renders exactly as it did before the setting existed:
+    // no custom properties, so the stylesheet's tuned values stand.
+    func testDefaultsEmitNoCSS() {
+        XCTAssertEqual(ReaderLayoutSetting().cssVariables, "")
+    }
+
+    func testBoldTextEmitsAWeightOnlyWhenOn() {
+        var setting = ReaderLayoutSetting()
+        setting.boldText = true
+        XCTAssertTrue(setting.cssVariables.contains("--mdp-body-weight: 600;"))
+
+        setting.boldText = false
+        XCTAssertFalse(setting.cssVariables.contains("--mdp-body-weight"))
+    }
+
+    // The Customize switch is the gate: slider positions persist while it is
+    // off, but the page keeps the tuned defaults.
+    func testSlidersOnlyApplyWhileCustomizeIsOn() {
+        var setting = ReaderLayoutSetting()
+        setting.lineSpacing = 1.8
+        setting.characterSpacingPercent = 4
+        setting.wordSpacingPercent = 6
+        setting.marginsPercent = 50
+
+        XCTAssertEqual(setting.cssVariables, "")
+        XCTAssertEqual(setting.effective.lineSpacing, ReaderLayoutSetting.defaultLineSpacing)
+        XCTAssertEqual(setting.pageInset, 0)
+
+        setting.isCustomized = true
+        let css = setting.cssVariables
+        XCTAssertTrue(css.contains("--mdp-line-height: 1.800;"))
+        XCTAssertTrue(css.contains("--mdp-letter-spacing: 0.040em;"))
+        XCTAssertTrue(css.contains("--mdp-word-spacing: 0.060em;"))
+        XCTAssertTrue(css.contains("--mdp-page-inset:"))
+        XCTAssertEqual(setting.effective.lineSpacing, 1.8)
+        XCTAssertGreaterThan(setting.pageInset, 0)
+    }
+
+    // Only values that differ from the stylesheet get a custom property, so a
+    // reader who turns Customize on without moving a slider changes nothing.
+    func testCustomizeWithUntouchedSlidersEmitsNoCSS() {
+        var setting = ReaderLayoutSetting()
+        setting.isCustomized = true
+        XCTAssertEqual(setting.cssVariables, "")
+    }
+
+    func testValuesRoundTripAndDefaultsClearTheirKeys() throws {
+        let suiteName = "doc.md-preview.tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var setting = ReaderLayoutSetting()
+        setting.boldText = true
+        setting.isCustomized = true
+        setting.lineSpacing = 1.75
+        setting.characterSpacingPercent = 3
+        setting.wordSpacingPercent = -4
+        setting.marginsPercent = 20
+        ReaderLayoutSetting.write(setting, to: defaults)
+        XCTAssertEqual(ReaderLayoutSetting.read(from: defaults), setting)
+
+        ReaderLayoutSetting.write(ReaderLayoutSetting(), to: defaults)
+        XCTAssertEqual(defaults.dictionaryRepresentation()
+            .keys
+            .filter { $0.hasPrefix("MarkdownPreview.readerLayout") },
+                       [])
+        XCTAssertEqual(ReaderLayoutSetting.read(from: defaults), ReaderLayoutSetting())
+    }
+
+    // Stored values are clamped on read: a hand-edited plist cannot push the
+    // page to an unreadable line height or a zero-width column.
+    func testStoredValuesAreClampedOnRead() throws {
+        let suiteName = "doc.md-preview.tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(99.0, forKey: "MarkdownPreview.readerLayout.lineSpacing")
+        defaults.set(-500.0, forKey: "MarkdownPreview.readerLayout.characterSpacing")
+        defaults.set(999.0, forKey: "MarkdownPreview.readerLayout.margins")
+        let setting = ReaderLayoutSetting.read(from: defaults)
+
+        XCTAssertEqual(setting.lineSpacing, ReaderLayoutSetting.lineSpacingRange.upperBound)
+        XCTAssertEqual(setting.characterSpacingPercent,
+                       ReaderLayoutSetting.characterSpacingRange.lowerBound)
+        XCTAssertEqual(setting.marginsPercent, ReaderLayoutSetting.marginsRange.upperBound)
+    }
+
+    // The decimals are written for CSS, not for the reader's locale — a comma
+    // separator would make the declaration invalid.
+    func testCSSNumbersUseAPeriodRegardlessOfLocale() {
+        var setting = ReaderLayoutSetting()
+        setting.isCustomized = true
+        setting.lineSpacing = 1.4
+        XCTAssertTrue(setting.cssVariables.contains("1.400"))
+        XCTAssertFalse(setting.cssVariables.contains(","))
+    }
+
+    func testRenderedHTMLCarriesTheLayoutVariables() {
+        var setting = ReaderLayoutSetting()
+        setting.boldText = true
+        setting.isCustomized = true
+        setting.lineSpacing = 1.9
+        let html = MarkdownHTML.makeHTML(from: "Body text.", readerLayout: setting)
+
+        XCTAssertTrue(html.contains("--mdp-body-weight: 600;"))
+        XCTAssertTrue(html.contains("--mdp-line-height: 1.900;"))
+        // The stylesheet keeps literal fallbacks, so a page rendered with the
+        // defaults still has a weight, leading and column width.
+        XCTAssertTrue(html.contains("font-weight: var(--mdp-body-weight, 400);"))
+        XCTAssertTrue(html.contains("line-height: var(--mdp-line-height,"))
+        XCTAssertTrue(html.contains("padding-left: var(--mdp-page-inset,"))
+    }
+}


### PR DESCRIPTION
## Summary

Reading themes get typography, not just colours. The toolbar's "aA" popover becomes the one place to pick a theme, nudge the text size, or flip the appearance, and a new **Customize Theme** sheet — modelled on Apple Books — carries the reading face, bold body text, and the spacing and margin controls.

A theme is now a whole reading look: each preset carries a palette, a reading face, and a body weight, so picking Paper switches to Charter and picking Bold switches to a heavier body.

## What's in it

**Themes & Settings popover** (toolbar "aA")
- Text-size pair with a dot scale showing where the document sits on the zoom ladder; it appears on a tap and fades after two seconds.
- Appearance button cycling Automatic → Light → Dark.
- Nine theme cards in a 3 × 3 gallery, each drawn in its own page colour, ink and reading face.
- Escape closes the popover.

**Customize Theme sheet** (popover → Customize, or Settings → Appearance → Customize…)
- Live preview in the current theme, with the header running over the page colour.
- Font list of 12 reading faces, each name set in the face it applies.
- Bold Text switch, and — behind an explicit Customize gate, as in Books — Line Spacing, Character Spacing, Word Spacing and Margins.
- Per-surface colour wells and Reset Colors.
- ✗ restores the values the sheet opened with; ✓ keeps them; Escape cancels.

**Rendering**
- New `ReaderLayoutSetting`, stored in the app group so Quick Look reads with the same layout, emitted as CSS custom properties (`--mdp-body-weight`, `--mdp-line-height`, `--mdp-letter-spacing`, `--mdp-word-spacing`, `--mdp-content-max-width`). Only values that differ from the tuned defaults are written, so an untouched install renders byte-identically. Code blocks keep normal spacing.
- `DocumentFontSetting` grows from 4 to 12 named faces; the pre-list `serif` value migrates to New York.

**Themes**
- Apple Books-style one-word names: Original, Quiet, Paper, Bold, Calm, Focus, Graphite, Dusk, Midnight.
- Quiet's ink corrected to `#EBEBF4` (it had been sampled from a gallery card's muted label).
- Dusk's ink raised to `#C3CFCC` — about 7.9:1 on its page, up from 4.8:1, the only dark theme below 7:1.

**Settings**
- The Appearance pane stays, rebuilt around the popover's own `ThemePresetCard`, so removing the toolbar item never strips access to themes.

**Reset**
- A full-width destructive **Reset Theme** row restores the *applied* theme's colours, face and weight and clears the spacing sliders — it does not drop the reader onto Original. The applied theme is remembered for exactly this.

## Notes

- Switches in the sheet came up with a track and no knob until the window was activated. The cause was presenting the sheet while the popover still held key focus, so it arrived inactive; presenting one run-loop hop later fixes it, and the system `Toggle` is used throughout. Two earlier workarounds (a hand-drawn switch and a post-present `makeKeyAndOrderFront`) were removed once the real cause was found.
- Reader margins are a symmetric page inset rather than a second `max-width`, so they hold in every content-width mode instead of being inert in Full Width and off-centre in the app's normal mode. Column measure stays `ContentWidthSetting`'s to own.
- Applying a theme now changes colours, appearance, face and weight together, so preview reloads are coalesced into one per tap (`withCoalescedPreviewReloads`).
- Escape closes the popover (a local key monitor, since popover content never takes key focus) and cancels the sheet (`cancelOperation`, which AppKit routes to a key sheet).
- Includes a one-line unrelated tweak: the Inspector toolbar icon moves from `info.circle` to `info`.

## Follow-ups (not in this PR)

- Reader-layout changes still re-render open documents. The app already has a live style-push channel (`ThemeColorsSetting.styleUpdateScript`) that these `--mdp-*` variables would fit; moving them there would remove the draft/commit-on-release machinery and make the real document the preview.
- `DocumentFontSetting` names each family twice — once as a CSS stack, once as a SwiftUI `Font`. A single descriptor per case would remove the second list.
- The zoom-step table lives on `MarkdownWebView` and is now read by the popover; it belongs in the preference layer, which needs `TextSizeSetting` added to the Quick Look target first.

## Test plan

- [x] `xcodebuild -scheme md-preview -configuration Debug build`
- [x] `swift test --package-path tests/swift-tests` — 246 tests, 0 failures (new `ReaderLayoutSettingTests`, updated `DocumentFontSettingTests`)
- [x] Popover: theme cards apply live to open windows; text-size dots track the zoom; Escape closes
- [x] Sheet: switches render correctly on first open; font list applies live; Escape cancels
- [x] Settings → Appearance: gallery matches the popover; Customize… opens the sheet
- [x] Escape closes the popover and cancels the sheet (verified with real key events)
- [x] Switches render correctly on first open with no activation (verified by window capture)
- [ ] Quick Look picks up the font and reading layout on next preview
