### PR TITLE
Allow tighter reader margins

### DIFF
--- a/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
+++ b/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
@@ -122,7 +122,7 @@ nonisolated extension MarkdownHTML {
         word-spacing: var(--mdp-word-spacing, normal);
         color: var(--text);
         background: transparent;
-        padding: \(pagePaddingTop)px \(pagePaddingHorizontal)px \(pagePaddingBottom)px;
+        padding: \(pagePaddingTop)px var(--mdp-page-padding, \(pagePaddingHorizontal)px) \(pagePaddingBottom)px;
         -webkit-font-smoothing: antialiased;
     }
     /* Reader spacing tweaks stop at code — whitespace fidelity wins. */

--- a/md-preview/Rendering/ReaderLayoutSetting.swift
+++ b/md-preview/Rendering/ReaderLayoutSetting.swift
@@ -30,7 +30,7 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
     static let lineSpacingRange = 1.0...2.0
     static let characterSpacingRange = -5.0...12.0
     static let wordSpacingRange = -10.0...25.0
-    static let marginsRange = 0.0...100.0
+    static let marginsRange = -100.0...100.0
 
     // MARK: - Effective values
 
@@ -47,7 +47,7 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
     /// nothing in Full Width and sit off-centre in the app's normal mode,
     /// where the article is host-centered with `margin-left: 0`.
     var pageInset: Int {
-        Int(0.9 * effective.marginsPercent)
+        Int(0.9 * max(0, effective.marginsPercent))
     }
 
     /// CSS custom-property declarations for the page `:root`. Only values
@@ -70,6 +70,8 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
         }
         if applied.marginsPercent != 0 {
             lines.append("--mdp-page-inset: \(pageInset)px;")
+            let padding = MarkdownHTML.pagePaddingHorizontal * (1 + min(0, applied.marginsPercent) / 100)
+            lines.append("--mdp-page-padding: \(Int(padding))px;")
         }
         return lines.joined(separator: "\n    ")
     }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
@@ -137,6 +137,18 @@ final class ReaderLayoutSettingTests: XCTestCase {
         XCTAssertLessThan(fontRange.lowerBound, layoutRange.lowerBound)
     }
 
+    func testTighterMarginsReduceOuterPaddingWithoutNegativeArticlePadding() {
+        var setting = ReaderLayoutSetting()
+        setting.isCustomized = true
+        setting.marginsPercent = -50
+        XCTAssertEqual(setting.pageInset, 0)
+        XCTAssertTrue(setting.cssVariables.contains("--mdp-page-padding: 20px;"))
+        setting.marginsPercent = -100
+        XCTAssertTrue(setting.cssVariables.contains("--mdp-page-padding: 0px;"))
+        setting.isCustomized = false
+        XCTAssertEqual(setting.cssVariables, "")
+    }
+
     func testRenderedHTMLCarriesTheLayoutVariables() {
         var setting = ReaderLayoutSetting()
         setting.boldText = true


### PR DESCRIPTION
Extends Appearance → Customize Theme → Margins below zero. Negative values reduce the default 40-point horizontal page padding down to zero; positive values retain the existing added inset. The existing default remains the midpoint.

Related to #291. This PR handles one request and intentionally does not close the umbrella issue.

Stack 2/6 for #291. Based on https://github.com/pluk-inc/markdown-preview/pull/353; merge in stack order.

Validation: Debug app/Quick Look build passed with CODE_SIGNING_ALLOWED=NO. The combined stack helper suite passed: 261 tests, one skipped, zero failures.

Runtime verification: set Margins to -100 and +100, committed each change, and visually confirmed the document text shifted from the default x=272 to x=232 and x=362 respectively in the same window. Reopening Customize preserved the saved value. Restored margin 0 and Customize off afterward.
