### PR TITLE
Replace the sidebar pulldown with a pane picker and the system toggle

### DIFF
--- a/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
+++ b/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
@@ -58,7 +58,7 @@ extension DocumentWindowController {
             menuItem.image = Self.alwaysOnTopMenuImage(isPinned: isAlwaysOnTop)
             return true
         }
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
         return true
     }
 }

--- a/md-preview/Document/DocumentWindowController+DocumentOpening.swift
+++ b/md-preview/Document/DocumentWindowController+DocumentOpening.swift
@@ -66,7 +66,7 @@ extension DocumentWindowController {
             .openFolder(folderURL, selectedFileURL: currentFileURL)
         documentWindow.makeKeyAndOrderFront(nil)
         NSApp.activate()
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
     }
 
     func contextMenuEditorItems(for fileURL: URL) -> [NSMenuItem] {

--- a/md-preview/Document/DocumentWindowController+Sidebar.swift
+++ b/md-preview/Document/DocumentWindowController+Sidebar.swift
@@ -2,88 +2,159 @@
 //  DocumentWindowController+Sidebar.swift
 //  md-preview
 //
-//  The sidebar toolbar item and its mode menu.
+//  The sidebar toolbar items: the mode picker and the show/hide toggle.
 //
 
 import Cocoa
 
 extension DocumentWindowController {
-    func makeSidebarMenuItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
-        // An AppKit-owned item rather than an NSPopUpButton in a custom view:
-        // the toolbar keeps its own drag regions only for items it draws
-        // itself, so a control view here costs the window its drag surface.
-        //
-        // The two objections to NSMenuToolbarItem both come from configuring
-        // it as a split button. Leaving `target`/`action` unset makes a click
-        // anywhere on the item open the menu, and setting `image` explicitly
-        // means no menu entry is promoted out of the dropdown to act as the
-        // face — so this behaves as the Preview-style pulldown it replaces.
-        let item = NSMenuToolbarItem(itemIdentifier: .sidebarMenu)
-        item.label = NSLocalizedString("Sidebar", comment: "Sidebar toolbar item label")
-        item.paletteLabel = NSLocalizedString("Sidebar", comment: "Sidebar toolbar palette label")
-        item.toolTip = NSLocalizedString("Sidebar options", comment: "Sidebar toolbar item tooltip")
-        item.image = sidebarFaceImage()
-        item.showsIndicator = true
+    /// Table of Contents / Project Navigator as a tabbed picker: a click
+    /// shows that pane, opening the sidebar if it was hidden. Hiding is the
+    /// sidebar toggle's job, at the other end of the sidebar's titlebar area.
+    ///
+    /// Selection mode follows the sidebar. `.selectOne` draws the grey
+    /// selected tint while a pane is on screen, but on macOS 26 it refuses to
+    /// show no selection, and `.selectAny` clears but paints the accent color
+    /// instead. So the group is `.selectOne` while the sidebar is visible and
+    /// `.momentary` while it is hidden.
+    /// An AppKit-owned `NSToolbarItemGroup` rather than an
+    /// `NSSegmentedControl` in a custom view, for the same reason as the
+    /// navigation group — the toolbar keeps window-drag regions only around
+    /// items it draws itself.
+    func makeSidebarModeItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
+        let outlineLabel = NSLocalizedString("Table of Contents", comment: "Sidebar mode toolbar segment label")
+        let filesLabel = NSLocalizedString("Project Navigator", comment: "Sidebar mode toolbar segment label")
 
-        let menu = NSMenu()
-        menu.identifier = NSUserInterfaceItemIdentifier("SidebarMenu")
-        menu.delegate = self
-        menu.autoenablesItems = false
-        rebuildSidebarMenu(menu)
-        item.menu = menu
+        let item = NSToolbarItemGroup(itemIdentifier: .sidebarMode,
+                                      images: [sidebarSymbolImage("list.bullet.indent", description: outlineLabel),
+                                               sidebarSymbolImage("folder", description: filesLabel)],
+                                      selectionMode: .selectOne,
+                                      labels: [outlineLabel, filesLabel],
+                                      target: self,
+                                      action: #selector(sidebarModeGroupAction(_:)))
+        item.label = NSLocalizedString("Sidebar Mode", comment: "Sidebar mode toolbar item label")
+        item.paletteLabel = item.label
+        // Not `isNavigational`: AppKit places navigational items after the
+        // sidebar tracking separator, which would move this picker out of
+        // the sidebar's titlebar area and into the content area.
+        item.autovalidates = false
+        // Keep both segments visible instead of collapsing into a single
+        // button + overflow menu when the toolbar gets tight.
+        item.controlRepresentation = .expanded
+        item.subitems.first?.toolTip = outlineLabel
+        item.subitems.last?.toolTip = filesLabel
+        // Per-subitem actions: on macOS 26 the group has no backing
+        // NSSegmentedControl and its selectedIndex does not report the
+        // clicked segment, so the group action alone cannot tell them apart.
+        // Pre-26 only the group action fires; both paths dedupe per event.
+        item.subitems.first?.target = self
+        item.subitems.first?.action = #selector(selectOutlineModeFromToolbar(_:))
+        item.subitems.last?.target = self
+        item.subitems.last?.action = #selector(selectFilesModeFromToolbar(_:))
+        // Pre-26 the group is backed by an NSSegmentedControl; on 26 `view`
+        // is nil and AppKit draws the subitems itself.
+        if let segmented = item.view as? NSSegmentedControl {
+            segmented.setToolTip(outlineLabel, forSegment: 0)
+            segmented.setToolTip(filesLabel, forSegment: 1)
+        }
 
         if willBeInsertedIntoToolbar {
-            sidebarMenu = menu
-            syncSidebarMenuState()
+            sidebarModeItem = item
         }
+        applySidebarModeSelection(to: item)
         return item
     }
 
-    func menuNeedsUpdate(_ menu: NSMenu) {
-        guard menu === sidebarMenu else { return }
-        rebuildSidebarMenu(menu)
-        syncSidebarMenuState()
+    /// Show/hide as a plain bordered item, so it can sit at the trailing edge
+    /// of the sidebar's titlebar area, opposite the pane picker.
+    func makeSidebarToggleItem() -> NSToolbarItem {
+        let label = NSLocalizedString("Sidebar", comment: "Sidebar toolbar item label")
+        let item = NSToolbarItem(itemIdentifier: .sidebarMenu)
+        item.label = label
+        item.paletteLabel = NSLocalizedString("Toggle Sidebar", comment: "Sidebar toolbar palette label")
+        item.toolTip = NSLocalizedString("Show or hide the sidebar", comment: "Sidebar toolbar item tooltip")
+        item.image = sidebarSymbolImage("sidebar.leading", description: label)
+        item.isBordered = true
+        item.autovalidates = false
+        item.target = self
+        item.action = #selector(toggleSidebarFromMenu(_:))
+        return item
     }
 
-    private func rebuildSidebarMenu(_ menu: NSMenu) {
-        menu.removeAllItems()
-
-        // NSMenuToolbarItem reserves the first menu item for its button face,
-        // even when the toolbar item supplies its own image. Keep that slot
-        // empty so every real command appears in the dropdown.
-        menu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
-
-        let hide = NSMenuItem(title: NSLocalizedString("Hide Sidebar", comment: "Sidebar dropdown item"),
-                              action: #selector(hideSidebarFromMenu(_:)),
-                              keyEquivalent: "")
-        hide.target = self
-        menu.addItem(hide)
-
-        let outline = NSMenuItem(title: NSLocalizedString("Table of Contents", comment: "Sidebar dropdown item"),
-                                 action: #selector(selectOutlineMode(_:)),
-                                 keyEquivalent: "")
-        outline.target = self
-        menu.addItem(outline)
-
-        let files = NSMenuItem(title: NSLocalizedString("Project Navigator", comment: "Sidebar dropdown item"),
-                               action: #selector(selectFilesMode(_:)),
-                               keyEquivalent: "")
-        files.target = self
-        menu.addItem(files)
-        syncSidebarMenuState(for: menu)
+    /// Pre-26 path, where the segmented control has already applied the
+    /// click to its selection. Momentary (sidebar hidden) reports the clicked
+    /// segment directly. In `.selectOne` the newly selected segment is the
+    /// one that was clicked; with no change, the click landed on the
+    /// selected one, which is already on screen.
+    @objc private func sidebarModeGroupAction(_ sender: NSToolbarItemGroup) {
+        guard claimSidebarToolbarEvent() else { return }
+        let clicked: Int?
+        if sender.selectionMode == .momentary {
+            clicked = sender.selectedIndex
+        } else {
+            let expected = expectedSidebarModeSelection()
+            let actual = expected.indices.map { sender.isSelected(at: $0) }
+            clicked = actual.indices.first { actual[$0] && !expected[$0] }
+                ?? expected.firstIndex(of: true)
+        }
+        guard let clicked, (0...1).contains(clicked) else { return }
+        showSidebarPane(clicked == 0 ? .outline : .files)
     }
 
-    func syncSidebarMenuState() {
-        if let sidebarMenu {
-            syncSidebarMenuState(for: sidebarMenu)
+    @objc private func selectOutlineModeFromToolbar(_ sender: Any?) {
+        guard claimSidebarToolbarEvent() else { return }
+        showSidebarPane(.outline)
+    }
+
+    @objc private func selectFilesModeFromToolbar(_ sender: Any?) {
+        guard claimSidebarToolbarEvent() else { return }
+        showSidebarPane(.files)
+    }
+
+    private func showSidebarPane(_ mode: SidebarViewController.Mode) {
+        switch mode {
+        case .outline: selectOutlineMode(nil)
+        case .files: selectFilesMode(nil)
+        }
+        // The group applies the clicked segment as its selection after the
+        // action returns; re-apply the model's state once AppKit is done.
+        DispatchQueue.main.async { [weak self] in
+            self?.syncSidebarToolbarState()
         }
     }
 
-    func syncSidebarMenuState(for menu: NSMenu) {
+    /// One click may reach both a subitem action and the group action. The
+    /// first handler for a given event wins; the other is a no-op. Keyed on
+    /// the timestamp: synthetic events can all share event number 0.
+    private func claimSidebarToolbarEvent() -> Bool {
+        guard let timestamp = NSApp.currentEvent?.timestamp else { return true }
+        guard timestamp != sidebarToolbarHandledEventTimestamp else { return false }
+        sidebarToolbarHandledEventTimestamp = timestamp
+        return true
+    }
+
+    /// Mirrors the split view into the mode picker: the visible pane is
+    /// selected, and nothing is selected while the sidebar is hidden.
+    func syncSidebarToolbarState() {
+        if let sidebarModeItem {
+            applySidebarModeSelection(to: sidebarModeItem)
+        }
+    }
+
+    private func applySidebarModeSelection(to item: NSToolbarItemGroup) {
+        let expected = expectedSidebarModeSelection()
+        item.selectionMode = expected.contains(true) ? .selectOne : .momentary
+        for (index, selected) in expected.enumerated() {
+            item.setSelected(selected, at: index)
+        }
+    }
+
+    /// Segment selection the model calls for: [Table of Contents, Project
+    /// Navigator]. Neither is selected while the sidebar is hidden.
+    private func expectedSidebarModeSelection() -> [Bool] {
         let state = currentSidebarMenuState()
-        menu.items.first { $0.action == #selector(hideSidebarFromMenu(_:)) }?.state = state.sidebarVisible ? .off : .on
-        menu.items.first { $0.action == #selector(selectOutlineMode(_:)) }?.state = (state.sidebarVisible && state.mode == .outline) ? .on : .off
-        menu.items.first { $0.action == #selector(selectFilesMode(_:)) }?.state = (state.sidebarVisible && state.mode == .files) ? .on : .off
+        guard state.sidebarVisible else { return [false, false] }
+        return [state.mode == .outline, state.mode == .files]
     }
 
     var sidebarMenuState: (sidebarVisible: Bool, mode: SidebarViewController.Mode) {
@@ -114,39 +185,38 @@ extension DocumentWindowController {
 
     func prepareSidebarForUntitledDocument() {
         mainSplit?.hideSidebar()
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
     }
 
-    private func sidebarFaceImage() -> NSImage {
-        let image = NSImage(systemSymbolName: "sidebar.leading",
-                            accessibilityDescription: NSLocalizedString("Sidebar", comment: "Sidebar toolbar image")) ?? NSImage()
+    private func sidebarSymbolImage(_ name: String, description: String) -> NSImage {
+        let image = NSImage(systemSymbolName: name, accessibilityDescription: description) ?? NSImage()
         image.isTemplate = true
         return image
     }
 
     @objc func toggleSidebarFromMenu(_ sender: Any?) {
         (documentWindow.contentViewController as? MainSplitViewController)?.toggleSidebar()
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
     }
 
     @objc func hideSidebarFromMenu(_ sender: Any?) {
         guard let split = documentWindow.contentViewController as? MainSplitViewController,
               split.isSidebarVisible else { return }
         split.toggleSidebar()
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
     }
 
     @objc func selectOutlineMode(_ sender: Any?) {
         guard let split = documentWindow.contentViewController as? MainSplitViewController else { return }
         split.setSidebarMode(.outline)
         split.showSidebar()
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
     }
 
     @objc func selectFilesMode(_ sender: Any?) {
         guard let split = documentWindow.contentViewController as? MainSplitViewController else { return }
         split.setSidebarMode(.files)
         split.showSidebar()
-        syncSidebarMenuState()
+        syncSidebarToolbarState()
     }
 }

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -15,7 +15,10 @@ extension NSToolbarItem.Identifier {
     static let inspector = NSToolbarItem.Identifier("Inspector")
     static let share = NSToolbarItem.Identifier("Share")
     static let search = NSToolbarItem.Identifier("Search")
+    /// The sidebar show/hide toggle. The raw value predates the mode picker
+    /// and is kept so saved toolbar layouts still resolve.
     static let sidebarMenu = NSToolbarItem.Identifier("SidebarMenu")
+    static let sidebarMode = NSToolbarItem.Identifier("SidebarMode")
     static let printDocument = NSToolbarItem.Identifier("PrintDocument")
     static let exportDocument = NSToolbarItem.Identifier("ExportDocument")
     static let exportPDF = NSToolbarItem.Identifier("ExportPDF")
@@ -39,10 +42,21 @@ private extension Array where Element == NSToolbarItem.Identifier {
 
 extension DocumentWindowController {
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        let identifiers: [NSToolbarItem.Identifier] = [
-            .flexibleSpace,
-            .sidebarMenu,
-            .sidebarTrackingSeparator,
+        // Inside the sidebar's titlebar area: the pane picker at the leading
+        // edge, the show/hide toggle at the trailing edge next to the
+        // separator. Pre-26 there is no sidebar-tracking region, so the two
+        // sit together at the leading edge instead.
+        // The toggle is the system item: AppKit lays it out correctly when
+        // the sidebar section collapses, and it reaches
+        // MainSplitViewController.toggleSidebar(_:) through the responder
+        // chain.
+        let leading: [NSToolbarItem.Identifier]
+        if #available(macOS 26.0, *) {
+            leading = [.sidebarMode, .flexibleSpace, .toggleSidebar, .sidebarTrackingSeparator]
+        } else {
+            leading = [.toggleSidebar, .sidebarMode]
+        }
+        let identifiers: [NSToolbarItem.Identifier] = leading + [
             .navigation,
             .flexibleSpace,
             .openActions,
@@ -55,14 +69,16 @@ extension DocumentWindowController {
             .search
         ]
         if #unavailable(macOS 26.0) {
-            return identifiers.filter { $0 != .space && $0 != .sidebarTrackingSeparator }
+            return identifiers.filter { $0 != .space }
         }
         return identifiers
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         var identifiers: [NSToolbarItem.Identifier] = [
+            .toggleSidebar,
             .sidebarMenu,
+            .sidebarMode,
             .sidebarTrackingSeparator,
             .navigation,
             .flexibleSpace,
@@ -91,7 +107,8 @@ extension DocumentWindowController {
                  itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
                  willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         switch itemIdentifier {
-        case .sidebarMenu: return makeSidebarMenuItem(willBeInsertedIntoToolbar: flag)
+        case .sidebarMenu: return makeSidebarToggleItem()
+        case .sidebarMode: return makeSidebarModeItem(willBeInsertedIntoToolbar: flag)
         case .navigation: return makeNavigationItem(willBeInsertedIntoToolbar: flag)
         case .openActions: return makeOpenActionsItem()
         case .openWith: return makeOpenWithItem()

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -111,7 +111,10 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     /// Armed only while the themes popover is open.
     let themesPopoverEscapeMonitor = EscapeKeyMonitor()
     weak var searchField: NSSearchField?
-    weak var sidebarMenu: NSMenu?
+    /// The Table of Contents / Project Navigator picker in the toolbar.
+    weak var sidebarModeItem: NSToolbarItemGroup?
+    /// Timestamp of the last click handled by the sidebar mode picker.
+    var sidebarToolbarHandledEventTimestamp: TimeInterval?
     var findBar: FindBar?
     /// Container for the find bar. A content overlay like editBar — not a
     /// titlebar accessory — so showing it never pushes the tab bar down.

--- a/md-preview/Document/MainSplitViewController.swift
+++ b/md-preview/Document/MainSplitViewController.swift
@@ -202,6 +202,15 @@ final class MainSplitViewController: NSSplitViewController {
         !(splitViewItems.first?.isCollapsed ?? true)
     }
 
+    /// Target of the system `.toggleSidebar` toolbar item. The themed layout
+    /// uses a plain split view item, which the stock implementation ignores,
+    /// so both layouts go through the app's own toggle and the toolbar's
+    /// pane picker is kept in step.
+    override func toggleSidebar(_ sender: Any?) {
+        toggleSidebar()
+        (view.window?.windowController as? DocumentWindowController)?.syncSidebarToolbarState()
+    }
+
     @discardableResult
     func toggleSidebar() -> Bool {
         guard let sidebar = splitViewItems.first else { return false }


### PR DESCRIPTION
## Summary

The sidebar toolbar item was one `NSMenuToolbarItem` with a dropdown (Hide Sidebar / Table of Contents / Project Navigator). It is now two items inside the sidebar's titlebar area, modelled on Notes and Xcode:

- **Pane picker** (`SidebarMode`, an `NSToolbarItemGroup`) at the leading edge: Table of Contents and Project Navigator as two segments. A click shows that pane and opens the sidebar if it was hidden. The visible pane is drawn with the grey selected tint; nothing is selected while the sidebar is hidden.
- **System `.toggleSidebar` item** at the trailing edge, next to the tracking separator. `MainSplitViewController` overrides `toggleSidebar(_:)` so the themed layout (a plain split view item) toggles as well and the picker stays in step.

The View menu items (⌘L, ⌘1–3) are unchanged. The old `SidebarMenu` identifier is kept as a plain bordered toggle so saved toolbar layouts still resolve.

## macOS 26 quirks handled

- `NSToolbarItemGroup.view` is nil on 26 and the group action reports `selectedIndex == 0` for every segment, so each subitem carries its own action. Pre-26 only the group action fires; a per-event timestamp guard prevents double handling.
- `.selectOne` draws the grey tint but refuses "nothing selected"; `.selectAny` clears but paints the accent color. The group is `.selectOne` while a pane is shown and `.momentary` while hidden, re-applied on the next run-loop pass because AppKit applies its own selection after the action returns.
- `isNavigational` moves an item after the sidebar separator, so it is not set.

## Test plan

- [x] Debug build succeeds
- [x] Picker: click Table of Contents / Project Navigator switches the pane and the grey highlight follows
- [x] Picker: clicking a pane while the sidebar is hidden opens the sidebar in that pane
- [x] Hidden sidebar shows no highlighted segment
- [x] Sidebar toggle collapses and reopens the sidebar (verified manually by the maintainer)
- [x] View menu sidebar items still work
- [ ] Pre-26 layout (toggle then picker at the leading edge) — not verifiable on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)