### PR TITLE
Add optional pointer-based outline highlighting

### DIFF
--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -101,9 +101,19 @@ final class ContentViewController: NSViewController {
             // The fresh article is in the DOM; a same-height render never
             // fires heightDidChange, so this is the reliable signal.
             self?.applyPendingScrollAnchorIfNeeded()
+            self?.updatePointerTracking()
         }
+        NotificationCenter.default.addObserver(self, selector: #selector(updatePointerTracking),
+                                               name: UserDefaults.didChangeNotification, object: nil)
         webView.fragmentLinkActivated = { [weak self] fragment in
             self?.scrollToElement(id: fragment)
+        }
+        webView.pointerDocumentYDidChange = { [weak self] y in
+            guard let self,
+                  UserDefaults.standard.bool(forKey: "MarkdownPreview.outlineFollowsPointer") else { return }
+            self.pointerHeadingID = self.headingOffsetsCSS.lastIndex(where: { $0 <= y })
+            self.sticky = nil
+            self.notifyActiveHeading(self.pointerHeadingID)
         }
         webView.localMarkdownLinkActivated = { [weak self] url in
             self?.localMarkdownLinkActivated?(url)
@@ -236,7 +246,19 @@ final class ContentViewController: NSViewController {
 
     /// Drops scrollspy state before a doc swap so the previous doc's
     /// heading doesn't briefly stay marked.
+    @objc private func updatePointerTracking() {
+        let enabled = UserDefaults.standard.bool(forKey: "MarkdownPreview.outlineFollowsPointer")
+        webView.webView.evaluateJavaScript("window.mdPreviewPointerTracking = \(enabled ? "true" : "false");", completionHandler: nil)
+        if !enabled {
+            pointerHeadingID = nil
+            evaluateActiveHeading()
+        }
+    }
+
+    private var pointerHeadingID: Int?
+
     private func resetScrollspy() {
+        pointerHeadingID = nil
         headingOffsetsCSS = []
         sticky = nil
         notifyActiveHeading(nil)
@@ -658,6 +680,11 @@ final class ContentViewController: NSViewController {
     }
 
     private func evaluateActiveHeading() {
+        if UserDefaults.standard.bool(forKey: "MarkdownPreview.outlineFollowsPointer"),
+           let pointerHeadingID, sticky == nil {
+            notifyActiveHeading(pointerHeadingID)
+            return
+        }
         if let pin = sticky {
             if DispatchTime.now() < pin.holdUntil { return }
             if !hasMovedFar(from: pin.anchor) { return }

--- a/md-preview/Features/Settings/GeneralSettingsView.swift
+++ b/md-preview/Features/Settings/GeneralSettingsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 // MARK: - General
 
 struct GeneralSettingsView: View {
+    @AppStorage("MarkdownPreview.outlineFollowsPointer") private var outlineFollowsPointer = false
     @Bindable private var model = SettingsModel.shared
 
     var body: some View {
@@ -19,6 +20,8 @@ struct GeneralSettingsView: View {
                     Text(L("Text size"))
                     Text(L("Size of rendered Markdown in document windows."))
                 }
+
+                Toggle(L("Highlight outline section under the pointer"), isOn: $outlineFollowsPointer)
 
                 Picker(L("Content width"), selection: $model.contentWidth) {
                     ForEach(ContentWidthSetting.allCases, id: \.self) { setting in

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -201,6 +201,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     var contentDidReplace: (() -> Void)?
     var zoomDidChange: ((CGFloat) -> Void)?
     var fragmentLinkActivated: ((String) -> Void)?
+    var pointerDocumentYDidChange: ((CGFloat) -> Void)?
     var localMarkdownLinkActivated: ((URL) -> Void)?
     var taskCheckboxToggled: ((Int, Bool) -> Void)?
     var tableEditRequested: ((MarkdownTableEditRequest) -> Void)?
@@ -277,6 +278,21 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
 
     private static let disableContextMenuScript = WKUserScript(
         source: """
+        let pointerFrame = null;
+        let pointerY = 0;
+        const reportPointer = event => {
+            if (!window.mdPreviewPointerTracking || !event.target.closest('article.markdown-body')) return;
+            pointerY = event.clientY + window.scrollY;
+            if (pointerFrame !== null) return;
+            pointerFrame = requestAnimationFrame(() => {
+                pointerFrame = null;
+                if (!window.mdPreviewPointerTracking) return;
+                window.webkit.messageHandlers.mdPreviewHost.postMessage({
+                    kind: 'pointerPosition', value: pointerY
+                });
+            });
+        };
+        document.addEventListener('pointermove', reportPointer, {passive: true});
         document.addEventListener('contextmenu', event => {
             const link = event.target.closest('a[href]');
             if (link) {
@@ -553,6 +569,9 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
             let raw = ceil(CGFloat(truncating: value))
             lastReportedDocumentHeight = raw
             heightDidChange?(raw * webView.pageZoom)
+        case "pointerPosition":
+            guard let value = dict["value"] as? NSNumber else { return }
+            pointerDocumentYDidChange?(CGFloat(truncating: value))
         case "linkContextMenu":
             guard let raw = dict["url"] as? String, let url = URL(string: raw) else { return }
             showLinkContextMenu(url)


### PR DESCRIPTION
Adds an off-by-default General setting that highlights the section under the pointer and retains the last pointed-at section. Outline clicks still take priority until the pointer moves over content again. Pointer reporting is disabled when the preference is off and bounded to one message per animation frame when enabled.

Related to #291. This PR handles one request and intentionally does not close the umbrella issue.

Stack 6/6 for #291. Based on https://github.com/pluk-inc/markdown-preview/pull/357; merge in stack order.

Validation: Debug app/Quick Look build passed with CODE_SIGNING_ALLOWED=NO. The combined stack helper suite passed: 261 tests, one skipped, zero failures.

Runtime verification of the final pointer-reporting guard: enabled the preference in the running app, moved into Child section 5 and verified its outline row became selected, then left the content and verified the selection stayed. Disabled the preference and moved over the same paragraph: the outline remained on the scroll-selected Child heading. Restored the preference off.
