### PR TITLE
Add initial German localization for review

### DIFF
--- a/docs/german-localization-review.md
+++ b/docs/german-localization-review.md
@@ -1,0 +1,26 @@
+# German localization review
+
+This is an AI-assisted first translation for issue #351, pending review by a fluent German speaker. Language feedback is welcome directly on the PR; no development experience is required.
+
+## Where to suggest changes
+
+- `md-preview/de.lproj/Localizable.strings`: settings, toolbar labels, dialogs, inspector, and preview controls. The left side is the English lookup key; suggest changes to the German text on the right.
+- `md-preview/de.lproj/MainMenu.strings`: menu titles. Suggest changes to the text inside `<string>…</string>`; keep the preceding identifier unchanged.
+
+Keep placeholders such as `%@` and `%d`, and escaped line breaks (`\n`) intact. Product names, font names, command names, and URL examples are intentionally preserved. The initial translation uses formal “Sie” in dialogs, “Sichern” for saving, and “Schnellvorschau” for Quick Look.
+
+## Check in the app
+
+Use a build from this branch. In Xcode, edit the **md-preview** scheme, then select **Run → Options → App Language → German** and run it. Alternatively, set German for Markdown Preview in macOS **System Settings → General → Language & Region → Applications**, then relaunch that build.
+
+Please check:
+
+- Menus, toolbar labels and tooltips, search, and the document information sidebar.
+- All settings tabs, theme customization, and the longer privacy explanations.
+- Save/discard dialogs using a disposable document, export, and print options.
+- Table editing, code-copy controls, and Mermaid diagram controls.
+- Narrow windows and larger text sizes for clipped labels or awkward wrapping.
+
+Quick Look runs separately from the app. An app-only language override does not establish that Finder's Quick Look preview is German; testing that requires the extension from this build to be registered and the preview process to use German.
+
+Please flag wording that sounds unnatural, inconsistent terms, remaining English UI, and any layout problems. A screenshot plus the preferred wording is enough. This initial PR does not close #351; fluent-speaker review is still needed before treating German as validated.

--- a/md-preview.xcodeproj/project.pbxproj
+++ b/md-preview.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		9AF000000000000000000109 /* Highlight-LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "Highlight-LICENSE.txt"; path = "md-preview/Vendor/Highlight/Highlight-LICENSE.txt"; sourceTree = "<group>"; };
 		9AF00000000000000000010A /* purify.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = purify.min.js; path = "md-preview/Vendor/DOMPurify/purify.min.js"; sourceTree = "<group>"; };
 		9AF00000000000000000010B /* DOMPurify-LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = "DOMPurify-LICENSE.txt"; path = "md-preview/Vendor/DOMPurify/DOMPurify-LICENSE.txt"; sourceTree = "<group>"; };
+		9A2040010000000000000005 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = "md-preview/de.lproj/Localizable.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -289,6 +290,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				de,
 				en,
 				Base,
 				"zh-Hans",
@@ -394,6 +396,7 @@
 			children = (
 				9A2040010000000000000002 /* en */,
 				9A2040010000000000000003 /* zh-Hans */,
+				9A2040010000000000000005 /* de */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/md-preview/de.lproj/Localizable.strings
+++ b/md-preview/de.lproj/Localizable.strings
@@ -1,0 +1,345 @@
+/* App menu */
+"Install CLI..." = "CLI installieren …";
+"Settings…" = "Einstellungen …";
+
+/* Settings */
+"General" = "Allgemein";
+"Privacy" = "Datenschutz";
+"About" = "Über";
+"Appearance also applies to Quick Look previews." = "Das Erscheinungsbild gilt auch für die Schnellvorschau.";
+"Layout" = "Layout";
+"Text size" = "Textgröße";
+"Size of rendered Markdown in document windows." = "Größe des dargestellten Markdown-Texts in Dokumentfenstern.";
+"Small" = "Klein";
+"Medium" = "Mittel";
+"Large" = "Groß";
+"Content width" = "Inhaltsbreite";
+"Zooming a document window with ⌘+ and ⌘− changes this same size." = "Das Zoomen eines Dokumentfensters mit ⌘+ und ⌘− ändert ebenfalls diese Größe.";
+"Editing" = "Bearbeiten";
+"Automatic saving" = "Automatisches Sichern";
+"Save edited documents periodically." = "Bearbeitete Dokumente regelmäßig sichern.";
+"Automatic saving runs while a document has unsaved edits." = "Dokumente mit ungesicherten Änderungen werden automatisch gesichert.";
+"30 seconds" = "30 Sekunden";
+"1 minute" = "1 Minute";
+"%d minutes" = "%d Minuten";
+"Hand-off" = "Übergabe";
+"Open documents in" = "Dokumente öffnen in";
+"AI apps" = "KI-Apps";
+"The app the Open button in the document toolbar uses first. Its menu still offers every other installed app." = "Die App, die über die Taste „Öffnen“ in der Symbolleiste standardmäßig verwendet wird. Im Menü stehen weiterhin alle anderen installierten Apps zur Verfügung.";
+"Command line tools" = "Befehlszeilenwerkzeuge";
+"Install…" = "Installieren …";
+"Adds mdp, md-preview, and markdown-preview to your PATH. Run it again after updating the app to refresh the commands." = "Fügt mdp, md-preview und markdown-preview zu PATH hinzu. Nach einem App-Update erneut ausführen, um die Befehle zu aktualisieren.";
+"Markdown Preview" = "Markdown Preview";
+"Version %@ (%@)" = "Version %@ (%@)";
+"Check for Updates" = "Nach Updates suchen";
+"Automatically check for updates" = "Automatisch nach Updates suchen";
+"Automatically download updates" = "Updates automatisch laden";
+"Last checked" = "Zuletzt geprüft";
+"Never" = "Nie";
+"Downloaded updates install the next time you quit Markdown Preview." = "Geladene Updates werden beim nächsten Beenden von Markdown Preview installiert.";
+"Colors" = "Farben";
+"Window background" = "Fensterhintergrund";
+"Editor background" = "Editorhintergrund";
+"Code block background" = "Hintergrund von Codeblöcken";
+"Text" = "Text";
+"Link" = "Link";
+"Presets" = "Vorlagen";
+"Colors apply to the current appearance. Choose the Automatic appearance to set Light and Dark separately." = "Die Farben gelten für das aktuelle Erscheinungsbild. „Automatisch“ auswählen, um Hell und Dunkel getrennt einzustellen.";
+"A preset fills every color and switches the app to its light or dark look. Adjust individual colors below afterwards." = "Eine Vorlage legt alle Farben fest und wechselt zum hellen oder dunklen Erscheinungsbild. Einzelne Farben können anschließend unten angepasst werden.";
+"Red Graphite" = "Roter Graphit";
+"Dark Graphite" = "Dunkler Graphit";
+"Normal" = "Normal";
+"Charcoal" = "Anthrazit";
+"Solarized Light" = "Solarized Light";
+"Solarized Dark" = "Solarized Dark";
+"Dracula" = "Dracula";
+"Each color has a separate value for the Light and Dark appearance. Picking the default color removes the override." = "Jede Farbe hat einen eigenen Wert für das helle und dunkle Erscheinungsbild. Die Auswahl der Standardfarbe hebt die Anpassung auf.";
+"Custom colors" = "Eigene Farben";
+"Reset Colors" = "Farben zurücksetzen";
+"Restores the default Normal theme." = "Stellt das Standarddesign „Normal“ wieder her.";
+"Current theme: %@" = "Aktuelles Design: %@";
+"Send anonymous crash reports" = "Anonyme Absturzberichte senden";
+"Crash reports contain diagnostic details such as stack traces and OS and app versions. They may include technical file paths; Markdown Preview does not deliberately attach document contents or personal information." = "Absturzberichte enthalten Diagnosedaten wie Stacktraces sowie Betriebssystem- und App-Versionen. Sie können technische Dateipfade enthalten. Markdown Preview fügt keine Dokumentinhalte oder persönlichen Informationen gezielt hinzu.";
+"Share anonymous usage analytics" = "Anonyme Nutzungsdaten teilen";
+"When enabled, Markdown Preview sends at most one event per day when the app becomes active, linked to a random installation identifier. It also sends the app version, macOS major version, processor architecture, and locale country or region. This is used only to count daily and monthly active installations and understand basic platform compatibility. It does not send document contents, file names or paths, actions, screens, precise location, personal information, or advertising identifiers." = "Wenn diese Option aktiviert ist, sendet Markdown Preview beim Aktivieren der App höchstens ein Ereignis pro Tag, das mit einer zufälligen Installationskennung verknüpft ist. Außerdem werden die App-Version, die macOS-Hauptversion, die Prozessorarchitektur und das Land oder die Region der Gebietseinstellung übermittelt. Diese Daten dienen ausschließlich dazu, täglich und monatlich aktive Installationen zu zählen und die grundlegende Plattformkompatibilität einzuschätzen. Dokumentinhalte, Dateinamen oder -pfade, Aktionen, Bildschirminhalte, genaue Standortdaten, persönliche Informationen und Werbekennungen werden nicht übermittelt.";
+
+/* View menu */
+"Appearance" = "Erscheinungsbild";
+"Automatic" = "Automatisch";
+"Light" = "Hell";
+"Dark" = "Dunkel";
+"Content Width" = "Inhaltsbreite";
+"Normal" = "Normal";
+"Full Width" = "Volle Breite";
+"Toggle Sidebar" = "Seitenleiste ein-/ausblenden";
+"Hide Sidebar" = "Seitenleiste ausblenden";
+"Table of Contents" = "Inhaltsverzeichnis";
+"Project Navigator" = "Projektnavigator";
+"Toggle Edit Mode" = "Bearbeitungsmodus ein-/ausschalten";
+
+/* File menu */
+"New Tab" = "Neuer Tab";
+"Choose a name and location for the new Markdown file." = "Namen und Speicherort für die neue Markdown-Datei auswählen.";
+
+/* Print panel */
+"Font Size:" = "Schriftgröße:";
+"Font Size" = "Schriftgröße";
+"%d pt" = "%d pt";
+"pt" = "pt";
+
+/* Export panel */
+"Export" = "Exportieren";
+"Format:" = "Format:";
+"PDF Document" = "PDF-Dokument";
+"HTML Document" = "HTML-Dokument";
+
+/* Go menu */
+"Go" = "Gehe zu";
+"Up" = "Nach oben";
+"Down" = "Nach unten";
+"Page Up" = "Eine Seite nach oben";
+"Page Down" = "Eine Seite nach unten";
+"Previous Item" = "Vorheriges Element";
+"Next Item" = "Nächstes Element";
+"Top of Document" = "Dokumentanfang";
+"Bottom of Document" = "Dokumentende";
+
+/* Format menu */
+"Format" = "Format";
+"Body" = "Fließtext";
+"Heading 1" = "Überschrift 1";
+"Heading 2" = "Überschrift 2";
+"Heading 3" = "Überschrift 3";
+"Bold" = "Fett";
+"Italic" = "Kursiv";
+"Strikethrough" = "Durchgestrichen";
+"Inline Code" = "Inline-Code";
+"Link" = "Link";
+"Bulleted List" = "Aufzählung";
+"Numbered List" = "Nummerierte Liste";
+"Checklist" = "Checkliste";
+"Block Quote" = "Zitatblock";
+
+/* Open panel */
+"Choose a Markdown file or folder" = "Markdown-Datei oder Ordner auswählen";
+
+/* Search toolbar */
+"Search" = "Suchen";
+"Search in Document" = "Im Dokument suchen";
+
+/* Main toolbar */
+"Navigation" = "Navigation";
+"Back and Forward" = "Zurück und vorwärts";
+"Back" = "Zurück";
+"Forward" = "Vorwärts";
+"Sidebar" = "Seitenleiste";
+"Sidebar options" = "Seitenleistenoptionen";
+"Inspector" = "Informationsbereich";
+"Get Info" = "Informationen";
+"Always on Top" = "Immer im Vordergrund";
+"Keep Markdown Preview windows in front of other apps" = "Fenster von Markdown Preview vor anderen Apps anzeigen";
+"Show the inspector" = "Informationsbereich anzeigen";
+"Share" = "Teilen";
+"Share document" = "Dokument teilen";
+"Print" = "Drucken";
+"Print document" = "Dokument drucken";
+"Copy" = "Kopieren";
+"Copy Markdown source to clipboard" = "Markdown-Quelltext in die Zwischenablage kopieren";
+"Copied" = "Kopiert";
+"Edit" = "Bearbeiten";
+"Edit document" = "Dokument bearbeiten";
+"Stop editing and return to preview" = "Bearbeiten beenden und zur Vorschau zurückkehren";
+"Open" = "Öffnen";
+"Open document in another app" = "Dokument in einer anderen App öffnen";
+"Open in %@" = "In %@ öffnen";
+"Open in LLM" = "In LLM-App öffnen";
+"Open document in an LLM app" = "Dokument in einer LLM-App öffnen";
+"Zoom" = "Zoom";
+"Zoom Out" = "Verkleinern";
+"Zoom In" = "Vergrößern";
+"Open With" = "Öffnen mit";
+"Open in another editor" = "In einem anderen Editor öffnen";
+
+/* Formatting toolbar */
+"Task List" = "Aufgabenliste";
+"Normal Text" = "Normaler Text";
+"Heading %d" = "Überschrift %d";
+
+/* Find bar */
+"Match:" = "Übereinstimmung:";
+"Contains" = "Enthält";
+"Begins With" = "Beginnt mit";
+"Done" = "Fertig";
+"Not found" = "Nicht gefunden";
+"%d of %d" = "%d von %d";
+"Previous match" = "Vorheriger Treffer";
+"Next match" = "Nächster Treffer";
+
+/* Open With context menu */
+"Open with External Editor" = "Mit externem Editor öffnen";
+"Open As" = "Öffnen als";
+"No editors available" = "Keine Editoren verfügbar";
+
+/* Inspector */
+"Inspector tab" = "Tab im Informationsbereich";
+"Document" = "Dokument";
+"Properties" = "Eigenschaften";
+"File Name" = "Dateiname";
+"Full Path" = "Vollständiger Pfad";
+"Document Type" = "Dokumenttyp";
+"Markdown Document" = "Markdown-Dokument";
+"File Size" = "Dateigröße";
+"Words" = "Wörter";
+"Characters" = "Zeichen";
+"Lines" = "Zeilen";
+"Headings" = "Überschriften";
+"Links" = "Links";
+"Images" = "Bilder";
+"Modified" = "Geändert";
+"No frontmatter" = "Keine Frontmatter-Metadaten";
+"Untitled" = "Ohne Titel";
+
+/* Document state and save dialogs */
+"Edited" = "Bearbeitet";
+"Auto-save failed" = "Automatisches Sichern fehlgeschlagen";
+"Do you want to save your changes?" = "Möchten Sie Ihre Änderungen sichern?";
+"this document" = "dieses Dokument";
+"Your changes to %@ will be lost if you don’t save them." = "Ihre Änderungen an „%@“ gehen verloren, wenn Sie sie nicht sichern.";
+"Save" = "Sichern";
+"Cancel" = "Abbrechen";
+"Don’t Save" = "Nicht sichern";
+"The file was removed while it was open." = "Die Datei wurde entfernt, während sie geöffnet war.";
+"Recreate File" = "Datei erneut erstellen";
+"The file could not be read to verify that it is unchanged." = "Die Datei konnte nicht gelesen werden, um zu prüfen, ob sie unverändert ist.";
+"Save Anyway" = "Trotzdem sichern";
+"This document changed on disk" = "Dieses Dokument wurde auf dem Datenträger geändert";
+"Another app changed %@. Cancel keeps your changes unsaved. Choose which version to keep." = "Eine andere App hat „%@“ geändert. Mit „Abbrechen“ bleiben Ihre Änderungen ungesichert erhalten. Wählen Sie die Version aus, die Sie behalten möchten.";
+"Keep My Changes" = "Meine Änderungen behalten";
+"Reload from Disk" = "Vom Datenträger neu laden";
+"Unable to verify the document on disk" = "Das Dokument auf dem Datenträger konnte nicht geprüft werden";
+"%@ Cancel keeps your changes unsaved." = "%@ Mit „Abbrechen“ bleiben Ihre Änderungen ungesichert erhalten.";
+"Markdown Preview needs your permission to save this file." = "Markdown Preview benötigt Ihre Erlaubnis, um diese Datei zu sichern.";
+"The clipboard does not contain an image." = "Die Zwischenablage enthält kein Bild.";
+"The pasted image could not be placed next to the Markdown file." = "Das eingefügte Bild konnte nicht im selben Ordner wie die Markdown-Datei abgelegt werden.";
+"Choose the folder containing this Markdown file to save the pasted image." = "Wählen Sie den Ordner dieser Markdown-Datei aus, um das eingefügte Bild zu sichern.";
+"Choose the folder containing this Markdown file." = "Wählen Sie den Ordner aus, der diese Markdown-Datei enthält.";
+"Rename Image" = "Bild umbenennen";
+"Choose a new name for this image." = "Wählen Sie einen neuen Namen für dieses Bild.";
+"Rename" = "Umbenennen";
+
+/* Open menus */
+"No document open" = "Kein Dokument geöffnet";
+"No apps available" = "Keine Apps verfügbar";
+"Editors" = "Editoren";
+"AI Apps" = "KI-Apps";
+"No LLM apps available" = "Keine LLM-Apps verfügbar";
+"Open in LLM…" = "In LLM-App öffnen …";
+"Open with…" = "Öffnen mit …";
+
+/* Project navigator context menu */
+"Show in Finder" = "Im Finder anzeigen";
+"Open in New Tab" = "In neuem Tab öffnen";
+"Open in New Window" = "In neuem Fenster öffnen";
+"Copy Path" = "Pfad kopieren";
+
+/* Table editing */
+"Table" = "Tabelle";
+"Row" = "Zeile";
+"Column" = "Spalte";
+"Select Row" = "Zeile auswählen";
+"Add Row Above" = "Zeile darüber einfügen";
+"Add Row Below" = "Zeile darunter einfügen";
+"Duplicate Row" = "Zeile duplizieren";
+"Delete Row" = "Zeile löschen";
+"Select Column" = "Spalte auswählen";
+"Add Column Left" = "Spalte links einfügen";
+"Add Column Right" = "Spalte rechts einfügen";
+"Delete Column" = "Spalte löschen";
+"Edit Table Cell" = "Tabellenzelle bearbeiten";
+"Add Row" = "Zeile hinzufügen";
+"Add Column" = "Spalte hinzufügen";
+"Edit Table" = "Tabelle bearbeiten";
+
+/* Rendered preview controls */
+"Heading" = "Überschrift";
+"Copy code" = "Code kopieren";
+"Code copied" = "Code kopiert";
+"Mermaid diagram" = "Mermaid-Diagramm";
+"%@ — Mermaid diagram" = "%@ — Mermaid-Diagramm";
+"Reset zoom" = "Zoom zurücksetzen";
+"Fill width" = "Breite ausfüllen";
+"Fit diagram" = "Diagramm einpassen";
+"Open in Window" = "In Fenster öffnen";
+"Mermaid renderer is unavailable.\n\n" = "Der Mermaid-Renderer ist nicht verfügbar.\n\n";
+"Footnote %d" = "Fußnote %d";
+"Back to reference %d" = "Zurück zu Verweis %d";
+"KaTeX renderer is unavailable.\n\n" = "Der KaTeX-Renderer ist nicht verfügbar.\n\n";
+
+/* URL scheme errors */
+"Cannot open link" = "Link kann nicht geöffnet werden";
+"“%@” is not a link Markdown Preview understands. Use md-preview://file/ followed by the absolute path of the file, for example md-preview://file/Users/me/notes/README.md." = "„%@“ ist kein von Markdown Preview unterstützter Link. Verwenden Sie md-preview://file/ gefolgt vom absoluten Dateipfad, zum Beispiel md-preview://file/Users/me/notes/README.md.";
+
+/* CLI installer errors */
+"Terminal automation failed: %@" = "Terminal-Automatisierung fehlgeschlagen: %@";
+"Terminal automation failed." = "Terminal-Automatisierung fehlgeschlagen.";
+"Failed to write CLI installer script: %@" = "Das CLI-Installationsskript konnte nicht geschrieben werden: %@";
+"The bundled Markdown Preview CLI could not be found." = "Das mitgelieferte Befehlszeilenwerkzeug von Markdown Preview wurde nicht gefunden.";
+
+/* Settings — Reading */
+"Reading" = "Lesen";
+"Font" = "Schrift";
+"System" = "System";
+"Serif" = "Mit Serifen";
+"Rounded" = "Abgerundet";
+"Monospace" = "Nichtproportional";
+"The font also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes the text size." = "Die Schrift gilt auch für die Schnellvorschau. Das Zoomen eines Dokumentfensters mit ⌘+ und ⌘− ändert die Textgröße.";
+
+/* Settings — Windows */
+"Windows" = "Fenster";
+"Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out." = "Zeigt alle Fenster von Markdown Preview vor anderen Apps an, auch später geöffnete Fenster. Für Fenster im Vollbildmodus gilt dies erst nach dem Verlassen des Vollbildmodus.";
+"Open documents in tabs" = "Dokumente in Tabs öffnen";
+"A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window." = "Eine im Finder geöffnete Datei wird als Tab im vordersten Fenster geöffnet. „In neuem Fenster öffnen“ öffnet weiterhin ein eigenes Fenster.";
+
+/* Appearance and navigation settings */
+"A theme fills every color, picks a reading face, and switches the app to its light or dark look." = "Ein Design legt alle Farben und die Leseschrift fest und wechselt zum hellen oder dunklen Erscheinungsbild.";
+"Accessibility & Layout Options" = "Bedienungshilfen und Layoutoptionen";
+"Appearance: %@" = "Erscheinungsbild: %@";
+"Athelas" = "Athelas";
+"Avenir Next" = "Avenir Next";
+"Bold Text" = "Fetter Text";
+"Character Spacing" = "Zeichenabstand";
+"Charter" = "Charter";
+"Clicking a link to another Markdown file opens it in a separate window. Turn this off to open it in the current window." = "Ein Link zu einer anderen Markdown-Datei öffnet diese in einem eigenen Fenster. Deaktivieren Sie diese Option, um sie im aktuellen Fenster zu öffnen.";
+"Customize" = "Anpassen";
+"Customize Theme" = "Design anpassen";
+"Customize…" = "Anpassen …";
+"Fonts, spacing and colors" = "Schriften, Abstände und Farben";
+"Georgia" = "Georgia";
+"GitHub Project" = "GitHub-Projekt";
+"Highlight outline section under the pointer" = "Abschnitt unter dem Mauszeiger im Inhaltsverzeichnis hervorheben";
+"Iowan" = "Iowan";
+"Line Spacing" = "Zeilenabstand";
+"Margins" = "Ränder";
+"New York" = "New York";
+"Open Markdown links in new windows" = "Markdown-Links in neuen Fenstern öffnen";
+"Original" = "Original";
+"Palatino" = "Palatino";
+"Reset Theme" = "Design zurücksetzen";
+"SF Rounded" = "SF Rounded";
+"Seravek" = "Seravek";
+"Text size also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes it too. Fonts and reading layout live in Appearance settings." = "Die Textgröße gilt auch für die Schnellvorschau. Das Zoomen eines Dokumentfensters mit ⌘+ und ⌘− ändert sie ebenfalls. Schrift und Leselayout lassen sich unter „Erscheinungsbild“ einstellen.";
+"Text size, appearance, and themes" = "Textgröße, Erscheinungsbild und Designs";
+"The same panel the toolbar's Themes & Settings button opens, with a Reset for the whole look." = "Öffnet denselben Bereich wie „Designs und Einstellungen“ in der Symbolleiste. Das gesamte Erscheinungsbild kann dort zurückgesetzt werden.";
+"Themes" = "Designs";
+"Themes & Settings" = "Designs und Einstellungen";
+"Times New Roman" = "Times New Roman";
+"Word Spacing" = "Wortabstand";
+
+/* Theme names */
+"Quiet" = "Ruhe";
+"Paper" = "Papier";
+"Calm" = "Gelassenheit";
+"Focus" = "Fokus";
+"Graphite" = "Graphit";
+"Dusk" = "Dämmerung";
+"Midnight" = "Mitternacht";

--- a/md-preview/de.lproj/MainMenu.strings
+++ b/md-preview/de.lproj/MainMenu.strings
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>1UK-8n-QPP.title</key>
+	<string>Symbolleiste anpassen …</string>
+	<key>1Xt-HY-uBw.title</key>
+	<string>Markdown Preview</string>
+	<key>1b7-l0-nxx.title</key>
+	<string>Suchen</string>
+	<key>2oI-Rn-ZJC.title</key>
+	<string>Transformationen</string>
+	<key>3IN-sU-3Bg.title</key>
+	<string>Rechtschreibung</string>
+	<key>3rS-ZA-NoH.title</key>
+	<string>Sprachausgabe</string>
+	<key>4EN-yA-p0u.title</key>
+	<string>Suchen</string>
+	<key>4J7-dP-txa.title</key>
+	<string>Vollbildmodus ein</string>
+	<key>4sb-4s-VLi.title</key>
+	<string>Markdown Preview beenden</string>
+	<key>5QF-Oa-p0T.title</key>
+	<string>Bearbeiten</string>
+	<key>5kV-Vb-QxS.title</key>
+	<string>Über Markdown Preview</string>
+	<key>6dh-zS-Vam.title</key>
+	<string>Wiederholen</string>
+	<key>78Y-hA-62v.title</key>
+	<string>Rechtschreibung automatisch korrigieren</string>
+	<key>9ic-FL-obx.title</key>
+	<string>Ersetzungen</string>
+	<key>9yt-4B-nSM.title</key>
+	<string>Intelligentes Kopieren und Einsetzen</string>
+	<key>AYu-sK-qS6.title</key>
+	<string>Hauptmenü</string>
+	<key>BOF-NM-1cW.title</key>
+	<string>Anonyme Absturzberichte senden</string>
+	<key>Bw7-FT-i3A.title</key>
+	<string>Sichern unter …</string>
+	<key>DVo-aG-piG.title</key>
+	<string>Schließen</string>
+	<key>Dv1-io-Yv7.title</key>
+	<string>Rechtschreibung und Grammatik</string>
+	<key>Ex0-fm-F00.title</key>
+	<string>Exportieren …</string>
+	<key>Ex1-pd-F01.title</key>
+	<string>Als PDF exportieren …</string>
+	<key>F2S-fz-NVQ.title</key>
+	<string>Hilfe</string>
+	<key>FKE-Sm-Kum.title</key>
+	<string>Markdown Preview-Hilfe</string>
+	<key>FeM-D8-WVr.title</key>
+	<string>Ersetzungen</string>
+	<key>H8h-7b-M4v.title</key>
+	<string>Darstellung</string>
+	<key>HFQ-gK-NFA.title</key>
+	<string>Textersetzung</string>
+	<key>HFo-cy-zxI.title</key>
+	<string>Rechtschreibung und Grammatik anzeigen</string>
+	<key>HyV-fh-RgO.title</key>
+	<string>Darstellung</string>
+	<key>IAo-SY-fd9.title</key>
+	<string>Öffnen …</string>
+	<key>KaW-ft-85H.title</key>
+	<string>Zurück zur letzten Version</string>
+	<key>Kd2-mp-pUS.title</key>
+	<string>Alle einblenden</string>
+	<key>LE2-aR-0XJ.title</key>
+	<string>Alle nach vorne bringen</string>
+	<key>NMo-om-nkz.title</key>
+	<string>Dienste</string>
+	<key>OY7-WF-poV.title</key>
+	<string>Im Dock ablegen</string>
+	<key>Olw-nP-bQN.title</key>
+	<string>Markdown Preview ausblenden</string>
+	<key>OwM-mh-QMV.title</key>
+	<string>Vorheriges suchen</string>
+	<key>Oyz-dy-DGm.title</key>
+	<string>Sprachausgabe stoppen</string>
+	<key>R4o-n2-Eq4.title</key>
+	<string>Zoom</string>
+	<key>Ruw-6m-B2m.title</key>
+	<string>Alles auswählen</string>
+	<key>S0p-oC-mLd.title</key>
+	<string>Auswahl anzeigen</string>
+	<key>Td7-aD-5lo.title</key>
+	<string>Fenster</string>
+	<key>UEZ-Bs-lqG.title</key>
+	<string>Wortanfänge großschreiben</string>
+	<key>Vdr-fp-XzO.title</key>
+	<string>Andere ausblenden</string>
+	<key>W48-6f-4Dl.title</key>
+	<string>Bearbeiten</string>
+	<key>Was-JA-tGl.title</key>
+	<string>Neu</string>
+	<key>WeT-3V-zwk.title</key>
+	<string>Einsetzen und Stil anpassen</string>
+	<key>Xz5-n4-O0W.title</key>
+	<string>Suchen …</string>
+	<key>YEy-JH-Tfz.title</key>
+	<string>Suchen und Ersetzen …</string>
+	<key>Ynk-f8-cLZ.title</key>
+	<string>Sprachausgabe starten</string>
+	<key>aTl-1u-JFS.title</key>
+	<string>Drucken …</string>
+	<key>aUF-d1-5bR.title</key>
+	<string>Fenster</string>
+	<key>bib-Uj-vzu.title</key>
+	<string>Ablage</string>
+	<key>buJ-ug-pKt.title</key>
+	<string>Auswahl suchen</string>
+	<key>c8a-y6-VQd.title</key>
+	<string>Transformationen</string>
+	<key>cwL-P1-jid.title</key>
+	<string>Intelligente Links</string>
+	<key>d9M-CD-aMd.title</key>
+	<string>Kleinschreibung</string>
+	<key>dMs-cI-mzQ.title</key>
+	<string>Ablage</string>
+	<key>dRJ-4n-Yzg.title</key>
+	<string>Widerrufen</string>
+	<key>gVA-U4-sdL.title</key>
+	<string>Einsetzen</string>
+	<key>hQb-2v-fYv.title</key>
+	<string>Typografische Anführungszeichen</string>
+	<key>hz2-CU-CR7.title</key>
+	<string>Dokument jetzt prüfen</string>
+	<key>hz9-B4-Xy5.title</key>
+	<string>Dienste</string>
+	<key>kIP-vf-haE.title</key>
+	<string>Seitenleiste einblenden</string>
+	<key>mK6-2p-4JG.title</key>
+	<string>Grammatik zusammen mit Rechtschreibung prüfen</string>
+	<key>mdp-aot-itm.title</key>
+	<string>Immer im Vordergrund</string>
+	<key>mdp-zi-itm.title</key>
+	<string>Vergrößern</string>
+	<key>mdp-zo-itm.title</key>
+	<string>Verkleinern</string>
+	<key>mdp-zr-itm.title</key>
+	<string>Originalgröße</string>
+	<key>oas-Oc-fiZ.title</key>
+	<string>Benutzte Dokumente</string>
+	<key>pa3-QI-u2k.title</key>
+	<string>Löschen</string>
+	<key>pxx-59-PXV.title</key>
+	<string>Sichern …</string>
+	<key>q09-fT-Sye.title</key>
+	<string>Nächstes suchen</string>
+	<key>rbD-Rh-wIN.title</key>
+	<string>Rechtschreibung während der Texteingabe prüfen</string>
+	<key>rgM-f4-ycn.title</key>
+	<string>Intelligente Bindestriche</string>
+	<key>snW-S8-Cw5.title</key>
+	<string>Symbolleiste einblenden</string>
+	<key>spk-cu-itm.title</key>
+	<string>Nach Updates suchen …</string>
+	<key>tRr-pd-1PS.title</key>
+	<string>Datenerkennung</string>
+	<key>tXI-mr-wws.title</key>
+	<string>Benutzte Dokumente</string>
+	<key>uQy-DD-JDr.title</key>
+	<string>Markdown Preview</string>
+	<key>uRl-iY-unG.title</key>
+	<string>Ausschneiden</string>
+	<key>vNY-rz-j42.title</key>
+	<string>Einträge löschen</string>
+	<key>vmV-6d-7jI.title</key>
+	<string>Großschreibung</string>
+	<key>wpr-3q-Mcd.title</key>
+	<string>Hilfe</string>
+	<key>x3v-GG-iWU.title</key>
+	<string>Kopieren</string>
+	<key>xrE-MZ-jX0.title</key>
+	<string>Sprachausgabe</string>
+	<key>z6F-FW-3nz.title</key>
+	<string>Ersetzungen anzeigen</string>
+</dict>
+</plist>

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -299,3 +299,47 @@
 "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out." = "Keeps every Markdown Preview window in front of other apps, including windows you open later. A window in full screen is left alone until it comes back out.";
 "Open documents in tabs" = "Open documents in tabs";
 "A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window." = "A file opened from Finder joins the front window as a tab instead of getting one of its own — Open in New Window still opens a window.";
+
+/* Appearance and navigation settings */
+"A theme fills every color, picks a reading face, and switches the app to its light or dark look." = "A theme fills every color, picks a reading face, and switches the app to its light or dark look.";
+"Accessibility & Layout Options" = "Accessibility & Layout Options";
+"Appearance: %@" = "Appearance: %@";
+"Athelas" = "Athelas";
+"Avenir Next" = "Avenir Next";
+"Bold Text" = "Bold Text";
+"Character Spacing" = "Character Spacing";
+"Charter" = "Charter";
+"Clicking a link to another Markdown file opens it in a separate window. Turn this off to open it in the current window." = "Clicking a link to another Markdown file opens it in a separate window. Turn this off to open it in the current window.";
+"Customize" = "Customize";
+"Customize Theme" = "Customize Theme";
+"Customize…" = "Customize…";
+"Fonts, spacing and colors" = "Fonts, spacing and colors";
+"Georgia" = "Georgia";
+"GitHub Project" = "GitHub Project";
+"Highlight outline section under the pointer" = "Highlight outline section under the pointer";
+"Iowan" = "Iowan";
+"Line Spacing" = "Line Spacing";
+"Margins" = "Margins";
+"New York" = "New York";
+"Open Markdown links in new windows" = "Open Markdown links in new windows";
+"Original" = "Original";
+"Palatino" = "Palatino";
+"Reset Theme" = "Reset Theme";
+"SF Rounded" = "SF Rounded";
+"Seravek" = "Seravek";
+"Text size also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes it too. Fonts and reading layout live in Appearance settings." = "Text size also applies to Quick Look previews. Zooming a document window with ⌘+ and ⌘− changes it too. Fonts and reading layout live in Appearance settings.";
+"Text size, appearance, and themes" = "Text size, appearance, and themes";
+"The same panel the toolbar's Themes & Settings button opens, with a Reset for the whole look." = "The same panel the toolbar's Themes & Settings button opens, with a Reset for the whole look.";
+"Themes" = "Themes";
+"Themes & Settings" = "Themes & Settings";
+"Times New Roman" = "Times New Roman";
+"Word Spacing" = "Word Spacing";
+
+/* Theme names */
+"Quiet" = "Quiet";
+"Paper" = "Paper";
+"Calm" = "Calm";
+"Focus" = "Focus";
+"Graphite" = "Graphite";
+"Dusk" = "Dusk";
+"Midnight" = "Midnight";


### PR DESCRIPTION
Adds an initial AI-assisted German translation for #351 so @mickimnet can review the wording and suggest improvements. This is a starting point for fluent-speaker review; #351 remains open.

- Translates 292 app strings and 87 menu entries, including settings, dialogs, toolbar, inspector, editing, and preview controls.
- Registers German and includes the shared translations in Quick Look. Adds 40 existing runtime strings missing from the English catalog, including recent appearance and navigation settings and theme names.
- Adds [review instructions](docs/german-localization-review.md) with the files to comment on, how to run the app in German, and suggested wording/layout checks.

@mickimnet: suggestions on natural wording and consistent macOS terminology are welcome directly on the German string files. You can also leave a comment with the current wording and your preferred alternative. The initial pass uses formal “Sie”, “Sichern” for save, and “Schnellvorschau” for Quick Look.

Validation: Debug build succeeded with signing disabled; English/German key parity, formatting placeholders, line breaks, and packaged app/Quick Look translations verified. Launched the exact built app in German and checked menus, toolbar, General, Appearance, and Privacy settings; the longer privacy text fits the settings window. Finder Quick Look rendering and exhaustive layout checks remain for follow-up review.
