### PR TITLE
Remove the page-wide Quick Look copy-button gutter

### DIFF
--- a/quick-look/PreviewViewController.swift
+++ b/quick-look/PreviewViewController.swift
@@ -427,7 +427,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private static let floatingButtonHeight: CGFloat = 26
     private static let floatingButtonTrailingInset: CGFloat = 12
     private static let floatingButtonBottomInset: CGFloat = 10
-    private static let floatingButtonHorizontalClearance: CGFloat = 90
+    // Reserve bottom space for the overlay without narrowing the whole page.
     private static let floatingButtonVerticalClearance: CGFloat = 44
 
     private var webView: QuickLookWebView!
@@ -592,12 +592,10 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         // Vendor scripts can contain `</head>` as data. The document's real
         // closing tag is the final occurrence in MarkdownHTML's output.
         guard let headEnd = html.range(of: "</head>", options: .backwards) else { return html }
-        let horizontalClearance = Int(Self.floatingButtonHorizontalClearance)
         let verticalClearance = Int(Self.floatingButtonVerticalClearance)
         let style = """
         <style>
         body {
-            padding-right: calc(\(horizontalClearance)px + env(safe-area-inset-right));
             padding-bottom: calc(\(verticalClearance)px + env(safe-area-inset-bottom));
         }
         </style>


### PR DESCRIPTION
The floating Quick Look Copy button reserves 90 px on the right side of every document, compared with the normal 40 px left margin. This narrows the entire preview and creates an asymmetric empty strip.

Remove the horizontal override and retain bottom clearance for the button. The shared renderer now controls both side margins.

Validation: signed Debug app and Quick Look extension build succeeded. Tested the margin change together with #343 in Finder Space-bar Quick Look on samples/codeblocks.md; confirmed balanced side margins and verified the running extension path. The combined runtime build is separate from this narrowly scoped branch.

This is separate from #343, which fixes the insertion point of the clearance CSS. When combining the changes, keep #343's safe insertion point and apply only bottom clearance.
