### PR TITLE
Add a Save button, and ask before leaving edit mode with unsaved changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or grab the latest signed and notarized DMG from the [Releases](https://github.c
 ## Features
 
 - **Native rendering** — `WKWebView` pipeline backed by [swift-markdown](https://github.com/swiftlang/swift-markdown), with heading anchors and link handling.
-- **Edit Mode** — edit Markdown in place with a formatting toolbar for headings, emphasis, lists, quotes, code, and links. Toggle it from the toolbar or with <kbd>⌘E</kbd>, then save with <kbd>⌘S</kbd>.
+- **Edit Mode** — edit Markdown in place with a formatting toolbar for headings, emphasis, lists, quotes, code, and links. Toggle it from the toolbar or with <kbd>⌘E</kbd>, and save with <kbd>⌘S</kbd> or the toolbar's Save button. Leaving edit mode with unsaved changes asks whether to save them, keep them for later, or revert them — or, with the setting turned on, simply keeps them.
 - **Mermaid diagrams** — fenced `mermaid` code blocks render as diagrams in both the app and Quick Look previews, using a bundled renderer so previews work offline without a CDN request.
 - **Math equations** — LaTeX inline (`$x_1 + x_2$`), display (`$$\int_0^1 x^2\,dx$$`), and fenced `math` blocks render with a bundled KaTeX. Selecting a rendered formula and copying yields the original LaTeX source (via the official `copy-tex` extension).
 - **Document outline** — sidebar TOC that mirrors your headings; click to jump.

--- a/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
+++ b/md-preview/Document/DocumentWindowController+AlwaysOnTop.swift
@@ -51,7 +51,14 @@ extension DocumentWindowController {
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(saveDocument(_:)) {
-            return isEditing
+            return EditExitPolicy.isSaveCommandEnabled(hasUnsavedChanges: hasUnsavedEditorChanges)
+        }
+        if menuItem.action == #selector(saveDocumentAs(_:)) {
+            return EditExitPolicy.isSaveAsCommandEnabled(hasDocument: canToggleEditMode)
+        }
+        if menuItem.action == #selector(revertDocumentToSaved(_:)) {
+            return EditExitPolicy.isRevertCommandEnabled(hasUnsavedChanges: hasUnsavedEditorChanges,
+                                                         hasFile: currentFileURL != nil)
         }
         if menuItem.action == #selector(toggleAlwaysOnTop(_:)) {
             menuItem.state = isAlwaysOnTop ? .on : .off

--- a/md-preview/Document/DocumentWindowController+EditMode.swift
+++ b/md-preview/Document/DocumentWindowController+EditMode.swift
@@ -80,7 +80,7 @@ extension DocumentWindowController {
 
     func toggleEditMode() {
         if isEditing {
-            previewPendingEdits()
+            requestExitEditMode()
         } else {
             enterEditMode()
         }

--- a/md-preview/Document/DocumentWindowController+EditSession.swift
+++ b/md-preview/Document/DocumentWindowController+EditSession.swift
@@ -24,7 +24,7 @@ extension DocumentWindowController {
             autofocus: autofocus
         )
         editor.cancelRequested = { [weak self] in
-            self?.previewPendingEdits()
+            self?.requestExitEditMode()
         }
         editor.contentDidChange = { [weak self] in
             self?.editorChangeRevision += 1
@@ -82,7 +82,169 @@ extension DocumentWindowController {
         }
     }
 
-    private func saveUntitledMarkdown(
+    /// Leaving edit mode from the toolbar, ⌘E or Escape in the editor. With
+    /// unsaved changes this asks whether to save them, keep them as a draft,
+    /// or revert them -- unless the reader has turned the prompt off, in which
+    /// case the edits stay pending exactly as they did before the prompt.
+    /// Closing, navigating away and quitting keep their own decision in
+    /// resolveUnsavedEdits.
+    func requestExitEditMode() {
+        guard let editor = mainSplit?.editorViewController,
+              documentWindow.attachedSheet == nil else { return }
+        // Let a save that is already running finish first, as
+        // resolveUnsavedEdits does, rather than comparing against a baseline
+        // that is about to move.
+        if isEditorCommitInFlight {
+            commitEdits(exitAfter: false) { [weak self] success in
+                guard success else { return }
+                self?.requestExitEditMode()
+            }
+            return
+        }
+        editor.fetchMarkdown { [weak self] markdown in
+            guard let self else { return }
+            guard let markdown else {
+                NSSound.beep()
+                return
+            }
+            guard EditExitPolicy.needsExitPrompt(
+                currentSource: markdown,
+                savedSource: self.editorBaselineMarkdown,
+                exitsSilently: EditExitPolicy.exitsSilently
+            ) else {
+                self.previewPendingEdits()
+                return
+            }
+            self.presentExitEditModePrompt()
+        }
+    }
+
+    private func presentExitEditModePrompt() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = NSLocalizedString(
+            "Do you want to save your changes?",
+            comment: "Unsaved changes alert title"
+        )
+        let fileName = currentFileURL?.lastPathComponent
+            ?? NSLocalizedString("this document", comment: "Fallback document name in alerts")
+        alert.informativeText = String(
+            format: NSLocalizedString(
+                "Continue keeps your changes to %@ without saving them, so you can save later. Revert… discards them.",
+                comment: "Leave edit mode alert message"
+            ),
+            fileName
+        )
+        for choice in EditExitPolicy.exitButtonOrder {
+            let button = alert.addButton(withTitle: exitChoiceTitle(choice))
+            if choice == EditExitPolicy.escapeChoice {
+                button.keyEquivalent = "\u{1b}"
+            }
+        }
+        alert.beginSheetModal(for: documentWindow) { [weak self] response in
+            guard let self else { return }
+            let index = response.rawValue - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
+            switch EditExitPolicy.exitChoice(forButtonAt: index) {
+            case .save:
+                self.commitEdits(exitAfter: true) { [weak self] success in
+                    if success { self?.dismissEditChrome() }
+                }
+            case .continueUnsaved:
+                self.previewPendingEdits()
+            case .revert:
+                self.confirmRevertingEdits { [weak self] in
+                    self?.exitEditModeWithoutSaving { [weak self] in
+                        self?.dismissEditChrome()
+                    }
+                }
+            }
+        }
+    }
+
+    private func exitChoiceTitle(_ choice: EditExitPolicy.ExitChoice) -> String {
+        switch choice {
+        case .save:
+            return NSLocalizedString("Save", comment: "Alert button")
+        case .continueUnsaved:
+            return NSLocalizedString("Continue", comment: "Leave edit mode alert button")
+        case .revert:
+            return NSLocalizedString("Revert…", comment: "Leave edit mode alert button")
+        }
+    }
+
+    /// Reverting discards edits that cannot be recovered, so it gets its own
+    /// confirmation. Cancel, on Escape, leaves everything as it was. Shared by
+    /// the leave-edit-mode prompt's Revert… and File › Revert to Saved, which
+    /// differ only in what happens afterwards.
+    private func confirmRevertingEdits(then revert: @escaping () -> Void) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        let fileName = currentFileURL?.lastPathComponent
+            ?? NSLocalizedString("this document", comment: "Fallback document name in alerts")
+        alert.messageText = String(
+            format: NSLocalizedString(
+                "Revert to the last saved version of %@?",
+                comment: "Revert confirmation title"
+            ),
+            fileName
+        )
+        alert.informativeText = NSLocalizedString(
+            "Your unsaved changes will be lost. You can’t undo this action.",
+            comment: "Revert confirmation message"
+        )
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Alert button"))
+        let revertButton = alert.addButton(withTitle: NSLocalizedString("Revert", comment: "Revert confirmation button"))
+        revertButton.hasDestructiveAction = true
+        alert.beginSheetModal(for: documentWindow) { response in
+            guard response == .alertSecondButtonReturn else { return }
+            revert()
+        }
+    }
+
+    /// File › Save As… (⇧⌘S): write the current source to a file chosen in a
+    /// save panel, then follow that file. Available for any open document,
+    /// changed or not.
+    @IBAction func saveDocumentAs(_ sender: Any?) {
+        guard EditExitPolicy.isSaveAsCommandEnabled(hasDocument: canToggleEditMode) else {
+            NSSound.beep()
+            return
+        }
+        pendingCommitSavesAs = true
+        commitEdits(exitAfter: false)
+    }
+
+    /// File › Revert to Saved (⌘R): go back to the version on disk, after the
+    /// same confirmation the leave-edit-mode prompt uses. While editing, the
+    /// saved version is loaded into the editor and editing continues; outside
+    /// edit mode the kept draft is dropped. Like Save, only with unsaved
+    /// changes, and only for a document with a file to go back to.
+    @IBAction func revertDocumentToSaved(_ sender: Any?) {
+        guard EditExitPolicy.isRevertCommandEnabled(hasUnsavedChanges: hasUnsavedEditorChanges,
+                                                    hasFile: currentFileURL != nil),
+              !isEditorCommitInFlight,
+              documentWindow.attachedSheet == nil else {
+            NSSound.beep()
+            return
+        }
+        confirmRevertingEdits { [weak self] in
+            self?.revertToSavedVersion()
+        }
+    }
+
+    private func revertToSavedVersion() {
+        guard let url = currentFileURL,
+              let saved = try? String(contentsOf: url, encoding: .utf8) else {
+            NSSound.beep()
+            return
+        }
+        adoptExternalMarkdown(saved,
+                              editor: isEditing ? mainSplit?.editorViewController : nil,
+                              exitAfter: false)
+    }
+
+    /// Writes through a save panel: the only way to save an untitled
+    /// document, and what Save As… does for one that already has a file.
+    private func saveMarkdownThroughPanel(
         _ text: String,
         completion: @escaping (EditedMarkdownSaveResult) -> Void
     ) {
@@ -90,11 +252,16 @@ extension DocumentWindowController {
         panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
         panel.allowsOtherFileTypes = false
         panel.canCreateDirectories = true
-        panel.nameFieldStringValue = "Untitled.md"
-        panel.message = NSLocalizedString(
-            "Choose a name and location for the new Markdown file.",
-            comment: "New Markdown file panel prompt"
-        )
+        if let existing = currentFileURL {
+            panel.directoryURL = existing.deletingLastPathComponent()
+            panel.nameFieldStringValue = existing.lastPathComponent
+        } else {
+            panel.nameFieldStringValue = "Untitled.md"
+            panel.message = NSLocalizedString(
+                "Choose a name and location for the new Markdown file.",
+                comment: "New Markdown file panel prompt"
+            )
+        }
         panel.prompt = NSLocalizedString("Save", comment: "Untitled Markdown file save panel button")
         panel.beginSheetModal(for: documentWindow) { [weak self] response in
             guard let self, response == .OK, let url = panel.url else {
@@ -103,6 +270,14 @@ extension DocumentWindowController {
             }
             guard self.write(text, to: url) else {
                 completion(.cancelled)
+                return
+            }
+            if self.currentFileURL != nil {
+                // Save As…: the window follows the new file, and the one it
+                // came from stays exactly as it was on disk.
+                self.currentMarkdown = text
+                self.handleRename(to: url)
+                completion(.saved)
                 return
             }
 
@@ -240,12 +415,17 @@ extension DocumentWindowController {
     private func performPendingEditorCommit() {
         let exitAfter = pendingCommitShouldExit
         pendingCommitShouldExit = false
+        let savesAs = pendingCommitSavesAs
+        pendingCommitSavesAs = false
         guard let split = mainSplit else {
             finishEditorCommit(success: false)
             return
         }
-        if !isEditing, let body = editorDraftMarkdown {
-            performPendingEditorCommit(body: body, editor: nil, exitAfter: exitAfter)
+        // Out of edit mode the source is the kept draft -- or, for Save As…
+        // with nothing changed, the document as it stands.
+        if !isEditing, let body = editorDraftMarkdown ?? (savesAs ? currentMarkdown : nil) {
+            performPendingEditorCommit(body: body, editor: nil, exitAfter: exitAfter,
+                                       savesAs: savesAs)
             return
         }
         guard let editor = split.editorViewController else {
@@ -264,17 +444,19 @@ extension DocumentWindowController {
                 return
             }
             self.performPendingEditorCommit(body: body, editor: editor,
-                                            revision: revision, exitAfter: exitAfter)
+                                            revision: revision, exitAfter: exitAfter,
+                                            savesAs: savesAs)
         }
     }
 
     private func performPendingEditorCommit(body: String,
                                             editor: EditorViewController?,
                                             revision: Int? = nil,
-                                            exitAfter: Bool) {
+                                            exitAfter: Bool,
+                                            savesAs: Bool = false) {
         isEditorCommitInFlight = true
-        if currentFileURL == nil {
-            saveUntitledMarkdown(body) { result in
+        if currentFileURL == nil || savesAs {
+            saveMarkdownThroughPanel(body) { result in
                 self.handleEditedMarkdownSaveResult(result,
                                                     body: body,
                                                     editor: editor,

--- a/md-preview/Document/DocumentWindowController+Toolbar.swift
+++ b/md-preview/Document/DocumentWindowController+Toolbar.swift
@@ -26,6 +26,7 @@ extension NSToolbarItem.Identifier {
     static let zoom = NSToolbarItem.Identifier("Zoom")
     static let themesAndSettings = NSToolbarItem.Identifier("ThemesAndSettings")
     static let editDocument = NSToolbarItem.Identifier("EditDocument")
+    static let saveDocument = NSToolbarItem.Identifier("SaveDocument")
     static let navigation = NSToolbarItem.Identifier("Navigation")
     static let alwaysOnTop = NSToolbarItem.Identifier("AlwaysOnTop")
 }
@@ -65,6 +66,7 @@ extension DocumentWindowController {
             .space,
             .inspector,
             .share,
+            .saveDocument,
             .editDocument,
             .search
         ]
@@ -85,6 +87,7 @@ extension DocumentWindowController {
             .space,
             .openActions,
             .openWith,
+            .saveDocument,
             .editDocument,
             .inspector,
             .share,
@@ -116,6 +119,7 @@ extension DocumentWindowController {
             guard hasLLMTargetsAvailable else { return nil }
             return makeOpenInLLMItem()
         case .editDocument: return makeEditItem(willBeInsertedIntoToolbar: flag)
+        case .saveDocument: return makeSaveItem(willBeInsertedIntoToolbar: flag)
         case .inspector: return makeInspectorItem(willBeInsertedIntoToolbar: flag)
         case .alwaysOnTop: return makeAlwaysOnTopItem(willBeInsertedIntoToolbar: flag)
         case .share: return makeShareItem()
@@ -258,6 +262,55 @@ extension DocumentWindowController {
         item.toolTip = NSLocalizedString("Share document", comment: "Share toolbar item tooltip")
         item.delegate = self
         return item
+    }
+
+    /// Always present, enabled only while there is something to save, so it
+    /// doubles as the unsaved-changes indicator. It saves through
+    /// saveDocument(_:), the same path as ⌘S, including after edit mode has
+    /// been left with the changes kept.
+    ///
+    /// Icon and word together, matching File › Save… in the menu. The icon on
+    /// its own, square.and.arrow.down, is the Share icon with its arrow flipped
+    /// and sits right next to Share; the word is what makes it unambiguous. A
+    /// custom view, like the Edit item, because a bordered image item shows
+    /// the image or the title, never both.
+    private func makeSaveItem(willBeInsertedIntoToolbar: Bool) -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: .saveDocument)
+        let save = NSLocalizedString("Save", comment: "Save toolbar item label")
+        item.label = save
+        item.paletteLabel = save
+        let image = NSImage(systemSymbolName: "square.and.arrow.down",
+                            accessibilityDescription: nil) ?? NSImage()
+        image.isTemplate = true
+        let button = NSButton(title: save, image: image,
+                              target: self, action: #selector(saveDocument(_:)))
+        button.imagePosition = .imageLeading
+        button.isBordered = true
+        item.view = button
+        // State comes from updateSaveToolbarItem(), not from validation.
+        item.autovalidates = false
+        if willBeInsertedIntoToolbar {
+            saveItem = item
+        }
+        applySaveToolbarState(to: item)
+        return item
+    }
+
+    func updateSaveToolbarItem() {
+        guard let saveItem else { return }
+        applySaveToolbarState(to: saveItem)
+    }
+
+    private func applySaveToolbarState(to item: NSToolbarItem) {
+        let enabled = EditExitPolicy.isSaveCommandEnabled(hasUnsavedChanges: hasUnsavedEditorChanges)
+        let tip = enabled
+            ? NSLocalizedString("Save changes", comment: "Save toolbar item tooltip")
+            : NSLocalizedString("No unsaved changes", comment: "Save toolbar item tooltip when disabled")
+        item.isEnabled = enabled
+        item.toolTip = tip
+        // A view-based item's control carries its own state.
+        (item.view as? NSButton)?.isEnabled = enabled
+        item.view?.toolTip = tip
     }
 
     private func makePrintItem() -> NSToolbarItem {
@@ -476,6 +529,23 @@ extension DocumentWindowController {
     /// who rearranges things in Customize Toolbar afterwards keeps their
     /// layout on the next launch.
     private static let didReplaceZoomItemKey = "Toolbar.DidReplaceZoomWithThemesAndSettings"
+
+    /// One-time insertion for toolbars restored from an autosaved
+    /// configuration that predates the Save item -- without it, everyone who
+    /// already has the app would never see the button. Guarded by a defaults
+    /// flag, like the zoom swap below, so a reader who removes it in Customize
+    /// Toolbar keeps it removed.
+    private static let didInsertSaveItemKey = "Toolbar.DidInsertSaveItem"
+
+    func insertSaveToolbarItemIfNeeded(in toolbar: NSToolbar) {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.didInsertSaveItemKey) else { return }
+        defaults.set(true, forKey: Self.didInsertSaveItemKey)
+        guard !toolbar.items.contains(where: { $0.itemIdentifier == .saveDocument }) else { return }
+        let index = toolbar.items.firstIndex(where: { $0.itemIdentifier == .editDocument })
+            ?? toolbar.items.count
+        toolbar.insertItem(withItemIdentifier: .saveDocument, at: index)
+    }
 
     func replaceZoomToolbarItemIfNeeded(in toolbar: NSToolbar) {
         let defaults = UserDefaults.standard

--- a/md-preview/Document/DocumentWindowController.swift
+++ b/md-preview/Document/DocumentWindowController.swift
@@ -64,6 +64,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     weak var inspectorButton: NSButton?
     weak var alwaysOnTopButton: NSButton?
     weak var editButton: NSButton?
+    weak var saveItem: NSToolbarItem?
     var editorChangeRevision = 0
     /// In-memory source shown by preview before the user saves it.
     var editorDraftMarkdown: String?
@@ -72,6 +73,9 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
     var isEditorCommitInFlight = false
     var pendingEditorCommitRequested = false
     var pendingCommitShouldExit = false
+    /// The next commit writes through a save panel -- Save As… -- even when
+    /// the document already has a file.
+    var pendingCommitSavesAs = false
     var pendingCommitCompletions: [(Bool) -> Void] = []
     /// When sidebar navigation starts from edit mode, the newly loaded file
     /// should return to edit mode instead of dropping the user into preview.
@@ -94,6 +98,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
                 stopAutoSaveTimer()
             }
             updateWindowSubtitle()
+            updateSaveToolbarItem()
         }
     }
     /// The formatting bar shown while editing. Not a titlebar accessory:
@@ -221,6 +226,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate, NSTo
         documentWindow.toolbar = toolbar
         documentWindow.toolbarStyle = .automatic
         replaceZoomToolbarItemIfNeeded(in: toolbar)
+        insertSaveToolbarItemIfNeeded(in: toolbar)
 
         installFindBar()
         applyWindowBackgroundTheme()

--- a/md-preview/Document/EditExitPolicy.swift
+++ b/md-preview/Document/EditExitPolicy.swift
@@ -1,0 +1,103 @@
+//
+//  EditExitPolicy.swift
+//  md-preview
+//
+//  What happens to unsaved edits when the reader leaves edit mode. Kept free
+//  of AppKit so the SPM helper tests can exercise it without a GUI host.
+//
+
+import Foundation
+
+enum EditExitPolicy {
+    /// What the reader can do with unsaved edits when leaving edit mode.
+    enum ExitChoice: Equatable {
+        /// Write the file, then show the preview.
+        case save
+        /// Show the preview with the edits kept as an unsaved draft, which
+        /// Save can still write later. Nothing touches the disk.
+        case continueUnsaved
+        /// Discard the edits and return to the last saved version. Confirmed
+        /// separately, because it cannot be undone.
+        case revert
+    }
+
+    /// Button order in the leave-edit-mode alert. The first button answers
+    /// Return, so it is Save: Return must never discard anything.
+    static let exitButtonOrder: [ExitChoice] = [.save, .continueUnsaved, .revert]
+
+    /// The choice Escape triggers. Escape in the editor is itself one of the
+    /// ways to leave edit mode, so pressing it again on the alert keeps the
+    /// edits and leaves -- which is what leaving did before the alert existed.
+    static let escapeChoice: ExitChoice = .continueUnsaved
+
+    /// Maps a zero-based alert button index back to its choice. Anything
+    /// unexpected keeps the edits and writes nothing.
+    static func exitChoice(forButtonAt index: Int) -> ExitChoice {
+        exitButtonOrder.indices.contains(index) ? exitButtonOrder[index] : .continueUnsaved
+    }
+
+    /// Whether leaving edit mode should ask what to do with the edits.
+    ///
+    /// Compares the editor's source with the last saved version rather than
+    /// trusting the "has changes" flag: typing and then undoing it leaves
+    /// nothing to decide about, and the flag stays set in that case. An
+    /// unknown saved version asks, since that is the side that loses nothing.
+    static func needsExitPrompt(currentSource: String,
+                                savedSource: String?,
+                                exitsSilently: Bool) -> Bool {
+        guard !exitsSilently else { return false }
+        return currentSource != savedSource
+    }
+
+    // MARK: - Save availability
+
+    /// File › Save (⌘S) and the toolbar Save button share this rule: only
+    /// when there are unsaved changes, in edit mode or after leaving it with
+    /// the changes kept.
+    ///
+    /// The editor reports a change asynchronously, so in principle a ⌘S
+    /// pressed within milliseconds of the last keystroke can arrive before
+    /// that report and beep instead of saving. That is the accepted cost of
+    /// never offering Save when there is nothing to save.
+    static func isSaveCommandEnabled(hasUnsavedChanges: Bool) -> Bool {
+        hasUnsavedChanges
+    }
+
+    /// File › Save As… (⇧⌘S): writes a copy, so it makes sense for any open
+    /// document, changed or not.
+    static func isSaveAsCommandEnabled(hasDocument: Bool) -> Bool {
+        hasDocument
+    }
+
+    /// File › Revert to Saved (⌘R): like Save, only with unsaved changes --
+    /// and only when there is a version on disk to go back to, which an
+    /// untitled document does not have.
+    static func isRevertCommandEnabled(hasUnsavedChanges: Bool, hasFile: Bool) -> Bool {
+        hasFile && hasUnsavedChanges
+    }
+
+    // MARK: - Setting
+
+    static let defaultsKey = "MarkdownPreview.exitsEditModeSilently"
+
+    /// Leave edit mode without asking, keeping unsaved edits as a draft -- the
+    /// behaviour before the prompt existed. Off by default.
+    static var exitsSilently: Bool {
+        get { read(from: .standard) }
+        set { write(newValue, to: .standard) }
+    }
+
+    static func read(from defaults: UserDefaults?) -> Bool {
+        defaults?.bool(forKey: defaultsKey) ?? false
+    }
+
+    /// Off clears the key rather than storing `false`, as the other
+    /// preferences do: an untouched preference leaves no trace.
+    static func write(_ exitsSilently: Bool, to defaults: UserDefaults?) {
+        if exitsSilently {
+            defaults?.set(true, forKey: defaultsKey)
+        } else {
+            defaults?.removeObject(forKey: defaultsKey)
+        }
+    }
+}

--- a/md-preview/Features/Settings/GeneralSettingsView.swift
+++ b/md-preview/Features/Settings/GeneralSettingsView.swift
@@ -70,6 +70,10 @@ struct GeneralSettingsView: View {
                     Text(L("Automatic saving"))
                     Text(L("Save edited documents periodically."))
                 }
+                Toggle(isOn: $model.exitsEditModeSilently) {
+                    Text(L("Leave edit mode without asking to save"))
+                    Text(L("Unsaved changes stay in the window until you save or close it."))
+                }
             } header: {
                 Text(L("Editing"))
             } footer: {

--- a/md-preview/Features/Settings/SettingsModel.swift
+++ b/md-preview/Features/Settings/SettingsModel.swift
@@ -89,6 +89,15 @@ final class SettingsModel {
         }
     }
 
+    /// Read each time a document leaves edit mode, so like the setting above
+    /// it has nothing to apply to open windows.
+    var exitsEditModeSilently: Bool {
+        didSet {
+            guard !isRestoringExternalValues, exitsEditModeSilently != oldValue else { return }
+            EditExitPolicy.exitsSilently = exitsEditModeSilently
+        }
+    }
+
     var opensMarkdownLinksInNewWindows: Bool {
         didSet {
             guard !isRestoringExternalValues else { return }
@@ -257,6 +266,7 @@ final class SettingsModel {
         readerLayout = ReaderLayoutSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         opensDocumentsInTabs = TabOpeningPolicy.isEnabled
+        exitsEditModeSilently = EditExitPolicy.exitsSilently
         opensMarkdownLinksInNewWindows = UserDefaults.standard.bool(forKey: "MarkdownPreview.opensMarkdownLinksInNewWindows")
         sendsCrashReports = CrashReporter.isEnabled
         themeColors = ThemeColorsSetting.current
@@ -312,6 +322,7 @@ final class SettingsModel {
         readerLayout = ReaderLayoutSetting.current
         isAlwaysOnTop = AlwaysOnTopPolicy.isEnabled
         opensDocumentsInTabs = TabOpeningPolicy.isEnabled
+        exitsEditModeSilently = EditExitPolicy.exitsSilently
         opensMarkdownLinksInNewWindows = UserDefaults.standard.bool(forKey: "MarkdownPreview.opensMarkdownLinksInNewWindows")
         sendsCrashReports = CrashReporter.isEnabled
         themeColors = ThemeColorsSetting.current

--- a/md-preview/en.lproj/Localizable.strings
+++ b/md-preview/en.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "Automatic saving" = "Automatic saving";
 "Save edited documents periodically." = "Save edited documents periodically.";
 "Automatic saving runs while a document has unsaved edits." = "Automatic saving runs while a document has unsaved edits.";
+"Leave edit mode without asking to save" = "Leave edit mode without asking to save";
+"Unsaved changes stay in the window until you save or close it." = "Unsaved changes stay in the window until you save or close it.";
 "30 seconds" = "30 seconds";
 "1 minute" = "1 minute";
 "%d minutes" = "%d minutes";
@@ -208,6 +210,14 @@
 "Save" = "Save";
 "Cancel" = "Cancel";
 "Don’t Save" = "Don’t Save";
+"Continue" = "Continue";
+"Revert…" = "Revert…";
+"Revert" = "Revert";
+"Continue keeps your changes to %@ without saving them, so you can save later. Revert… discards them." = "Continue keeps your changes to %@ without saving them, so you can save later. Revert… discards them.";
+"Revert to the last saved version of %@?" = "Revert to the last saved version of %@?";
+"Your unsaved changes will be lost. You can’t undo this action." = "Your unsaved changes will be lost. You can’t undo this action.";
+"Save changes" = "Save changes";
+"No unsaved changes" = "No unsaved changes";
 "The file was removed while it was open." = "The file was removed while it was open.";
 "Recreate File" = "Recreate File";
 "The file could not be read to verify that it is unchanged." = "The file could not be read to verify that it is unchanged.";

--- a/md-preview/zh-Hans.lproj/Localizable.strings
+++ b/md-preview/zh-Hans.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "Automatic saving" = "自动保存";
 "Save edited documents periodically." = "定期保存编辑中的文稿。";
 "Automatic saving runs while a document has unsaved edits." = "文稿有未保存的编辑时，自动保存会运行。";
+"Leave edit mode without asking to save" = "退出编辑模式时不询问是否存储";
+"Unsaved changes stay in the window until you save or close it." = "未存储的更改会保留在窗口中，直到您存储或关闭它。";
 "30 seconds" = "30 秒";
 "1 minute" = "1 分钟";
 "%d minutes" = "%d 分钟";
@@ -208,6 +210,14 @@
 "Save" = "存储";
 "Cancel" = "取消";
 "Don’t Save" = "不存储";
+"Continue" = "继续";
+"Revert…" = "复原…";
+"Revert" = "复原";
+"Continue keeps your changes to %@ without saving them, so you can save later. Revert… discards them." = "“继续”会保留对 %@ 的更改但不存储，您可以稍后再存储。“复原…”会丢弃这些更改。";
+"Revert to the last saved version of %@?" = "要将 %@ 复原到上次存储的版本吗？";
+"Your unsaved changes will be lost. You can’t undo this action." = "未存储的更改将会丢失。此操作无法撤销。";
+"Save changes" = "存储更改";
+"No unsaved changes" = "没有未存储的更改";
 "The file was removed while it was open." = "文件在打开期间被移除。";
 "Recreate File" = "重新创建文件";
 "The file could not be read to verify that it is unchanged." = "无法读取文件，因此无法确认文件是否已更改。";

--- a/tests/swift-tests/Sources/MarkdownHelpers/EditExitPolicy.swift
+++ b/tests/swift-tests/Sources/MarkdownHelpers/EditExitPolicy.swift
@@ -1,0 +1,1 @@
+../../../../md-preview/Document/EditExitPolicy.swift

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/EditExitPolicyTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/EditExitPolicyTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import XCTest
+@testable import MarkdownHelpers
+
+final class EditExitPolicyTests: XCTestCase {
+    private typealias Policy = EditExitPolicy
+
+    func testChangedSourceAsksBeforeLeavingEditMode() {
+        XCTAssertTrue(Policy.needsExitPrompt(currentSource: "edited", savedSource: "saved",
+                                             exitsSilently: false))
+    }
+
+    // Typing and then undoing it leaves nothing to decide about, even though
+    // the editor still reports that it changed.
+    func testSourceMatchingTheSavedVersionLeavesWithoutAsking() {
+        XCTAssertFalse(Policy.needsExitPrompt(currentSource: "saved", savedSource: "saved",
+                                              exitsSilently: false))
+    }
+
+    func testTheSilentSettingNeverAsks() {
+        XCTAssertFalse(Policy.needsExitPrompt(currentSource: "edited", savedSource: "saved",
+                                              exitsSilently: true))
+    }
+
+    func testAnUnknownSavedVersionAsks() {
+        XCTAssertTrue(Policy.needsExitPrompt(currentSource: "edited", savedSource: nil,
+                                             exitsSilently: false))
+    }
+
+    // Return answers the first button and must never discard anything;
+    // Escape must neither discard nor write.
+    func testReturnSavesAndEscapeKeepsTheDraft() {
+        XCTAssertEqual(Policy.exitButtonOrder.first, .save)
+        XCTAssertEqual(Policy.escapeChoice, .continueUnsaved)
+        XCTAssertNotEqual(Policy.exitButtonOrder.first, .revert)
+        XCTAssertNotEqual(Policy.escapeChoice, .revert)
+    }
+
+    func testButtonIndicesMapBackToTheirChoices() {
+        for (index, choice) in Policy.exitButtonOrder.enumerated() {
+            XCTAssertEqual(Policy.exitChoice(forButtonAt: index), choice)
+        }
+        XCTAssertEqual(Policy.exitButtonOrder.count, 3)
+    }
+
+    func testAnUnexpectedResponseKeepsTheDraftAndWritesNothing() {
+        XCTAssertEqual(Policy.exitChoice(forButtonAt: -1), .continueUnsaved)
+        XCTAssertEqual(Policy.exitChoice(forButtonAt: 99), .continueUnsaved)
+    }
+
+    // Leaving edit mode can keep unsaved changes as a draft. File › Save and
+    // ⌘S used to be disabled at that point although the save itself handled
+    // it, so the draft could only be written by closing the window.
+    func testSaveIsAvailableForUnsavedChanges() {
+        XCTAssertTrue(Policy.isSaveCommandEnabled(hasUnsavedChanges: true))
+    }
+
+    // In edit mode or out of it: with nothing to save, Save is not offered.
+    func testSaveIsNotOfferedWithNothingToSave() {
+        XCTAssertFalse(Policy.isSaveCommandEnabled(hasUnsavedChanges: false))
+    }
+
+    func testRevertNeedsUnsavedChangesAndAFileToGoBackTo() {
+        XCTAssertTrue(Policy.isRevertCommandEnabled(hasUnsavedChanges: true, hasFile: true))
+        XCTAssertFalse(Policy.isRevertCommandEnabled(hasUnsavedChanges: false, hasFile: true))
+    }
+
+    func testAnUntitledDocumentHasNothingToRevertTo() {
+        XCTAssertFalse(Policy.isRevertCommandEnabled(hasUnsavedChanges: true, hasFile: false))
+    }
+
+    // Save As… writes a copy, so it is offered whether or not anything changed.
+    func testSaveAsIsAvailableForAnyOpenDocument() {
+        XCTAssertTrue(Policy.isSaveAsCommandEnabled(hasDocument: true))
+    }
+
+    func testSaveAsNeedsADocument() {
+        XCTAssertFalse(Policy.isSaveAsCommandEnabled(hasDocument: false))
+    }
+
+    func testThePromptIsOnWhenNothingHasBeenStored() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(Policy.read(from: defaults))
+        XCTAssertFalse(Policy.read(from: nil))
+    }
+
+    func testTheSettingRoundTripsAndClearsItsKeyWhenOff() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        Policy.write(true, to: defaults)
+        XCTAssertTrue(Policy.read(from: defaults))
+
+        Policy.write(false, to: defaults)
+        XCTAssertFalse(Policy.read(from: defaults))
+        XCTAssertNil(defaults.object(forKey: Policy.defaultsKey))
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "doc.md-preview.tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}


### PR DESCRIPTION
Closes #378

- **Save button** available in Customize Toolbar — not in the default toolbar. Icon-only, like the other items. Enabled only while there are unsaved changes, in edit mode or after leaving it.
- **Leaving edit mode** — toolbar, ⌘E or Escape — with changes asks **Save / Revert… / Continue**. Continue, also on Escape, keeps the changes as an unsaved draft, which is what leaving did before. Revert asks for confirmation first. There is no prompt when the source matches the last save.
- **Setting:** General › Editing › *Leave edit mode without asking to save* restores the silent exit. Off by default.
- **Save As… and Revert to Saved**, previously always disabled, now work. Save As… is available for any open document, changed or not; it writes to a file chosen in a save panel and the window follows it. Revert to Saved, like Save, needs unsaved changes — and a file to go back to, so not for untitled documents. It asks first, then returns to the version on disk: in place while editing, or by dropping the kept draft in preview. This makes ⌘R live whenever there is something to revert.
- **Fix:** File › Save and ⌘S were disabled after leaving edit mode with unsaved changes, although `saveDocument(_:)` handles that case — and enabled while editing even with nothing to save. They now follow unsaved changes, exactly as the button does.

Exiting was silent by design, so this changes deliberate behaviour; the setting keeps the old one available. Close, navigate and quit keep their existing Save / Cancel / Don't Save prompt.

**Testing**

- `EditExitPolicy` holds the decisions — when to prompt, button order, when Save, Save As… and Revert to Saved are available, the setting — and `EditExitPolicyTests` covers them. Each rule was mutation-checked: breaking it fails a test.
- UI checked by hand on macOS 26.6.2:
  - Leaving edit mode with no real change (typing then undoing included) does not prompt.
  - A fresh toolbar has no Save button; Customize Toolbar offers it, and once added it is icon-only. It is enabled only with unsaved changes; saving from it stays in edit mode, and the next keystroke re-enables it.
  - All three exits raise the prompt: toolbar, ⌘E, and Escape in the editor.
  - Save writes and returns to preview. Continue, by click or Escape, keeps the draft, and ⌘S or File › Save then writes it.
  - Revert… asks first. Escape on the confirmation cancels and keeps the edits; Revert restores the last saved version.
  - With the setting on there is no prompt, the draft is kept and ⌘S still writes it; switching the setting applies on the next exit without reopening the window.
  - The existing prompts are unchanged: an external change still raises the conflict alert on Save, and closing a window with a kept draft still asks Save / Don't Save / Cancel.
  - An untitled document's Save button opens the save panel.
  - File › Save, Save As… and Revert to Saved are enabled as described above — checked clean in preview, clean in edit mode, edited, and with a kept draft.
  - Save As… opens a save panel pre-filled with the current file's name and folder. With or without changes it writes the new file and the window follows it; the original is untouched; Cancel changes nothing.
  - Revert to Saved and ⌘R share the confirmation. While editing it reloads the saved version in place and editing continues; in preview it drops the kept draft; with nothing changed it is disabled.
- The zh-Hans strings need a native speaker's check.

**AppKit details a reviewer may wonder about**

- The buttons read Save / Revert… / Continue because AppKit puts the Escape button last, as in the system's own Save / Delete / Cancel alert.
- The Revert confirmation has no Return default: Cancel takes Escape, Revert is marked destructive, and Return does nothing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Save, Save As, and Revert to Saved actions.
  * Added prompts when leaving edit mode with unsaved changes, including options to save, continue, or revert.
  * Added an option to leave edit mode silently while retaining unsaved changes.
  * Added Save toolbar support with state-aware availability and tooltips.
  * Added English and Simplified Chinese translations for related dialogs and settings.
* **Documentation**
  * Expanded Edit Mode documentation.
* **Tests**
  * Added coverage for exit prompts, command availability, and preference persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=65837707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge after considering two non-blocking UI correctness issues around Save As asset resolution and stale command availability after undo.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Editor Keeps Old Asset Base** <a href="https://github.com/pluk-inc/markdown-preview/pull/379#discussion_r4042984558">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Undo Leaves Commands Enabled** <a href="https://github.com/pluk-inc/markdown-preview/pull/379#discussion_r4042984562">▶</a>

<details open><summary>Summary</summary>

This PR adds explicit edit-exit decisions, an optional Save toolbar item, functional Save As and Revert commands, and a preference that restores silent edit-mode exits. It also updates localization, documentation, and policy-level tests.

- Routes toolbar, Command-E, and Escape exits through a Save / Continue / Revert decision.
- Makes Save, Save As, and Revert availability depend on document and dirty state.
- Adds Save As destination-following and on-disk revert behavior.
- Adds the silent-exit setting and English/Simplified Chinese strings.
- Adds focused tests for `EditExitPolicy`.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Leave edit mode] --> B{Source differs from saved baseline?}
  B -->|No| C[Show preview]
  B -->|Yes, silent setting enabled| D[Keep unsaved draft and show preview]
  B -->|Yes| E[Save / Continue / Revert prompt]
  E -->|Save| F[Commit edits]
  F --> G[Show preview]
  E -->|Continue| D
  E -->|Revert| H[Confirm destructive revert]
  H -->|Confirm| I[Adopt version from disk]
  H -->|Cancel| J[Remain in edit mode]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["Merge branch &#39;main&#39; into contrib/save-bu..."](https://github.com/pluk-inc/markdown-preview/commit/8743755c2e74bad4d65b2e1b7899a1d617802ca6)</sub>

<!-- /greptile_comment -->