### PR TITLE
Improve Mermaid diagram popup navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Mermaid popups open with a screen-centered 16:9 viewport. Large diagrams fit the viewport; smaller diagrams retain their natural size. Scroll to zoom around the pointer, drag to pan, and press Space to restore the initial diagram view.
+
+### Fixed
+
+- Mermaid popup wheel zoom respects the web view's flipped coordinate system, keeping both axes anchored to the mouse position.
+
 ## [0.0.52] – 2026-09-01
 
 This release rebuilds the reading experience around a single "aA" control in the toolbar: a theme is now a complete reading look — page color, ink, reading face, and body weight — and a new Customize Theme sheet carries the fonts and the spacing controls. The toolbar is also a native window-drag surface again, editing gains pasted images and a native New Document flow, and a long list of layout and rendering faults are fixed.

--- a/md-preview/Features/Mermaid/MermaidDiagramPopup.swift
+++ b/md-preview/Features/Mermaid/MermaidDiagramPopup.swift
@@ -2,30 +2,74 @@
 //  MermaidDiagramPopup.swift
 //  md-preview
 //
-//  Floating panel that shows a rendered Mermaid SVG at a measured size.
-//  Resizable — the diagram scales with the window. Behaves like a regular
-//  window: it stays open when it loses key focus and closes via its close
-//  button / ⌘W, so the diagram can be read alongside the document.
+//  Floating panel with a stable 16:9 viewport. The diagram is fit only when
+//  larger than the viewport; smaller diagrams keep their natural size.
+//  Mouse-wheel zoom and pointer dragging navigate the diagram independently
+//  of the panel size. Space restores the initial diagram scale and position.
 //
 
 import AppKit
 import WebKit
 
 @MainActor
-final class MermaidDiagramPopup: NSObject {
+private final class MermaidPopupWebView: WKWebView {
+    private var pendingDeltaY = 0.0
+    private var pendingClientX = 0.0
+    private var pendingClientY = 0.0
+    private var flushScheduled = false
+
+    override func scrollWheel(with event: NSEvent) {
+        guard event.scrollingDeltaY != 0 else { return }
+        let point = convert(event.locationInWindow, from: nil)
+        // Precise devices report points; coarse wheels report small line deltas.
+        pendingDeltaY += Double(event.scrollingDeltaY) * (event.hasPreciseScrollingDeltas ? 1 : 8)
+        pendingClientX = point.x
+        pendingClientY = isFlipped ? point.y : bounds.height - point.y
+        guard !flushScheduled else { return }
+        flushScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            self?.flushWheel()
+        }
+    }
+
+    private func flushWheel() {
+        guard pendingDeltaY != 0 else {
+            flushScheduled = false
+            return
+        }
+        let deltaY = pendingDeltaY
+        let clientX = pendingClientX
+        let clientY = pendingClientY
+        pendingDeltaY = 0
+        flushScheduled = false
+        evaluateJavaScript(
+            "window.mdPreviewZoom?.(\(deltaY), \(clientX), \(clientY));",
+            completionHandler: nil
+        )
+    }
+    override func keyDown(with event: NSEvent) {
+        guard event.keyCode == 49 else {
+            super.keyDown(with: event)
+            return
+        }
+        evaluateJavaScript("window.mdPreviewReset?.();", completionHandler: nil)
+    }
+}
+
+
+@MainActor
+final class MermaidDiagramPopup: NSObject, WKNavigationDelegate {
     static let shared = MermaidDiagramPopup()
 
     private var panel: NSPanel?
     private var webView: WKWebView?
+    private var pendingNavigation: WKNavigation?
 
     private override init() {
         super.init()
     }
-
     struct Request {
         let svgHTML: String
-        let naturalSize: CGSize
-        let displaySize: CGSize
         /// Nearest preceding Markdown heading, if any — gives the window a
         /// title that's more useful than the generic "Mermaid diagram" when
         /// reopening the popup on a different diagram.
@@ -37,34 +81,25 @@ final class MermaidDiagramPopup: NSObject {
 
         let screen = parentWindow?.screen ?? NSScreen.main
         let visible = screen?.visibleFrame.size ?? CGSize(width: 1280, height: 800)
-        let contentSize = MermaidPopupSizing.preferredContentSize(
-            natural: request.naturalSize,
-            display: request.displaySize,
-            screen: visible
-        )
+        let contentSize = MermaidPopupSizing.preferredContentSize(screen: visible)
 
         let panel = ensurePanel()
+        webView?.alphaValue = 0
         // Detach from a previous parent so re-opening re-centers correctly.
         if let currentParent = panel.parent {
             currentParent.removeChildWindow(panel)
         }
         panel.setContentSize(contentSize)
 
-        // Frame size after setContentSize includes chrome; use it for placement.
+        // Center on the hosting screen's visible frame, not on the document
+        // window. The document can be offset or partially off-screen.
         var frame = panel.frame
-        if let parent = parentWindow {
-            let parentFrame = parent.frame
+        if let screen {
+            let visibleFrame = screen.visibleFrame
             frame.origin = NSPoint(
-                x: parentFrame.midX - frame.width / 2,
-                y: parentFrame.midY - frame.height / 2
+                x: visibleFrame.midX - frame.width / 2,
+                y: visibleFrame.midY - frame.height / 2
             )
-            frame.origin = clampedOrigin(frame.origin, size: frame.size, screen: screen)
-            panel.setFrame(frame, display: false)
-            // Don't use addChildWindow — a child stays tied to the parent's
-            // ordering/visibility. Keep it as an independent float.
-        } else if let screen {
-            panel.center()
-            frame = panel.frame
             frame.origin = clampedOrigin(frame.origin, size: frame.size, screen: screen)
             panel.setFrame(frame, display: false)
         }
@@ -72,6 +107,7 @@ final class MermaidDiagramPopup: NSObject {
         panel.title = Self.title(for: request.sectionTitle)
         load(svgHTML: request.svgHTML)
         panel.makeKeyAndOrderFront(nil)
+        panel.makeFirstResponder(webView)
         NSApp.activate()
     }
 
@@ -111,9 +147,11 @@ final class MermaidDiagramPopup: NSObject {
         panel.becomesKeyOnlyIfNeeded = false
 
         let config = WKWebViewConfiguration()
-        let webView = WKWebView(frame: .zero, configuration: config)
+        let webView = MermaidPopupWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        // Wheel events are consumed by the native view and forwarded to the
+        // popup canvas, so macOS does not turn them into page scrolling.
         webView.setValue(false, forKey: "drawsBackground")
-        // Window resize is the zoom control; keep the page scale at 1.
         webView.allowsMagnification = false
         webView.autoresizingMask = [.width, .height]
         panel.contentView = webView
@@ -132,29 +170,26 @@ final class MermaidDiagramPopup: NSObject {
     }
 
     @objc private func panelWillClose(_ notification: Notification) {
+        pendingNavigation = nil
         // Drop the heavy SVG document when the user closes the panel.
         webView?.loadHTMLString("", baseURL: nil)
     }
 
     private func load(svgHTML: String) {
-        // Strip scripts just in case; mermaid SVGs are static markup.
         let safeSVG = MermaidPopupSizing.sanitizedSVGHTML(svgHTML)
-        // Same generic label the inline figure carries, so the popup is no
-        // less navigable than the diagram it was opened from.
         let label = Self.htmlAttributeEscape(
             NSLocalizedString("Mermaid diagram", comment: "Mermaid diagram popup window title")
         )
 
+        let scriptNonce = UUID().uuidString
         let html = """
         <!DOCTYPE html>
         <html>
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-\(scriptNonce)'; style-src 'unsafe-inline'; img-src data:">
         <style>
-          /* Let the page follow the window's appearance on its own, so
-             toggling system dark mode restyles an open popup live. */
           html, body {
             margin: 0;
             width: 100%;
@@ -166,31 +201,132 @@ final class MermaidDiagramPopup: NSObject {
           @media (prefers-color-scheme: dark) {
             html, body { background: #1e1e1e; }
           }
-          /* Fill the web view; diagram scales with window resize. */
           .stage {
             position: absolute;
             inset: 0;
-            box-sizing: border-box;
-            padding: 16px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
+            overflow: hidden;
+            cursor: grab;
+            touch-action: none;
+            user-select: none;
           }
+          .stage.dragging { cursor: grabbing; }
           .stage svg {
+            position: absolute;
+            left: 0;
+            top: 0;
             display: block;
-            width: 100%;
-            height: 100%;
-            max-width: 100%;
-            max-height: 100%;
+            transform-origin: 0 0;
+            max-width: none;
           }
         </style>
         </head>
         <body>
         <div class="stage" role="img" aria-label="\(label)">\(safeSVG)</div>
+        <script nonce="\(scriptNonce)">
+        (() => {
+          const stage = document.querySelector('.stage');
+          const svg = stage.querySelector('svg');
+          if (!svg) return;
+          const vb = svg.viewBox.baseVal;
+          const naturalWidth = vb.width || parseFloat(svg.getAttribute('width')) || 1;
+          const naturalHeight = vb.height || parseFloat(svg.getAttribute('height')) || 1;
+          svg.setAttribute('width', naturalWidth + 'px');
+          svg.setAttribute('height', naturalHeight + 'px');
+          svg.removeAttribute('style');
+          let scale = 1;
+          let minimumScale = 0.1;
+          let tx = 0;
+          let ty = 0;
+          let drag;
+          const apply = () => {
+            svg.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
+          };
+          const center = () => {
+            const availableWidth = Math.max(stage.clientWidth - 48, 1);
+            const availableHeight = Math.max(stage.clientHeight - 48, 1);
+            scale = Math.min(1, availableWidth / naturalWidth, availableHeight / naturalHeight);
+            minimumScale = Math.min(0.1, scale / 10);
+            tx = (stage.clientWidth - naturalWidth * scale) / 2;
+            ty = (stage.clientHeight - naturalHeight * scale) / 2;
+            apply();
+          };
+          window.mdPreviewReset = center;
+          window.addEventListener('keydown', (event) => {
+            if (event.code !== 'Space' && event.key !== ' ') return;
+            event.preventDefault();
+            center();
+          });
+          const zoomAt = (deltaY, x, y) => {
+            const oldScale = scale;
+            const magnitude = Math.min(Math.abs(deltaY), 40);
+            const nextScale = Math.max(
+              minimumScale,
+              Math.min(8, oldScale * Math.exp(-Math.sign(deltaY) * magnitude * 0.015))
+            );
+            tx = x - (x - tx) * nextScale / oldScale;
+            ty = y - (y - ty) * nextScale / oldScale;
+            scale = nextScale;
+            apply();
+          };
+          window.mdPreviewZoom = zoomAt;
+          stage.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            const rect = stage.getBoundingClientRect();
+            const unit = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? stage.clientHeight : 1;
+            zoomAt(event.deltaY * unit, event.clientX - rect.left, event.clientY - rect.top);
+          }, { passive: false });
+          stage.addEventListener('pointerdown', (event) => {
+            if (event.button !== 0) return;
+            stage.setPointerCapture(event.pointerId);
+            drag = { id: event.pointerId, x: event.clientX, y: event.clientY };
+            stage.classList.add('dragging');
+          });
+          stage.addEventListener('pointermove', (event) => {
+            if (!drag || drag.id !== event.pointerId) return;
+            tx += event.clientX - drag.x;
+            ty += event.clientY - drag.y;
+            drag.x = event.clientX;
+            drag.y = event.clientY;
+            apply();
+          });
+          const stop = (event) => {
+            if (!drag || drag.id !== event.pointerId) return;
+            drag = null;
+            stage.classList.remove('dragging');
+          };
+          stage.addEventListener('pointerup', stop);
+          stage.addEventListener('pointercancel', stop);
+          window.addEventListener('resize', center);
+          center();
+        })();
+        </script>
         </body>
         </html>
         """
-        webView?.loadHTMLString(html, baseURL: nil)
+        pendingNavigation = webView?.loadHTMLString(html, baseURL: nil)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let navigation, navigation === pendingNavigation else { return }
+        Task { @MainActor [weak self] in
+            do {
+                _ = try await webView.callAsyncJavaScript(
+                    "await document.fonts.ready; window.mdPreviewReset();",
+                    arguments: [:], in: nil, contentWorld: .page
+                )
+                guard let self, navigation === self.pendingNavigation else { return }
+                // Wait for WebKit to render the prepared layout before revealing it.
+                _ = try await webView.takeSnapshot(configuration: nil)
+                guard navigation === self.pendingNavigation else { return }
+                self.pendingNavigation = nil
+                webView.alphaValue = 1
+            } catch {
+                guard let self, navigation === self.pendingNavigation else { return }
+                self.pendingNavigation = nil
+                self.panel?.close()
+                NSApp.presentError(error)
+            }
+        }
     }
 
     private static func htmlAttributeEscape(_ string: String) -> String {

--- a/md-preview/Features/Mermaid/MermaidPopupSizing.swift
+++ b/md-preview/Features/Mermaid/MermaidPopupSizing.swift
@@ -10,109 +10,26 @@ import CoreGraphics
 import Foundation
 
 enum MermaidPopupSizing {
-    /// Padding around the diagram inside the popup content area.
-    static let contentPadding: CGFloat = 40
-    /// Soft minimum so tiny diagrams don't open a postage-stamp window.
-    static let minimumWidth: CGFloat = 360
-    static let minimumHeight: CGFloat = 260
+    /// Stable 16:9 client size for the popup. The diagram is deliberately not
+    /// used to choose the initial window geometry.
+    static let initialContentSize = CGSize(width: 1440, height: 810)
+    static let minimumWidth: CGFloat = 640
+    static let minimumHeight: CGFloat = 360
     /// Fraction of the screen's visible frame the popup may occupy.
     static let screenFraction: CGFloat = 0.9
-    /// Prefer not to upscale beyond this relative to the natural size.
-    static let maxUpscale: CGFloat = 1.75
 
-    /// Chooses a popup content size that shows the diagram clearly.
+    /// Chooses a stable popup content size independent of diagram aspect ratio.
     ///
-    /// - Parameters:
-    ///   - natural: SVG viewBox / intrinsic size in CSS pixels (preferred).
-    ///   - display: On-screen figure size used when natural size is unavailable.
-    ///   - screen: Visible frame of the screen that will host the popup.
-    /// - Returns: Content size for the popup's client area (not including
-    ///   the window chrome). Aspect ratio of the diagram is preserved.
-    static func preferredContentSize(
-        natural: CGSize,
-        display: CGSize,
-        screen: CGSize
-    ) -> CGSize {
-        let maxW = max(screen.width * screenFraction, minimumWidth)
-        let maxH = max(screen.height * screenFraction, minimumHeight)
-
-        // Prefer the natural (uncapped) diagram size — this is what the
-        // document max-height may have truncated. Treat width and height as
-        // one pair: the on-screen figure can have a different aspect ratio
-        // after CSS caps its height, so mixing one axis from each size would
-        // corrupt the SVG's natural aspect ratio.
-        let diagram = positiveSize(natural) ?? positiveSize(display)
-            ?? CGSize(width: 400, height: 300)
-        let diagramW = diagram.width
-        let diagramH = diagram.height
-
-        let aspect = diagramW / diagramH
-
-        // Ideal: natural size + padding, optionally upscaled a bit for very
-        // small diagrams so labels stay readable, but never beyond maxUpscale.
-        let upscaleFloorW = minimumWidth - contentPadding
-        let upscaleFloorH = minimumHeight - contentPadding
-        var scale: CGFloat = 1
-        if diagramW < upscaleFloorW || diagramH < upscaleFloorH {
-            let up = min(upscaleFloorW / diagramW, upscaleFloorH / diagramH)
-            scale = min(max(up, 1), maxUpscale)
-        }
-
-        var contentW = diagramW * scale + contentPadding
-        var contentH = diagramH * scale + contentPadding
-
-        // Fit within the screen budget, preserving aspect.
-        if contentW > maxW || contentH > maxH {
-            let fit = min(maxW / contentW, maxH / contentH)
-            contentW *= fit
-            contentH *= fit
-        }
-
-        // Enforce soft minimums while preserving aspect if screen allows.
-        if contentW < minimumWidth, contentW < maxW {
-            let target = min(minimumWidth, maxW)
-            let grownH = target / (contentW / contentH)
-            if grownH <= maxH {
-                contentW = target
-                contentH = grownH
-            }
-        }
-        if contentH < minimumHeight, contentH < maxH {
-            let target = min(minimumHeight, maxH)
-            let grownW = target * (contentW / contentH)
-            if grownW <= maxW {
-                contentH = target
-                contentW = grownW
-            }
-        }
-
-        // Final clamp + keep aspect stable against float drift.
-        contentW = min(max(contentW, 1), maxW)
-        contentH = min(max(contentH, 1), maxH)
-        // Re-sync aspect if clamp distorted it significantly.
-        let clampedAspect = contentW / contentH
-        if abs(clampedAspect - aspect) > 0.05 {
-            if clampedAspect > aspect {
-                contentW = contentH * aspect
-            } else {
-                contentH = contentW / aspect
-            }
-            contentW = min(max(contentW, 1), maxW)
-            contentH = min(max(contentH, 1), maxH)
-        }
-
-        return CGSize(width: contentW.rounded(.up), height: contentH.rounded(.up))
+    /// The viewport, rather than the SVG, determines the initial window geometry.
+    static func preferredContentSize(screen: CGSize) -> CGSize {
+        let maxW = max(screen.width * screenFraction, 1)
+        let maxH = max(screen.height * screenFraction, 1)
+        let fit = min(maxW / initialContentSize.width, maxH / initialContentSize.height)
+        let width = initialContentSize.width * fit
+        let height = initialContentSize.height * fit
+        return CGSize(width: width.rounded(.up), height: height.rounded(.up))
     }
 
-    private static func positive(_ value: CGFloat) -> CGFloat? {
-        value.isFinite && value > 1 ? value : nil
-    }
-
-    private static func positiveSize(_ size: CGSize) -> CGSize? {
-        guard let width = positive(size.width),
-              let height = positive(size.height) else { return nil }
-        return CGSize(width: width, height: height)
-    }
 
     // MARK: - Popup content helpers (shared with MermaidDiagramPopup)
 

--- a/md-preview/Rendering/MarkdownHTML+Mermaid.swift
+++ b/md-preview/Rendering/MarkdownHTML+Mermaid.swift
@@ -306,33 +306,12 @@ nonisolated extension MarkdownHTML {
                 return text;
             }
 
-            // Measure the diagram's natural (viewBox) size and current on-screen
-            // box, then ask the host to open a floating window sized to fit.
+            // Clone without the pan/zoom transform so the popup starts with
+            // the pristine rendered diagram.
             function openPopup(figure) {
                 const s = states.get(figure);
                 if (!s || !s.svg) return;
                 const svg = s.svg;
-                let naturalW = s.vbW;
-                let naturalH = s.vbH;
-                try {
-                    // getBBox reflects drawn content; prefer it when viewBox
-                    // is missing or clearly wrong.
-                    const bb = svg.getBBox();
-                    if (bb && bb.width > 1 && bb.height > 1) {
-                        if (!(naturalW > 1 && naturalH > 1)) {
-                            naturalW = bb.width;
-                            naturalH = bb.height;
-                        }
-                    }
-                } catch (_) {}
-                if (!s.rect) cacheRect(figure);
-                const r = s.rect || figure.getBoundingClientRect();
-                // Clone without the pan/zoom transform so the popup shows
-                // the pristine rendered diagram. Drive layout purely from
-                // viewBox so the popup's CSS width/height can stretch or
-                // shrink the graphic with the window — done here, before the
-                // SVG leaves the content process, so the popup document
-                // itself needs no script to finish sizing it.
                 const clone = svg.cloneNode(true);
                 clone.removeAttribute('style');
                 clone.setAttribute('preserveAspectRatio', 'xMidYMid meet');
@@ -344,11 +323,7 @@ nonisolated extension MarkdownHTML {
                     window.webkit?.messageHandlers?.mdPreviewHost?.postMessage({
                         kind: 'mermaidPopup',
                         svg: clone.outerHTML,
-                        sectionTitle: nearestHeadingText(figure),
-                        naturalWidth: naturalW,
-                        naturalHeight: naturalH,
-                        displayWidth: r.width,
-                        displayHeight: r.height
+                        sectionTitle: nearestHeadingText(figure)
                     });
                 } catch (_) {}
             }

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -657,17 +657,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     #if !QUICK_LOOK_EXTENSION
     private func presentMermaidPopup(_ payload: [String: Any]) {
         guard let svg = payload["svg"] as? String, !svg.isEmpty else { return }
-        let natural = CGSize(
-            width: (payload["naturalWidth"] as? NSNumber).map { CGFloat(truncating: $0) } ?? 0,
-            height: (payload["naturalHeight"] as? NSNumber).map { CGFloat(truncating: $0) } ?? 0
-        )
-        let display = CGSize(
-            width: (payload["displayWidth"] as? NSNumber).map { CGFloat(truncating: $0) } ?? 0,
-            height: (payload["displayHeight"] as? NSNumber).map { CGFloat(truncating: $0) } ?? 0
-        )
         let sectionTitle = payload["sectionTitle"] as? String
         MermaidDiagramPopup.shared.present(
-            .init(svgHTML: svg, naturalSize: natural, displaySize: display, sectionTitle: sectionTitle),
+            .init(svgHTML: svg, sectionTitle: sectionTitle),
             relativeTo: window
         )
     }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -867,14 +867,13 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         // back to the "renderer unavailable" stub — assert the real wiring
         // string (injected by the app when Vendor/Mermaid is present).
         XCTAssertTrue(MarkdownHTML.mermaidInitWiring.contains("kind: 'mermaidPopup'"))
-        XCTAssertTrue(MarkdownHTML.mermaidInitWiring.contains("naturalWidth"))
         XCTAssertTrue(MarkdownHTML.mermaidInitWiring.contains("function openPopup"))
         XCTAssertTrue(MarkdownHTML.mermaidInitWiring.contains("case 'popup'"))
         XCTAssertTrue(MarkdownHTML.mermaidInitWiring.contains("openPopup(figure)"))
     }
 
     @MainActor
-    func testMermaidPopupPostsMeasuredSizeMessage() async throws {
+    func testMermaidPopupPostsSVGAndSectionTitle() async throws {
         // Headings before the figure exercise the popup's section-title
         // lookup — the real documents this ships against always have them.
         let rendered = MarkdownHTML.render(
@@ -900,7 +899,7 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         )
 
         // Drive the real mermaidInitWiring with a stub renderer + host so the
-        // openPopup path posts a measured mermaidPopup message.
+        // openPopup path posts the diagram SVG and section title.
         let html = """
         <!DOCTYPE html>
         <html><head>
@@ -964,12 +963,8 @@ final class MarkdownHTMLRenderTests: XCTestCase {
 
         let hudPayload = try await waitForMermaidPopupMessage(in: webView)
         XCTAssertEqual(hudPayload.kind, "mermaidPopup")
-        XCTAssertEqual(hudPayload.naturalWidth, 400, accuracy: 0.5)
-        XCTAssertEqual(hudPayload.naturalHeight, 200, accuracy: 0.5)
-        XCTAssertGreaterThan(hudPayload.displayWidth, 1)
-        XCTAssertGreaterThan(hudPayload.displayHeight, 1)
         XCTAssertTrue(hudPayload.svg.contains("<svg"), hudPayload.svg)
-        XCTAssertTrue(hudPayload.svg.contains("viewBox"), hudPayload.svg)
+        XCTAssertTrue(hudPayload.svg.contains(#"viewBox="0 0 400 200""#), hudPayload.svg)
         // Nearest preceding heading, not the document title.
         XCTAssertEqual(hudPayload.sectionTitle, "1. System overview")
         // Clone should not carry pan/zoom transform styles from the surface.
@@ -1274,11 +1269,7 @@ final class MarkdownHTMLRenderTests: XCTestCase {
                 return JSON.stringify({
                     kind: String(msg.kind || ''),
                     svg: String(msg.svg || ''),
-                    sectionTitle: String(msg.sectionTitle || ''),
-                    naturalWidth: Number(msg.naturalWidth) || 0,
-                    naturalHeight: Number(msg.naturalHeight) || 0,
-                    displayWidth: Number(msg.displayWidth) || 0,
-                    displayHeight: Number(msg.displayHeight) || 0
+                    sectionTitle: String(msg.sectionTitle || '')
                 });
             })()
             """)
@@ -2247,8 +2238,4 @@ private struct MermaidPopupMessage: Decodable {
     let kind: String
     let svg: String
     let sectionTitle: String
-    let naturalWidth: CGFloat
-    let naturalHeight: CGFloat
-    let displayWidth: CGFloat
-    let displayHeight: CGFloat
 }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MermaidPopupSizingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MermaidPopupSizingTests.swift
@@ -2,59 +2,27 @@ import XCTest
 @testable import MarkdownHelpers
 
 final class MermaidPopupSizingTests: XCTestCase {
-    func testFitsLargeDiagramIntoScreen() {
-        let size = MermaidPopupSizing.preferredContentSize(
-            natural: CGSize(width: 2400, height: 1600),
-            display: CGSize(width: 600, height: 400),
-            screen: CGSize(width: 1440, height: 900)
-        )
-        XCTAssertLessThanOrEqual(size.width, 1440 * MermaidPopupSizing.screenFraction + 0.5)
-        XCTAssertLessThanOrEqual(size.height, 900 * MermaidPopupSizing.screenFraction + 0.5)
-        // Aspect roughly preserved (2400/1600 = 1.5).
-        XCTAssertEqual(size.width / size.height, 1.5, accuracy: 0.08)
+    func testInitialSizePreservesWidescreenAspectRatio() {
+        let screen = CGSize(width: 1440, height: 900)
+        let size = MermaidPopupSizing.preferredContentSize(screen: screen)
+        XCTAssertEqual(size.width / size.height, 16.0 / 9.0, accuracy: 0.01)
+        XCTAssertLessThanOrEqual(size.width, screen.width * MermaidPopupSizing.screenFraction + 1)
+        XCTAssertLessThanOrEqual(size.height, screen.height * MermaidPopupSizing.screenFraction + 1)
     }
 
-    func testPrefersNaturalSizeOverCappedDisplay() {
-        // Document capped a tall diagram; popup should open closer to natural.
+    func testInitialSizeFitsSmallScreenWithoutUsingDiagramAspectRatio() {
         let size = MermaidPopupSizing.preferredContentSize(
-            natural: CGSize(width: 400, height: 1200),
-            display: CGSize(width: 400, height: 500),
-            screen: CGSize(width: 1600, height: 1200)
+            screen: CGSize(width: 800, height: 600)
         )
-        XCTAssertGreaterThan(size.height, 500)
-        XCTAssertLessThanOrEqual(size.height, 1200 * MermaidPopupSizing.screenFraction + 0.5)
+        XCTAssertEqual(size.width, 720, accuracy: 0.5)
+        XCTAssertEqual(size.height, 405, accuracy: 0.5)
     }
 
-    func testCappedDisplayDoesNotOverrideNaturalAspectRatio() {
-        // A tall figure remains full-width after CSS caps its height, so its
-        // displayed box can be much wider than the SVG's natural aspect.
-        let size = MermaidPopupSizing.preferredContentSize(
-            natural: CGSize(width: 400, height: 1200),
-            display: CGSize(width: 800, height: 720),
-            screen: CGSize(width: 1600, height: 1200)
-        )
-        XCTAssertLessThan(size.width, 500)
-        XCTAssertEqual(size.width / size.height, 1.0 / 3.0, accuracy: 0.03)
-    }
-
-    func testUpscalesTinyDiagramsToReadableMinimum() {
-        let size = MermaidPopupSizing.preferredContentSize(
-            natural: CGSize(width: 120, height: 80),
-            display: CGSize(width: 120, height: 80),
-            screen: CGSize(width: 1600, height: 1000)
-        )
-        XCTAssertGreaterThanOrEqual(size.width, MermaidPopupSizing.minimumWidth - 1)
-        XCTAssertGreaterThanOrEqual(size.height, 100)
-    }
-
-    func testFallsBackToDisplayWhenNaturalMissing() {
-        let size = MermaidPopupSizing.preferredContentSize(
-            natural: .zero,
-            display: CGSize(width: 500, height: 300),
-            screen: CGSize(width: 1600, height: 1000)
-        )
-        XCTAssertGreaterThanOrEqual(size.width, 500)
-        XCTAssertGreaterThanOrEqual(size.height, 300)
+    func testSmallScreenTakesPrecedenceOverMinimumSize() {
+        let size = MermaidPopupSizing.preferredContentSize(screen: CGSize(width: 640, height: 480))
+        XCTAssertEqual(size.width / size.height, 16.0 / 9.0, accuracy: 0.01)
+        XCTAssertLessThanOrEqual(size.width, 576)
+        XCTAssertLessThanOrEqual(size.height, 432)
     }
 
     func testCanPresentRejectsEmptySVG() {
@@ -68,19 +36,15 @@ final class MermaidPopupSizingTests: XCTestCase {
         XCTAssertFalse(safe.lowercased().contains("<script"))
         XCTAssertTrue(safe.contains("&lt;script"))
         XCTAssertTrue(safe.contains("&lt;/script"))
-        // Non-script markup is left intact.
         XCTAssertTrue(safe.hasPrefix("<svg>"))
         XCTAssertTrue(safe.hasSuffix("</svg>"))
     }
 
-    /// sanitizedSVGHTML is defense-in-depth only, not the primary guard: it
-    /// neutralizes `<script>` but deliberately leaves `on*` handlers alone.
-    /// The popup document's CSP (`default-src 'none'`) is what actually
-    /// blocks any script execution, inline or event-handler-based.
+    /// The popup CSP permits only its nonce-authorized interaction script.
     func testSanitizedSVGHTMLDoesNotStripEventHandlerAttributes() {
         let raw = #"<svg onload="alert(1)"><rect onclick="alert(2)"/></svg>"#
         let safe = MermaidPopupSizing.sanitizedSVGHTML(raw)
-        XCTAssertTrue(safe.contains(#"onload="alert(1)""#))
-        XCTAssertTrue(safe.contains(#"onclick="alert(2)""#))
+        XCTAssertTrue(safe.contains(#"onload="alert(1)"#))
+        XCTAssertTrue(safe.contains(#"onclick="alert(2)"#))
     }
 }


### PR DESCRIPTION
## Summary

- Open Mermaid diagrams in a stable, screen-centered 16:9 popup.
- Fit oversized diagrams without upscaling smaller diagrams; support pointer-anchored wheel zoom, drag panning, and Space reset.
- Reveal the canvas only after WebKit finishes layout preparation, while showing the window immediately.
- Keep the popup CSP restricted to its nonce-authorized interaction script.
- Preserve the existing inline Mermaid scroll behavior.

## Verification

- swift test --package-path tests/swift-tests
- Native AppKit/WKWebView smoke: immediate window/canvas readiness, fit, fine wheel zoom, both-axis mouse anchoring, Space reset, and SVG event-handler blocking.
- xcodebuild -quiet -project md-preview.xcodeproj -scheme md-preview -configuration Debug -derivedDataPath build-custom build CODE_SIGNING_ALLOWED=NO

The app was also rebuilt and installed locally as /Applications/Markdown Preview.app.