### PR TITLE
Simplify application menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Build and run the `markdown-preview` scheme. Swift Package Manager will resolve 
 
 ### Crash reporting
 
-Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths. Users can turn reporting off directly from Markdown Preview > Send Anonymous Crash Reports; on later launches, the Sentry SDK will not initialize at all.
+Release builds submit native crash reports to the `pluk-inc/markdown-preview` Sentry project. The integration does not collect performance traces, session data, breadcrumbs, network requests, user information, document contents, or file paths. Users can turn reporting off in Markdown Preview > Settings > Privacy; on later launches, the Sentry SDK will not initialize at all.
 
 The committed DSN is a public client key. Release archives upload the app dSYM with `sentry-cli`; authenticate locally with `sentry-cli login` and keep that authentication token outside the repository.
 

--- a/md-preview/App/AppDelegate.swift
+++ b/md-preview/App/AppDelegate.swift
@@ -118,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         installGoMenu()
         installSettingsMenuItem()
         NSApp.windowsMenu?.delegate = self
-        installAppMenuItemIcons()
+        installAppMenuItems()
         installViewMenuItemIcons()
         hasFinishedLaunching = true
         if !didReceiveOpenURLsDuringLaunch {
@@ -265,12 +265,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         updaterController.updater.checkForUpdates()
     }
 
-    @IBAction func toggleCrashReporting(_ sender: NSMenuItem) {
-        CrashReporter.isEnabled.toggle()
-        SettingsModel.shared.refreshFromExternalSources()
-        sender.state = CrashReporter.isEnabled ? .on : .off
-    }
-
     // MARK: - Settings
 
     /// Inserted after About, where macOS puts Settings, since MainMenu.xib
@@ -288,18 +282,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                               keyEquivalent: ",")
         item.keyEquivalentModifierMask = [.command]
         item.target = self
-        if let image = NSImage(systemSymbolName: "gearshape",
-                               accessibilityDescription: item.title) {
-            image.isTemplate = true
-            item.image = image
-        }
-
         let aboutIndex = appMenu.items.firstIndex {
             $0.action == #selector(NSApplication.orderFrontStandardAboutPanel(_:))
         }
-        let insertIndex = aboutIndex.map { $0 + 1 } ?? 0
-        appMenu.insertItem(.separator(), at: insertIndex)
-        appMenu.insertItem(item, at: insertIndex + 1)
+        // MainMenu.xib already separates About from the settings and tools group.
+        let insertIndex = aboutIndex.map { $0 + 2 } ?? 0
+        appMenu.insertItem(item, at: insertIndex)
     }
 
     @objc func showSettingsWindow(_ sender: Any?) {
@@ -488,9 +476,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return activeDocumentWindowController != nil
         case #selector(selectAppearanceMode(_:)),
              #selector(selectContentWidthSetting(_:)):
-            return true
-        case #selector(toggleCrashReporting(_:)):
-            menuItem.state = CrashReporter.isEnabled ? .on : .off
             return true
         case #selector(toggleEditModeFromMenu(_:)):
             return activeDocumentWindowController?.canToggleEditMode ?? false
@@ -1075,7 +1060,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         reloadDocumentPreviewsForSettingChange()
     }
 
-    private func installAppMenuItemIcons() {
+    private func installAppMenuItems() {
         checkForUpdatesMenuItem?.target = updaterController
         checkForUpdatesMenuItem?.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
 
@@ -1087,20 +1072,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                                  action: #selector(installCommandLineTools(_:)),
                                  keyEquivalent: "")
         cliItem.target = self
-        appMenu.insertItem(.separator(), at: appMenu.index(of: updatesItem) + 1)
-        appMenu.insertItem(cliItem, at: appMenu.index(of: updatesItem) + 2)
-
-        let icons: [(NSMenuItem, String)] = [
-            (updatesItem, "arrow.triangle.2.circlepath"),
-            (cliItem, "terminal")
-        ]
-        for (item, symbol) in icons {
-            guard let image = NSImage(systemSymbolName: symbol,
-                                      accessibilityDescription: item.title)
-            else { continue }
-            image.isTemplate = true
-            item.image = image
-        }
+        appMenu.insertItem(cliItem, at: appMenu.index(of: updatesItem) + 1)
     }
 
     private func installSidebarViewMenuItems() {

--- a/md-preview/Base.lproj/MainMenu.xib
+++ b/md-preview/Base.lproj/MainMenu.xib
@@ -36,13 +36,6 @@
                                     <action selector="checkForUpdates:" target="Voe-Tx-rLC" id="spk-cu-act"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                            <menuItem title="Send Anonymous Crash Reports" id="BOF-NM-1cW">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="toggleCrashReporting:" target="Voe-Tx-rLC" id="sentry-pref-act"/>
-                                </connections>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
                             <menuItem title="Services" id="NMo-om-nkz">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/md-preview/en.lproj/MainMenu.strings
+++ b/md-preview/en.lproj/MainMenu.strings
@@ -34,8 +34,6 @@
 	<string>Smart Copy/Paste</string>
 	<key>AYu-sK-qS6.title</key>
 	<string>Main Menu</string>
-	<key>BOF-NM-1cW.title</key>
-	<string>Send Anonymous Crash Reports</string>
 	<key>Bw7-FT-i3A.title</key>
 	<string>Save As…</string>
 	<key>DVo-aG-piG.title</key>

--- a/md-preview/zh-Hans.lproj/MainMenu.strings
+++ b/md-preview/zh-Hans.lproj/MainMenu.strings
@@ -46,9 +46,6 @@
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "主菜单";
 
-/* Class = "NSMenuItem"; title = "Send Anonymous Crash Reports"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "发送匿名崩溃报告";
-
 /* Class = "NSMenuItem"; title = "Save As…"; ObjectID = "Bw7-FT-i3A"; */
 "Bw7-FT-i3A.title" = "存储为…";
 


### PR DESCRIPTION
Simplifies the application menu by grouping Settings, Check for Updates, and Install CLI beneath About, with fewer separators and no custom icons on those commands.

Removes the duplicate crash-reporting menu toggle and its unused action/localizations. Reporting remains configurable in Settings → Privacy, and the README now points there.

Validation: Debug app build passed using a separate output directory; git diff --check passed. Menu appearance has not been verified in the running app.
