### PR TITLE
Add GitHub project link to About settings

### DIFF
--- a/md-preview/Features/Settings/AboutSettingsView.swift
+++ b/md-preview/Features/Settings/AboutSettingsView.swift
@@ -42,6 +42,10 @@ struct AboutSettingsView: View {
             }
 
             Section {
+                Link(L("GitHub Project"), destination: URL(string: "https://github.com/pluk-inc/markdown-preview")!)
+            }
+
+            Section {
                 Toggle(L("Automatically check for updates"),
                        isOn: $model.checksForUpdatesAutomatically)
                 Toggle(L("Automatically download updates"),


### PR DESCRIPTION
Adds a GitHub Project link to Settings → About so readers can find the project and report issues.

Related to #291. This PR handles one request and intentionally does not close the umbrella issue.

Stack 1/6 for #291. First PR in the stack; merge in stack order.

Validation: the combined stack passes the Debug Xcode app/Quick Look build with CODE_SIGNING_ALLOWED=NO and the helper suite (261 tests, one skipped, zero failures). Verified the link and destination in the built app.
