### PR TITLE
Fix reader top spacing when the tab bar is visible

### DIFF
--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -407,40 +407,30 @@ final class ContentViewController: NSViewController {
         // The chrome (toolbar, accessories) is final here; layout passes
         // before it attaches see a smaller contentLayoutRect.
         updateObscuredContentInsets()
+        observeWindowChrome()
     }
 
-    /// With a themed window background the titlebar is transparent and the
-    /// page runs to the window's top edge, so WebKit is told which strip the
-    /// toolbar obscures — it lays the page out below it and frosts content
-    /// that scrolls underneath, the way Safari's toolbar works. Without a
-    /// theme the titlebar is opaque and the inset must be zero.
+    private var contentLayoutObservation: NSKeyValueObservation?
 
-    /// Height of the titlebar-and-toolbar strip, from the window's
-    /// contentLayoutRect (authoritative immediately, unlike safeAreaInsets
-    /// which lags the toolbar attach), minus visible bottom titlebar
-    /// accessories.
-    private var obscuredTopInset: CGFloat {
-        max(0, fullChromeTopInset - visibleBottomAccessoryHeight)
+    /// Showing or hiding the native tab bar can change the content area
+    /// without laying out this full-height view. Follow the window's chrome
+    /// directly, as the editor does, without forcing a nested layout pass.
+    private func observeWindowChrome() {
+        contentLayoutObservation = view.window?.observe(\.contentLayoutRect) { [weak self] _, _ in
+            MainActor.assumeIsolated {
+                self?.updateObscuredContentInsets()
+            }
+        }
     }
 
-    /// The whole obscured strip — titlebar, toolbar, and visible bottom
-    /// accessories. contentLayoutRect already excludes the accessories, so
-    /// the gap alone is the full chrome height.
+    /// The whole obscured strip, including the native tab bar. AppKit
+    /// exposes the tab bar as a bottom titlebar accessory; subtracting its
+    /// height would let it consume the page's top padding.
     private var fullChromeTopInset: CGFloat {
         guard let window = view.window, let contentView = window.contentView else {
             return view.safeAreaInsets.top
         }
         return max(0, contentView.bounds.height - window.contentLayoutRect.maxY)
-    }
-
-    private var visibleBottomAccessoryHeight: CGFloat {
-        guard let window = view.window else { return 0 }
-        var height: CGFloat = 0
-        for accessory in window.titlebarAccessoryViewControllers
-        where accessory.layoutAttribute == .bottom && !accessory.isHidden {
-            height += accessory.view.frame.height
-        }
-        return height
     }
 
     /// Pre-Tahoe there is no frost and no `obscuredContentInsets`, so the
@@ -478,7 +468,7 @@ final class ContentViewController: NSViewController {
         // web view's lifetime — the page then collides with the toolbar
         // until the window is recreated. Keeping the explicit value equal
         // to the chrome strip matches the automatic behavior exactly.
-        let inset = obscuredTopInset
+        let inset = fullChromeTopInset
         if toolbarGutterHeightConstraint?.constant != inset {
             toolbarGutterHeightConstraint?.constant = inset
         }

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -798,7 +798,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             max-width: 28vw;
             min-width: 4.5em;
             box-sizing: border-box;
-            padding: 2px 6px;
+            padding: 2px 8px;
             border: 1px solid var(--grid);
             border-radius: 5px;
             background: var(--code-bg);
@@ -813,8 +813,8 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             opacity: 0.8;
         }
         #editor .cm-md-code-language-input:focus {
-            border-color: var(--link);
-            box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 22%, transparent);
+            border-color: color-mix(in srgb, var(--secondary) 40%, transparent);
+            box-shadow: none;
         }
         /* Frontmatter — a quiet metadata card above the document, echoing
            the preview's properties panel. YAML stays editable; only the

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -798,7 +798,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             max-width: 28vw;
             min-width: 4.5em;
             box-sizing: border-box;
-            padding: 2px 8px;
+            padding: 2px 6px;
             border: 1px solid var(--grid);
             border-radius: 5px;
             background: var(--code-bg);
@@ -813,8 +813,8 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             opacity: 0.8;
         }
         #editor .cm-md-code-language-input:focus {
-            border-color: color-mix(in srgb, var(--secondary) 40%, transparent);
-            box-shadow: none;
+            border-color: var(--link);
+            box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 22%, transparent);
         }
         /* Frontmatter — a quiet metadata card above the document, echoing
            the preview's properties panel. YAML stays editable; only the


### PR DESCRIPTION
Showing the native tab bar previously consumed 36 points of the reader’s top spacing because its height was subtracted from the obscured-content inset. Include the full window chrome height and observe content-layout changes so showing or hiding tabs updates the reader immediately.

Validation:
- Reproduced the reader regression in the running macOS 26 app and verified showing/hiding tabs with the fix.
- The reader fix passed an Xcode Debug build and Swift tests: 252 executed, one skipped, zero failures.
