### PR TITLE
Add Quick Look troubleshooting docs and dev-handler repair script

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ Bump `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in `Version.xcconfig`, th
 
 Use `./scripts/rollback-release.sh` to revert the appcast pointer if a release misbehaves.
 
+## Troubleshooting
+
+### Quick Look spins forever on files inside another app's container
+
+Pressing Space in Finder on a Markdown file stored under another app's sandbox container — for example files received via WeChat, which live under `~/Library/Containers/com.tencent.xinWeChat/…` — shows an endless spinner. This is a macOS limitation, not a bug the extension can fix: Finder hosts third-party Quick Look extensions through Apple's `QLPreviewGenerationExtension`, which fails on items under `~/Library/Containers/<other-app>/` before any extension code runs (it asserts in `QLPreviewExtensionViewController.m` and the panel retries forever). Files in regular locations preview fine, and double-clicking always works.
+
+Workarounds:
+
+- Double-click the file to open it in Markdown Preview.
+- Copy or move the file out of the container.
+- In WeChat, change 设置 → 通用 → 文件管理 to a regular folder so received files land outside the container.
+
+### Running the Debug build breaks Finder Quick Look for `.md` files
+
+The Debug build uses bundle id `doc.md-preview.dev`. Opening a Markdown file with it once makes that bundle the persisted default handler for `net.daringfireball.markdown` in `com.apple.launchservices.secure.plist` — and that entry survives DerivedData cleanup. While it dangles, every Finder Space-press on a `.md` file spins for ~45s while Quick Look's "appex record" lookup dead-ends, even though `LSCopyDefaultRoleHandlerForContentType` reports the release bundle (the layers disagree). Repair with:
+
+```sh
+./scripts/fix-md-handlers.sh        # or --dry-run / --check
+```
+
 ## Contributing
 
 Pull requests are welcome. For larger changes, please open an issue first to discuss what you'd like to change.

--- a/scripts/fix-md-handlers.sh
+++ b/scripts/fix-md-handlers.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Repair LaunchServices handler preferences that still point at the Debug
+# build after its bundle went away.
+#
+# Running the app from Xcode registers `doc.md-preview.dev` with
+# LaunchServices, and opening a Markdown file with it once makes that bundle
+# the persisted default handler for `net.daringfireball.markdown` (and other
+# Markdown UTIs). The persisted preference lives in
+# ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist
+# and is NOT cleaned up when DerivedData is wiped. Quick Look's
+# "appex record for item" resolution follows the persisted layer, so every
+# Finder Space-press on a .md file then spins while the lookup dead-ends on
+# the missing dev bundle — LSCopyDefaultRoleHandlerForContentType happily
+# falls back at the same time, which is why the breakage is so confusing.
+#
+# This script repoints those entries at the installed release bundle
+# (`doc.md-preview`) and restarts lsd so the change sticks.
+#
+# Usage:
+#   scripts/fix-md-handlers.sh             Fix entries (backs up the plist first)
+#   scripts/fix-md-handlers.sh --dry-run   Only print what would change
+#   scripts/fix-md-handlers.sh --check     Exit 1 if dangling entries exist
+
+set -euo pipefail
+
+PLIST="$HOME/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+DEV_ID="doc.md-preview.dev"
+RELEASE_ID="doc.md-preview"
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+MODE="fix"
+case "${1:-}" in
+    --dry-run) MODE="dry-run" ;;
+    --check)   MODE="check" ;;
+    "")        ;;
+    *) echo "usage: $0 [--dry-run|--check]" >&2; exit 2 ;;
+esac
+
+if [[ ! -f "$PLIST" ]]; then
+    echo "No LaunchServices preference plist at $PLIST — nothing to fix."
+    exit 0
+fi
+
+# If the dev bundle is actually registered, the election is live, not stale.
+if "$LSREGISTER" -dump 2>/dev/null | grep -q "identifier: *$DEV_ID"; then
+    echo "$DEV_ID is currently registered (a Debug build is alive)."
+    echo "Nothing to repair — delete/clean that build first if it should stop owning the handler."
+    exit 0
+fi
+
+ENTRY_COUNT=$(/usr/libexec/PlistBuddy -c "Print :LSHandlers" "$PLIST" 2>/dev/null | grep -c "Dict {" || true)
+if [[ "$ENTRY_COUNT" -eq 0 ]]; then
+    echo "No LSHandlers entries found — nothing to fix."
+    exit 0
+fi
+
+MATCHING=()
+for ((i = 0; i < ENTRY_COUNT; i++)); do
+    role=$(/usr/libexec/PlistBuddy -c "Print :LSHandlers:$i:LSHandlerRoleAll" "$PLIST" 2>/dev/null || true)
+    if [[ "$role" == "$DEV_ID" ]]; then
+        uti=$(/usr/libexec/PlistBuddy -c "Print :LSHandlers:$i:LSHandlerContentType" "$PLIST" 2>/dev/null \
+              || /usr/libexec/PlistBuddy -c "Print :LSHandlers:$i:LSHandlerURLScheme" "$PLIST" 2>/dev/null \
+              || echo "(unnamed)")
+        MATCHING+=("$i")
+        echo "dangling: [$i] $uti -> $DEV_ID"
+    fi
+done
+
+if [[ ${#MATCHING[@]} -eq 0 ]]; then
+    echo "No handler entries point at $DEV_ID — LaunchServices preferences are healthy."
+    exit 0
+fi
+
+if [[ "$MODE" == "check" ]]; then
+    echo "Found ${#MATCHING[@]} dangling entries — run scripts/fix-md-handlers.sh to repair."
+    exit 1
+fi
+
+if [[ "$MODE" == "dry-run" ]]; then
+    echo "dry-run: would repoint ${#MATCHING[@]} entries to $RELEASE_ID and restart lsd."
+    exit 0
+fi
+
+BACKUP="/tmp/launchservices.secure.backup.$(date +%Y%m%d%H%M%S).plist"
+cp "$PLIST" "$BACKUP"
+echo "backup: $BACKUP"
+
+for i in "${MATCHING[@]}"; do
+    /usr/libexec/PlistBuddy -c "Set :LSHandlers:$i:LSHandlerRoleAll $RELEASE_ID" "$PLIST"
+done
+
+killall lsd 2>/dev/null || true
+qlmanage -r >/dev/null 2>&1 || true
+qlmanage -r cache >/dev/null 2>&1 || true
+
+echo "Repaired ${#MATCHING[@]} entries: $DEV_ID -> $RELEASE_ID (lsd restarted, Quick Look cache reset)."


### PR DESCRIPTION
## Summary

- Adds `scripts/fix-md-handlers.sh` to repair the persisted LaunchServices handler entry for Markdown UTIs after a Debug build (`doc.md-preview.dev`) claimed it and its bundle went away (DerivedData cleanup). While dangling, every Finder Space-press on a `.md` file spins ~45s while Quick Look's appex-record lookup dead-ends on the missing dev bundle — even though `LSCopyDefaultRoleHandlerForContentType` happily reports the release bundle, which makes the breakage near-impossible to spot. The script backs up the plist, repoints the entry at `doc.md-preview`, restarts `lsd`, and resets the Quick Look cache. `--dry-run` and `--check` modes included.
- Documents both known Finder Quick Look failure modes in the README:
  - the dangling dev-handler election above (fix: run the script), and
  - files under `~/Library/Containers/<other-app>/…` (e.g. WeChat downloads) spin forever because Apple's `QLPreviewGenerationExtension` host asserts before any third-party appex launches — an macOS limitation with no app-side fix; workarounds listed.

## What's in this PR

- `scripts/fix-md-handlers.sh` (new)
- `README.md` — new Troubleshooting section

## Test plan

- [x] `scripts/fix-md-handlers.sh --check` reports healthy on a fixed machine
- [x] Re-poisoned the plist entry manually, verified `--dry-run` output, ran the real fix, confirmed the entry is repointed via PlistBuddy and `lsregister -dump`
- [x] Confirmed a clean `.md` file previews instantly in Finder after the repair