### PR TITLE
Fix Tahoe fullscreen search and formatting bar backgrounds

### DIFF
--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -559,16 +559,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// Sequoia rows use the native titlebar material with unthemed controls.
     /// Newer systems provide their backdrop through native chrome.
     final class EditAccessoryContainerView: NSView {
+        private var fullscreenBackdrop: NSVisualEffectView?
+
         func updateFullscreenBackground() {
             guard #available(macOS 26.0, *) else { return }
             guard #unavailable(macOS 27.0) else { return }
             if window?.styleMask.contains(.fullScreen) == true {
-                wantsLayer = true
-                effectiveAppearance.performAsCurrentDrawingAppearance {
-                    layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+                if fullscreenBackdrop == nil {
+                    let backdrop = NSVisualEffectView(frame: bounds)
+                    backdrop.material = .titlebar
+                    backdrop.blendingMode = .withinWindow
+                    backdrop.state = .followsWindowActiveState
+                    backdrop.autoresizingMask = [.width, .height]
+                    addSubview(backdrop, positioned: .below, relativeTo: subviews.first)
+                    fullscreenBackdrop = backdrop
                 }
+                fullscreenBackdrop?.isHidden = false
             } else {
-                layer?.backgroundColor = nil
+                fullscreenBackdrop?.isHidden = true
             }
         }
 

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -255,6 +255,8 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                 documentWindow.titlebarAppearsTransparent = true
             }
         }
+        (editBar as? EditAccessoryContainerView)?.updateFullscreenBackground()
+        (findBarOverlay as? EditAccessoryContainerView)?.updateFullscreenBackground()
     }
 
     /// AppKit's automatic tab placement runs when NSDocument shows its
@@ -557,6 +559,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// Sequoia rows use the native titlebar material with unthemed controls.
     /// Newer systems provide their backdrop through native chrome.
     final class EditAccessoryContainerView: NSView {
+        func updateFullscreenBackground() {
+            guard #available(macOS 26.0, *) else { return }
+            guard #unavailable(macOS 27.0) else { return }
+            if window?.styleMask.contains(.fullScreen) == true {
+                wantsLayer = true
+                effectiveAppearance.performAsCurrentDrawingAppearance {
+                    layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+                }
+            } else {
+                layer?.backgroundColor = nil
+            }
+        }
+
+        override func viewDidChangeEffectiveAppearance() {
+            super.viewDidChangeEffectiveAppearance()
+            updateFullscreenBackground()
+        }
+
         override init(frame frameRect: NSRect) {
             super.init(frame: frameRect)
             if #unavailable(macOS 26.0) {
@@ -582,6 +602,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         // cursor wins between the buttons until the bar is reinstalled.
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            updateFullscreenBackground()
             window?.invalidateCursorRects(for: self)
         }
 


### PR DESCRIPTION
On macOS 26, full-screen search could remain transparent in preview mode while the toolbar used a system background. Search and formatting rows now use the native AppKit titlebar material in full screen, providing a consistent surface in both modes.

The material follows window activation and appearance, and updates when entering/exiting full screen, installing a row, and changing appearance. It hides again in windowed mode. This is a follow-up to merged PR #362 and changes only the macOS 26 path; macOS 15 and 27 retain their existing behavior.

Validation: signed Debug app and Quick Look extension build passed, copied app signature verified, and full-screen row backgrounds plus restoration on exit were exercised locally on macOS 26.6.2. Existing accessory geometry and scroll-edge styles remain unchanged.
