### PR TITLE
Fix TOC parsing for code blocks inside lists

### DIFF
--- a/md-preview/Features/Sidebar/MarkdownTOC.swift
+++ b/md-preview/Features/Sidebar/MarkdownTOC.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import Markdown
 
 struct TOCItem: Identifiable, Hashable {
     let id: Int
@@ -25,89 +26,30 @@ enum MarkdownTOC {
     }
 
     private static func extractHeadings(from markdown: String) -> [RawHeading] {
-        var result: [RawHeading] = []
-        var inFence = false
+        // Share the renderer's CommonMark parsing so container nesting and fence
+        // delimiters cannot turn code-block contents into outline entries.
+        let body = MarkdownFrontmatter.split(markdown).body
+        var collector = HeadingCollector()
+        collector.visit(Document(parsing: body))
+        return collector.headings
+    }
 
-        let lines = markdown.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+    private struct HeadingCollector: MarkupWalker {
+        var headings: [RawHeading] = []
 
-        for raw in lines {
-            let line = String(raw)
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
+        mutating func visitHeading(_ heading: Heading) {
+            // Keep empty headings too: IDs follow rendered heading order.
+            headings.append(RawHeading(level: heading.level, title: Self.titleText(heading)))
+        }
 
-            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
-                inFence.toggle()
-                continue
+        private static func titleText(_ markup: Markup) -> String {
+            // InlineCode.plainText includes backticks; the outline shows its content.
+            if let code = markup as? InlineCode { return code.code }
+            if markup.childCount > 0 {
+                return markup.children.map { titleText($0) }.joined()
             }
-            if inFence { continue }
-
-            guard let heading = parseATXHeading(line) else { continue }
-            result.append(heading)
+            return (markup as? InlineMarkup)?.plainText ?? ""
         }
-
-        return result
-    }
-
-    private static func parseATXHeading(_ line: String) -> RawHeading? {
-        let chars = Array(line)
-        var i = 0
-
-        // Up to 3 leading spaces (CommonMark).
-        var leading = 0
-        while i < chars.count, chars[i] == " ", leading < 3 {
-            i += 1
-            leading += 1
-        }
-
-        var hashes = 0
-        while i < chars.count, chars[i] == "#", hashes < 7 {
-            hashes += 1
-            i += 1
-        }
-        guard hashes >= 1, hashes <= 6 else { return nil }
-
-        // Heading marker must be followed by a space or end of line.
-        if i < chars.count, chars[i] != " " { return nil }
-        if i < chars.count { i += 1 }
-
-        var rest = String(chars[i...]).trimmingCharacters(in: .whitespaces)
-
-        // Strip optional trailing closing hashes (CommonMark ATX closing sequence).
-        if let trimmedClose = stripClosingHashes(rest) { rest = trimmedClose }
-
-        let cleaned = stripInlineMarkers(rest)
-        guard !cleaned.isEmpty else { return nil }
-
-        return RawHeading(level: hashes, title: cleaned)
-    }
-
-    private static func stripClosingHashes(_ text: String) -> String? {
-        guard let lastNonSpace = text.lastIndex(where: { $0 != " " }),
-              text[lastNonSpace] == "#" else { return nil }
-
-        var idx = lastNonSpace
-        while idx > text.startIndex, text[idx] == "#" {
-            idx = text.index(before: idx)
-        }
-        // Need whitespace before the hash run for it to count as a closer.
-        guard idx >= text.startIndex, text[idx] == " " else { return nil }
-        return String(text[..<idx]).trimmingCharacters(in: .whitespaces)
-    }
-
-    private static func stripInlineMarkers(_ text: String) -> String {
-        var s = text
-
-        // [label](url) → label
-        if let regex = try? NSRegularExpression(pattern: #"\[([^\]]+)\]\([^)]*\)"#) {
-            let range = NSRange(s.startIndex..., in: s)
-            s = regex.stringByReplacingMatches(in: s, range: range, withTemplate: "$1")
-        }
-
-        // Remove emphasis / code markers.
-        for marker in ["**", "__", "*", "_", "`", "~~"] {
-            s = s.replacingOccurrences(of: marker, with: "")
-        }
-
-        return s.trimmingCharacters(in: .whitespaces)
     }
 
     private static func buildTree(_ headings: [RawHeading]) -> [TOCItem] {

--- a/tests/swift-tests/Sources/MarkdownHelpers/MarkdownTOC.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/MarkdownTOC.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/Features/Sidebar/MarkdownTOC.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownTOCTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownTOCTests.swift
@@ -80,4 +80,67 @@ final class MarkdownTOCTests: XCTestCase {
         XCTAssertEqual(roots.count, 1)
         XCTAssertEqual(roots[0].children.count, 4)
     }
+
+    func testCommonHeadingSyntaxAndNonHeadings() {
+        let markdown = """
+        # First ###
+        ### Skipped level
+        #\tTabbed marker
+           ## Three spaces
+
+            # Indented code
+
+        \\# Escaped marker
+        #No space
+        ####### Seven hashes
+
+        <!--
+        # Comment
+        -->
+
+        Last
+        ====
+        """.replacingOccurrences(of: "\n", with: "\r\n")
+        let items = flattened(MarkdownTOC.parse(markdown))
+        XCTAssertEqual(items.map(\.title), ["First", "Skipped level", "Tabbed marker", "Three spaces", "Last"])
+        XCTAssertEqual(items.map(\.level), [1, 3, 1, 2, 1])
+        XCTAssertTrue(MarkdownTOC.parse("").isEmpty)
+        XCTAssertTrue(MarkdownTOC.parse("Just a paragraph").isEmpty)
+    }
+
+    func testInlineFormattingPreservesLiteralTitleContent() {
+        let markdown = #"# **Bold** *italic* ~~deleted~~ [link](https://example.com) `a_b*` &amp; \*literal\* ![alt](image.png)"#
+        XCTAssertEqual(MarkdownTOC.parse(markdown).first?.title, "Bold italic deleted link a_b* & *literal* alt")
+    }
+
+    func testOutlineIDsAndLevelsMatchRenderedArticle() throws {
+        let markdown = """
+        ---
+        title: Example
+        ---
+        # Root
+        > ## Quoted heading
+
+        - ### List heading
+
+          ~~~~text
+          # Hidden
+          ```
+          ~~~~
+
+        Setext heading
+        --------------
+
+        ##
+        ## **Final** `a_b`
+        """
+        let items = flattened(MarkdownTOC.parse(markdown))
+        let html = MarkdownHTML.render(markdown: markdown, vendorLoading: .lazy).articleHTML as NSString
+        let regex = try NSRegularExpression(pattern: #"<h([1-6])[^>]* id="md-heading-(\d+)">"#)
+        let matches = regex.matches(in: html as String, range: NSRange(location: 0, length: html.length))
+        XCTAssertEqual(matches.count, 6)
+        XCTAssertEqual(items.map(\.level), matches.compactMap { Int(html.substring(with: $0.range(at: 1))) })
+        XCTAssertEqual(items.map(\.id), matches.compactMap { Int(html.substring(with: $0.range(at: 2))) })
+    }
+
 }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownTOCTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownTOCTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+@testable import MarkdownHelpers
+
+final class MarkdownTOCTests: XCTestCase {
+    private func flattened(_ items: [TOCItem]) -> [TOCItem] {
+        items.flatMap { [$0] + flattened($0.children) }
+    }
+
+    func testListFenceDoesNotHideFollowingHeadingOrExposeCodeHeadings() {
+        for opener in ["- ```", "* ```", "+ ```", "1. ```", "1) ```", "> - ```"] {
+            let indent = opener.hasPrefix("1") ? "   " : "  "
+            let quote = opener.hasPrefix(">") ? "> " : ""
+            let markdown = """
+            ## Code block inside a list item
+
+            \(opener)
+            \(quote)    foo
+            \(quote)\(indent)```
+
+            ## Code block containing ATX headings
+
+            ```text
+            # foo
+            ## foo
+            ### foo
+            #### foo
+            ##### foo
+            ###### foo
+            ```
+            """
+            let items = flattened(MarkdownTOC.parse(markdown))
+            XCTAssertEqual(items.map(\.title), ["Code block inside a list item", "Code block containing ATX headings"], opener)
+            XCTAssertEqual(items.map(\.id), [0, 1], opener)
+        }
+    }
+
+    func testFenceCloserMustMatchCharacterLengthAndHaveNoInfoString() {
+        for (open, inner, close) in [
+            ("````text", "- ```\n    foo\n  ```", "````"),
+            ("~~~~", "```\n# hidden\n```", "~~~~"),
+            ("````", "```\n# hidden", "`````"),
+            ("```", "```text\n# hidden", "```"),
+        ] {
+            let markdown = "## Before\n\n\(open)\n\(inner)\n\(close)\n\n## After\n\n```text\n# hidden\n```"
+            XCTAssertEqual(flattened(MarkdownTOC.parse(markdown)).map(\.title), ["Before", "After"])
+        }
+    }
+
+    func testUnclosedListFenceEndsWithItsContainer() {
+        let markdown = "# Before\n\n- ```\n  # hidden\n\n# After"
+        XCTAssertEqual(flattened(MarkdownTOC.parse(markdown)).map(\.title), ["Before", "After"])
+    }
+
+    func testFrontmatterDoesNotCreateOutlineHeadings() {
+        let markdown = "---\n# Metadata comment\ntitle: Example\n---\n# Body"
+        let items = flattened(MarkdownTOC.parse(markdown))
+        XCTAssertEqual(items.map(\.title), ["Body"])
+        XCTAssertEqual(items.map(\.id), [0])
+    }
+
+    func testHeadingHierarchyAndIDsFollowMarkdownDocumentOrder() {
+        let markdown = """
+        # **Root**
+        > ## [Link](https://example.com)
+
+        - ### `child_name`
+
+        Setext
+        ------
+
+        ##
+        ## Last
+        """
+        let roots = MarkdownTOC.parse(markdown)
+        let items = flattened(roots)
+        XCTAssertEqual(items.map(\.title), ["Root", "Link", "child_name", "Setext", "", "Last"])
+        XCTAssertEqual(items.map(\.id), Array(0...5))
+        XCTAssertEqual(items.map(\.level), [1, 2, 3, 2, 2, 2])
+        XCTAssertEqual(roots.count, 1)
+        XCTAssertEqual(roots[0].children.count, 4)
+    }
+}


### PR DESCRIPTION
A fenced code block opened on a list-item line could put the outline scanner out of sync, hiding the next real heading and exposing headings inside subsequent code blocks. Shorter fences inside a longer fence caused the same failure.

Replace the boolean fence scanner with a heading walk using the existing swift-markdown parser. The outline now respects CommonMark containers and fence delimiters, strips frontmatter, and includes nested, Setext, and empty headings in document order to preserve heading navigation IDs. Inline code titles retain their content without delimiter backticks.

Validation:
- Reproduced the old scanner failures with regression tests before applying the fix.
- Full Swift suite: 260 tests executed, one opt-in performance probe skipped, zero failures. Coverage includes heading syntax, inline formatting, CRLF, nesting, frontmatter, empty headings, and outline ID/level parity with the rendered article.
- Xcode Debug build passed with existing warnings.
- Launched the exact built app and verified both issue examples show only the two expected outline headings. Also verified general outline hierarchy, formatted titles, and click-to-scroll navigation to the final section of a long document.

Fixes #336.
