### PR TITLE
Fix stale frosted strip after search and formatting bars close

### DIFF
--- a/md-preview/Document/ContentViewController.swift
+++ b/md-preview/Document/ContentViewController.swift
@@ -448,6 +448,11 @@ final class ContentViewController: NSViewController {
     /// The search row sits in the content host beneath the native toolbar.
     weak var findOverlay: NSView?
 
+    /// The formatting row (macOS 26.1+ native accessory path only). The
+    /// preview is hidden while editing, but it shows again beneath the bar
+    /// during the exit crossfade and must keep the same page padding.
+    weak var formattingBar: NSView?
+
     func chromeOverlaysDidChange() {
         updateObscuredContentInsets()
     }
@@ -461,7 +466,14 @@ final class ContentViewController: NSViewController {
         }
         var inset = contentView.bounds.height - window.contentLayoutRect.maxY
         if MainSplitViewController.usesNativeChromeAccessories {
-            return max(inset, view.safeAreaInsets.top)
+            // Measured from the bars, not `view.safeAreaInsets`: the safe
+            // area follows an accessory show, hide, or removal only on the
+            // next layout pass, and this view may not get one — the frost
+            // then lagged one step behind the strip (missing while it was
+            // shown, still covering the page after it was gone).
+            inset += MainSplitViewController.nativeAccessoryHeight(findOverlay, in: window)
+            inset += MainSplitViewController.nativeAccessoryHeight(formattingBar, in: window)
+            return max(0, inset)
         }
         if #available(macOS 26.0, *),
            let find = findOverlay, find.window === window, !find.isHidden {

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -561,9 +561,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     final class EditAccessoryContainerView: NSView {
         private var fullscreenBackdrop: NSVisualEffectView?
 
+        /// Full screen on macOS 26 and later draws the toolbar on an opaque
+        /// native strip instead of frosting the page, so the rows below it
+        /// take the same titlebar material to read as one piece of chrome.
         func updateFullscreenBackground() {
             guard #available(macOS 26.0, *) else { return }
-            guard #unavailable(macOS 27.0) else { return }
             if window?.styleMask.contains(.fullScreen) == true {
                 if fullscreenBackdrop == nil {
                     let backdrop = NSVisualEffectView(frame: bounds)

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -382,6 +382,10 @@ final class MainSplitViewController: NSSplitViewController {
         // The editor pads its page below the chrome; the bar is part of
         // that chrome now, so it must be measured alongside the titlebar.
         cachedEditorViewController?.formattingBar = bar
+        if Self.usesNativeChromeAccessories {
+            contentViewController?.formattingBar = bar
+            contentViewController?.chromeOverlaysDidChange()
+        }
     }
 
     func removeFormattingBar() {
@@ -394,6 +398,10 @@ final class MainSplitViewController: NSSplitViewController {
             layeredContentViewController?.removeFormattingBar()
         }
         cachedEditorViewController?.formattingBar = nil
+        if Self.usesNativeChromeAccessories {
+            contentViewController?.formattingBar = nil
+            contentViewController?.chromeOverlaysDidChange()
+        }
     }
 
     private weak var findOverlayView: NSView?
@@ -404,6 +412,15 @@ final class MainSplitViewController: NSSplitViewController {
         if #available(macOS 27.0, *) { return false }
         if #available(macOS 26.1, *) { return true }
         return false
+    }
+
+    /// Height a native chrome accessory (find bar, formatting bar) adds to
+    /// the obscured strip above the page, or 0 when it is absent or hidden.
+    /// fittingSize rather than the frame: the frame is unresolved between
+    /// install and the next layout pass, exactly when callers ask.
+    static func nativeAccessoryHeight(_ bar: NSView?, in window: NSWindow) -> CGFloat {
+        guard let bar, bar.window === window, !bar.isHidden else { return 0 }
+        return bar.fittingSize.height
     }
 
     private func installNativeChromeAccessory(_ bar: NSView) -> NSViewController? {

--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -181,7 +181,11 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         // out below the lowest piece of chrome.
         var gap = contentView.bounds.height - window.contentLayoutRect.maxY
         if MainSplitViewController.usesNativeChromeAccessories {
-            return max(gap, view.safeAreaInsets.top)
+            // See ContentViewController.fullChromeTopInset: the safe area
+            // lags accessory changes by a layout pass, so measure the bars.
+            gap += MainSplitViewController.nativeAccessoryHeight(findOverlay, in: window)
+            gap += MainSplitViewController.nativeAccessoryHeight(formattingBar, in: window)
+            return max(0, gap)
         }
         for accessory in window.titlebarAccessoryViewControllers
         where accessory.layoutAttribute == .bottom && !accessory.isHidden


### PR DESCRIPTION
## Summary
- On macOS 26.1+, the search bar and formatting bar are native split view accessories. The preview and editor sized the frosted strip above the page from `view.safeAreaInsets`, which AppKit updates only on the next layout pass. The strip lagged one step behind the bars: the page showed through a freshly opened search bar, and the frosted band stayed at the old height after a bar was dismissed (window and full screen).
- The strip is now measured from the bars themselves (fitting height of each visible accessory added to the titlebar gap), so it is correct the moment a bar is shown, hidden, or removed. The preview also tracks the formatting bar and is notified on install/remove.
- macOS 27: apply the full screen titlebar material to the search and formatting rows, matching macOS 26. Full screen draws the toolbar on an opaque native strip there, so the rows take the same material instead of frosting the page under a white toolbar. Interim until the full screen toolbar itself can be made translucent on 27.

## Test plan
- [x] macOS 26.6 window: open search (page no longer shows through the bar), clear search (no leftover frosted band), enter and leave edit mode (no leftover band).
- [x] macOS 26.6 full screen: same four checks.
- [x] macOS 26.6: edit mode still pads the page below the formatting bar.
- [ ] macOS 27 VM: full screen search and formatting rows match the toolbar strip.
- [ ] macOS 15: unchanged (code path not touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
