### PR TITLE
Add setting to open Markdown links in new windows

### DIFF
--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -556,6 +556,14 @@ final class ContentViewController: NSViewController {
         navigationTargetRetriesLeft = target == nil ? 0 : Self.navigationTargetMaxRetries
     }
 
+    /// Document opening can finish after display() has already started.
+    /// Arm the target immediately and retry until the new page has geometry.
+    func scrollToAnchorWhenReady(_ fragment: String) {
+        prepareToScrollAfterNavigation(to: .anchor(fragment))
+        shouldApplyNavigationTargetOnHeight = true
+        scheduleNavigationTargetAttempt()
+    }
+
     /// Immediate fragment scroll within the already-rendered document.
     func scrollToAnchor(_ fragment: String) {
         scrollToElement(id: fragment)

--- a/md-preview/Document/DocumentWindowController+DocumentOpening.swift
+++ b/md-preview/Document/DocumentWindowController+DocumentOpening.swift
@@ -33,9 +33,19 @@ extension DocumentWindowController {
     }
 
     private func openDocumentWindow(for fileURL: URL, completion: (() -> Void)? = nil) {
-        NSDocumentController.shared.openDocument(withContentsOf: fileURL,
-                                                 display: true) { [weak self] _, _, error in
+        let fragment = fileURL.fragment?.removingPercentEncoding
+        NSDocumentController.shared.openDocument(withContentsOf: Self.fileURLWithoutFragment(fileURL),
+                                                 display: true) { [weak self] document, wasOpen, error in
             completion?()
+            if let fragment,
+               let controller = document?.windowControllers.first as? DocumentWindowController,
+               let split = controller.documentWindow.contentViewController as? MainSplitViewController {
+                if wasOpen {
+                    split.scrollToAnchor(fragment)
+                } else {
+                    split.prepareToScrollAfterNavigation(to: .anchor(fragment))
+                }
+            }
             guard let self, let error else { return }
             NSAlert(error: error).beginSheetModal(for: self.documentWindow)
         }

--- a/md-preview/Document/DocumentWindowController+DocumentOpening.swift
+++ b/md-preview/Document/DocumentWindowController+DocumentOpening.swift
@@ -35,16 +35,12 @@ extension DocumentWindowController {
     private func openDocumentWindow(for fileURL: URL, completion: (() -> Void)? = nil) {
         let fragment = fileURL.fragment?.removingPercentEncoding
         NSDocumentController.shared.openDocument(withContentsOf: Self.fileURLWithoutFragment(fileURL),
-                                                 display: true) { [weak self] document, wasOpen, error in
+                                                 display: true) { [weak self] document, _, error in
             completion?()
             if let fragment,
                let controller = document?.windowControllers.first as? DocumentWindowController,
                let split = controller.documentWindow.contentViewController as? MainSplitViewController {
-                if wasOpen {
-                    split.scrollToAnchor(fragment)
-                } else {
-                    split.prepareToScrollAfterNavigation(to: .anchor(fragment))
-                }
+                split.scrollToAnchorWhenReady(fragment)
             }
             guard let self, let error else { return }
             NSAlert(error: error).beginSheetModal(for: self.documentWindow)

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -192,7 +192,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
             self?.present(url: url)
         }
         split.onOpenMarkdownLink = { [weak self] url in
-            self?.present(url: url)
+            if SettingsModel.shared.opensMarkdownLinksInNewWindows {
+                self?.openInNewWindow(url)
+            } else {
+                self?.present(url: url)
+            }
         }
         split.onToggleTaskCheckbox = { [weak self] line, checked in
             self?.toggleTaskCheckbox(onLine: line, checked: checked)
@@ -520,7 +524,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         }
     }
 
-    private static func fileURLWithoutFragment(_ url: URL) -> URL {
+    static func fileURLWithoutFragment(_ url: URL) -> URL {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               components.fragment != nil else { return url }
         components.fragment = nil

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -114,6 +114,10 @@ final class MainSplitViewController: NSSplitViewController {
         contentViewController?.prepareToScrollAfterNavigation(to: target)
     }
 
+    func scrollToAnchorWhenReady(_ fragment: String) {
+        contentViewController?.scrollToAnchorWhenReady(fragment)
+    }
+
     func scrollToAnchor(_ fragment: String) {
         contentViewController?.scrollToAnchor(fragment)
     }

--- a/md-preview/Features/Settings/GeneralSettingsView.swift
+++ b/md-preview/Features/Settings/GeneralSettingsView.swift
@@ -37,6 +37,9 @@ struct GeneralSettingsView: View {
                     Text(L("Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out."))
                 }
 
+                Toggle(L("Open Markdown links in new windows"),
+                       isOn: $model.opensMarkdownLinksInNewWindows)
+
                 Toggle(isOn: $model.opensDocumentsInTabs) {
                     Text(L("Open documents in tabs"))
                     Text(L("A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window."))

--- a/md-preview/Features/Settings/GeneralSettingsView.swift
+++ b/md-preview/Features/Settings/GeneralSettingsView.swift
@@ -37,8 +37,10 @@ struct GeneralSettingsView: View {
                     Text(L("Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out."))
                 }
 
-                Toggle(L("Open Markdown links in new windows"),
-                       isOn: $model.opensMarkdownLinksInNewWindows)
+                Toggle(isOn: $model.opensMarkdownLinksInNewWindows) {
+                    Text(L("Open Markdown links in new windows"))
+                    Text(L("Clicking a link to another Markdown file opens it in a separate window. Turn this off to open it in the current window."))
+                }
 
                 Toggle(isOn: $model.opensDocumentsInTabs) {
                     Text(L("Open documents in tabs"))

--- a/md-preview/Features/Settings/SettingsModel.swift
+++ b/md-preview/Features/Settings/SettingsModel.swift
@@ -89,6 +89,14 @@ final class SettingsModel {
         }
     }
 
+    var opensMarkdownLinksInNewWindows: Bool {
+        didSet {
+            guard !isRestoringExternalValues else { return }
+            UserDefaults.standard.set(opensMarkdownLinksInNewWindows,
+                                      forKey: "MarkdownPreview.opensMarkdownLinksInNewWindows")
+        }
+    }
+
     var sendsCrashReports: Bool {
         didSet {
             guard !isRestoringExternalValues, sendsCrashReports != oldValue else { return }
@@ -250,6 +258,7 @@ final class SettingsModel {
         readerLayout = ReaderLayoutSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         opensDocumentsInTabs = TabOpeningPolicy.isEnabled
+        opensMarkdownLinksInNewWindows = UserDefaults.standard.bool(forKey: "MarkdownPreview.opensMarkdownLinksInNewWindows")
         sendsCrashReports = CrashReporter.isEnabled
         themeColors = ThemeColorsSetting.current
         sharesAnonymousUsageAnalytics = UsageAnalyticsReporter.isEnabled
@@ -304,6 +313,7 @@ final class SettingsModel {
         readerLayout = ReaderLayoutSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         opensDocumentsInTabs = TabOpeningPolicy.isEnabled
+        opensMarkdownLinksInNewWindows = UserDefaults.standard.bool(forKey: "MarkdownPreview.opensMarkdownLinksInNewWindows")
         sendsCrashReports = CrashReporter.isEnabled
         themeColors = ThemeColorsSetting.current
         sharesAnonymousUsageAnalytics = UsageAnalyticsReporter.isEnabled

--- a/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
+++ b/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
@@ -122,7 +122,7 @@ nonisolated extension MarkdownHTML {
         word-spacing: var(--mdp-word-spacing, normal);
         color: var(--text);
         background: transparent;
-        padding: \(pagePaddingTop)px \(pagePaddingHorizontal)px \(pagePaddingBottom)px;
+        padding: \(pagePaddingTop)px var(--mdp-page-padding, \(pagePaddingHorizontal)px) \(pagePaddingBottom)px;
         -webkit-font-smoothing: antialiased;
     }
     /* Reader spacing tweaks stop at code — whitespace fidelity wins. */

--- a/md-preview/Rendering/ReaderLayoutSetting.swift
+++ b/md-preview/Rendering/ReaderLayoutSetting.swift
@@ -30,7 +30,7 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
     static let lineSpacingRange = 1.0...2.0
     static let characterSpacingRange = -5.0...12.0
     static let wordSpacingRange = -10.0...25.0
-    static let marginsRange = 0.0...100.0
+    static let marginsRange = -100.0...100.0
 
     // MARK: - Effective values
 
@@ -47,7 +47,7 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
     /// nothing in Full Width and sit off-centre in the app's normal mode,
     /// where the article is host-centered with `margin-left: 0`.
     var pageInset: Int {
-        Int(0.9 * effective.marginsPercent)
+        Int(0.9 * max(0, effective.marginsPercent))
     }
 
     /// CSS custom-property declarations for the page `:root`. Only values
@@ -70,6 +70,8 @@ nonisolated struct ReaderLayoutSetting: Equatable, Sendable {
         }
         if applied.marginsPercent != 0 {
             lines.append("--mdp-page-inset: \(pageInset)px;")
+            let padding = MarkdownHTML.pagePaddingHorizontal * (1 + min(0, applied.marginsPercent) / 100)
+            lines.append("--mdp-page-padding: \(Int(padding))px;")
         }
         return lines.joined(separator: "\n    ")
     }

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/ReaderLayoutSettingTests.swift
@@ -137,6 +137,18 @@ final class ReaderLayoutSettingTests: XCTestCase {
         XCTAssertLessThan(fontRange.lowerBound, layoutRange.lowerBound)
     }
 
+    func testTighterMarginsReduceOuterPaddingWithoutNegativeArticlePadding() {
+        var setting = ReaderLayoutSetting()
+        setting.isCustomized = true
+        setting.marginsPercent = -50
+        XCTAssertEqual(setting.pageInset, 0)
+        XCTAssertTrue(setting.cssVariables.contains("--mdp-page-padding: 20px;"))
+        setting.marginsPercent = -100
+        XCTAssertTrue(setting.cssVariables.contains("--mdp-page-padding: 0px;"))
+        setting.isCustomized = false
+        XCTAssertEqual(setting.cssVariables, "")
+    }
+
     func testRenderedHTMLCarriesTheLayoutVariables() {
         var setting = ReaderLayoutSetting()
         setting.boldText = true


### PR DESCRIPTION
Adds an off-by-default General setting for opening local Markdown links in separate windows. Uses the existing document-opening path and preserves heading fragments, including when the destination is already open.

Related to #291. This PR handles one request and intentionally does not close the umbrella issue.

Stack 3/6 for #291. Based on https://github.com/pluk-inc/markdown-preview/pull/354; merge in stack order.

Validation: Debug app/Quick Look build passed with CODE_SIGNING_ALLOWED=NO. The combined stack helper suite passed: 261 tests, one skipped, zero failures.

Runtime verification found and fixed a new-window fragment race: the document could start rendering before the open completion queued its scroll target. The completion now arms a bounded retry immediately. Verified ordinary link clicks with the preference off retain the current window and scroll to the target; with it on they open a separate window and scroll to the target. Verified a second click reuses an already-open destination and scrolls back to its target. Used long parent/child fixtures so a top-of-document failure was visible. Restored the preference off.
