### PR TITLE
Fix editor code block corners and simplify language labels

### DIFF
--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -768,10 +768,9 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             z-index: -2;
             background: var(--code-bg);
         }
-        #editor .cm-md-codeblock-first {
+        #editor .cm-content > .cm-line.cm-md-codeblock-first {
             padding-top: 10px;
             position: relative;
-            padding-inline-end: 9em;
         }
         #editor .cm-md-codeblock-first::before {
             border-radius: 15px 15px 0 0;
@@ -782,27 +781,37 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         #editor .cm-md-codeblock-last::before {
             border-radius: 0 0 15px 15px;
         }
+        /* A single content line owns both ends of the card. */
+        #editor .cm-md-codeblock-first.cm-md-codeblock-last::before {
+            border-radius: 15px;
+        }
+        /* Reserve a header row so the language never competes with code,
+           including wrapped lines and blocks at the start of a document. */
+        #editor .cm-content > .cm-line.cm-md-codeblock-first:has(.cm-md-code-language) {
+            padding-top: 36px;
+        }
         #editor .cm-md-code-fence-source-hidden {
             visibility: hidden;
         }
         #editor .cm-md-code-language {
             position: absolute;
-            inset-inline-end: 14px;
-            top: 7px;
+            inset-inline-start: 14px;
+            max-width: calc(100% - 28px);
+            top: 9px;
             z-index: 1;
             line-height: 1;
             white-space: nowrap;
         }
         #editor .cm-md-code-language-input {
-            width: 8em;
-            max-width: 28vw;
+            width: 14em;
+            max-width: 100%;
             min-width: 4.5em;
             box-sizing: border-box;
-            padding: 2px 6px;
-            border: 1px solid var(--grid);
+            padding: 2px 0;
+            border: 1px solid transparent;
             border-radius: 5px;
-            background: var(--code-bg);
-            color: var(--text);
+            background: transparent;
+            color: var(--secondary);
             font-family: system-ui, -apple-system, sans-serif;
             font-size: 0.8em;
             line-height: 1.35;
@@ -812,7 +821,12 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             color: var(--secondary);
             opacity: 0.8;
         }
+        #editor .cm-md-code-language-input:hover {
+            color: var(--text);
+        }
         #editor .cm-md-code-language-input:focus {
+            background: var(--code-bg);
+            color: var(--text);
             border-color: var(--link);
             box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 22%, transparent);
         }

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -795,8 +795,8 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         }
         #editor .cm-md-code-language {
             position: absolute;
-            inset-inline-start: 14px;
-            max-width: calc(100% - 28px);
+            inset-inline-start: 7px;
+            max-width: calc(100% - 21px);
             top: 9px;
             z-index: 1;
             line-height: 1;
@@ -807,7 +807,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             max-width: 100%;
             min-width: 4.5em;
             box-sizing: border-box;
-            padding: 2px 0;
+            padding: 2px 6px;
             border: 1px solid transparent;
             border-radius: 5px;
             background: transparent;
@@ -825,10 +825,11 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             color: var(--text);
         }
         #editor .cm-md-code-language-input:focus {
-            background: var(--code-bg);
+            background: color-mix(in srgb, var(--text) 4%, var(--code-bg));
             color: var(--text);
-            border-color: var(--link);
-            box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 22%, transparent);
+            border-color: var(--grid);
+            caret-color: var(--link);
+            box-shadow: none;
         }
         /* Frontmatter — a quiet metadata card above the document, echoing
            the preview's properties panel. YAML stays editable; only the


### PR DESCRIPTION
Single-line editor code blocks lost their top rounded corners, and the language input occupied space beside the code. Preserve all four corners for single-line blocks and keep top padding when a block starts the document.

Move the editable language label into a reserved header row with muted, borderless styling and a visible focus state. Code can use the full content width without overlapping the label.

Validation: Debug Xcode build succeeded; all 141 editor smoke checks passed; rendered single-line, multiline, and wrapped blocks in a WKWebView using the editor CSS and bundled CodeMirror.
