### PR TITLE
Show a concrete error page when Quick Look can't read a file

### DIFF
--- a/quick-look/PreviewProvider.swift
+++ b/quick-look/PreviewProvider.swift
@@ -26,7 +26,6 @@ class PreviewProvider: QLPreviewProvider, QLPreviewingController {
             "[mdp-perf-ql] provide start \(request.fileURL.lastPathComponent, privacy: .public)"
         )
         #endif
-        let text = try String(contentsOf: request.fileURL, encoding: .utf8)
         let appearanceMode = AppearanceMode.current
         let colorScheme: MarkdownHTML.ColorScheme
         switch appearanceMode {
@@ -41,6 +40,32 @@ class PreviewProvider: QLPreviewProvider, QLPreviewingController {
         case .dark:
             colorScheme = .dark
         }
+        let text: String
+        do {
+            text = try String(contentsOf: request.fileURL, encoding: .utf8)
+        } catch {
+            // A rendered page with the concrete reason beats a thrown error,
+            // which the host shows as an empty preview.
+            let errorHTML = MarkdownHTML.makeHTML(
+                from: QuickLookErrorPage.makeMarkdown(
+                    for: error,
+                    fileURL: request.fileURL
+                ),
+                allowsScroll: true,
+                colorScheme: colorScheme
+            )
+            return QLPreviewReply(
+                dataOfContentType: .html,
+                contentSize: CGSize(
+                    width: MarkdownHTML.preferredPageWidth,
+                    height: MarkdownHTML.preferredPageWidth
+                )
+            ) { replyToUpdate in
+                replyToUpdate.stringEncoding = .utf8
+                return Data(errorHTML.utf8)
+            }
+        }
+
         let renderedHTML = MarkdownHTML.makeHTML(
             from: text,
             allowsScroll: true,

--- a/quick-look/PreviewViewController.swift
+++ b/quick-look/PreviewViewController.swift
@@ -586,7 +586,6 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     func preparePreviewOfFile(at url: URL) async throws {
-        let text = try String(contentsOf: url, encoding: .utf8)
         let appearanceMode = AppearanceMode.current
         let colorScheme: MarkdownHTML.ColorScheme
         switch appearanceMode {
@@ -598,6 +597,22 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             colorScheme = .light
         case .dark:
             colorScheme = .dark
+        }
+
+        let text: String
+        do {
+            text = try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            // Surfacing the concrete reason beats throwing, which leaves the
+            // panel blank while the user wonders what went wrong.
+            loadErrorPage(
+                MarkdownHTML.makeHTML(
+                    from: QuickLookErrorPage.makeMarkdown(for: error, fileURL: url),
+                    allowsScroll: true,
+                    colorScheme: colorScheme
+                )
+            )
+            return
         }
 
         let renderedHTML = addingCopyButtonClearance(to: MarkdownHTML.makeHTML(
@@ -624,6 +639,19 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             // would let WebKit fetch rejected or over-budget relative images.
             baseURL: nil
         )
+    }
+
+    /// Loads a rendered error page instead of the document. The copy button
+    /// stays disabled (there is no source to copy) and cursor regions are
+    /// cleared so the previous document's hover regions don't leak through.
+    private func loadErrorPage(_ html: String) {
+        loadViewIfNeeded()
+        markdownSource = nil
+        isPreviewReady = false
+        resetCopyButton()
+        copyButton.isEnabled = false
+        webView.clearCursorRegions()
+        currentNavigation = webView.loadHTMLString(html, baseURL: nil)
     }
 
     // Quick Look opens with keyboard focus in the host (Finder), so ⌘A/⌘C

--- a/quick-look/QuickLookErrorPage.swift
+++ b/quick-look/QuickLookErrorPage.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Markdown source for the page shown when a Quick Look preview cannot read
+/// its file. Rendering the page through the normal `MarkdownHTML` pipeline
+/// keeps the app's theme; showing the concrete error (description, domain,
+/// code) plus a hint turns a blank pane into something the user can act on.
+enum QuickLookErrorPage {
+
+    static func makeMarkdown(for error: Error, fileURL: URL) -> String {
+        let title = NSLocalizedString(
+            "Couldn't preview this file",
+            comment: "Quick Look error page title"
+        )
+        let lead = NSLocalizedString(
+            "couldn't be read for preview.",
+            comment: "Quick Look error page lead-in after the file name"
+        )
+        let errorLabel = NSLocalizedString(
+            "Error",
+            comment: "Quick Look error page label for the error description"
+        )
+        let domainLabel = NSLocalizedString(
+            "Domain",
+            comment: "Quick Look error page label for the error domain"
+        )
+        let pathLabel = NSLocalizedString(
+            "Path",
+            comment: "Quick Look error page label for the file path"
+        )
+
+        let nsError = error as NSError
+        let lines: [String] = [
+            "# \(title)",
+            "",
+            "**\(escaped(fileURL.lastPathComponent))** \(lead)",
+            "",
+            "- **\(errorLabel):** \(escaped(error.localizedDescription))",
+            "- **\(domainLabel):** \(escaped(nsError.domain)) (\(nsError.code))",
+            "- **\(pathLabel):** \(escaped(fileURL.path))",
+            "",
+            "> \(hint(for: fileURL))",
+        ]
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Advice tailored to where the file lives. Files inside another app's
+    /// sandbox container (`~/Library/Containers/<bundle-id>/…`, e.g. WeChat
+    /// downloads) are off-limits to Quick Look extensions on macOS — no app
+    /// can change that, so the page says so instead of failing silently.
+    private static func hint(for fileURL: URL) -> String {
+        if fileURL.path.contains("/Library/Containers/") {
+            return NSLocalizedString(
+                "This file is inside another app's sandbox container, which macOS keeps off-limits to Quick Look. Double-click the file to open it in Markdown Preview, or copy it to a regular folder and preview the copy.",
+                comment: "Quick Look error page hint for files in an app container"
+            )
+        }
+        return NSLocalizedString(
+            "Double-click the file to open it in Markdown Preview. If that also fails, check the file's permissions with Finder's Get Info (⌘I).",
+            comment: "Quick Look error page hint for unreadable files"
+        )
+    }
+
+    /// Backslash-escapes every ASCII punctuation character so interpolated
+    /// values (file names, localized error descriptions) can never light up
+    /// markdown syntax or inline HTML once rendered.
+    static func escaped(_ text: String) -> String {
+        var escaped = String()
+        escaped.reserveCapacity(text.count)
+        for scalar in text.unicodeScalars {
+            if escapableCharacters.contains(scalar) {
+                escaped.append("\\")
+            }
+            escaped.append(Character(scalar))
+        }
+        return escaped
+    }
+
+    // CommonMark only honors backslash escapes for ASCII punctuation, so
+    // escaping that full set is both necessary and sufficient.
+    private static let escapableCharacters: Set<Unicode.Scalar> = Set(
+        "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".unicodeScalars
+    )
+}

--- a/tests/swift-tests/Sources/QuickLookHelpers/QuickLookErrorPage.swift
+++ b/tests/swift-tests/Sources/QuickLookHelpers/QuickLookErrorPage.swift
@@ -1,0 +1,1 @@
+../../../../quick-look/QuickLookErrorPage.swift

--- a/tests/swift-tests/Tests/QuickLookHelperTests/QuickLookErrorPageTests.swift
+++ b/tests/swift-tests/Tests/QuickLookHelperTests/QuickLookErrorPageTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import QuickLookHelpers
+
+final class QuickLookErrorPageTests: XCTestCase {
+
+    // MARK: - Markdown escaping
+
+    func testEscapingNeutralizesMarkdownAndHTMLSyntax() {
+        let hostile = "*_`<script>alert(\"&\")</script> [link](x) #{}end"
+        let escaped = QuickLookErrorPage.escaped(hostile)
+        XCTAssertEqual(
+            escaped,
+            "\\*\\_\\`\\<script\\>alert\\(\\\"\\&\\\"\\)\\<\\/script\\> \\[link\\]\\(x\\) \\#\\{\\}end"
+        )
+        // …so no raw HTML or emphasis markup survives.
+        XCTAssertFalse(escaped.contains("<script>"))
+        XCTAssertFalse(escaped.contains("[link]"))
+    }
+
+    func testEscapingLeavesPlainWordsAlone() {
+        XCTAssertEqual(QuickLookErrorPage.escaped("notes 2026 v1 final"), "notes 2026 v1 final")
+    }
+
+    // MARK: - Page content
+
+    private let readError = CocoaError(.fileReadNoPermission)
+
+    func testPageIncludesFileNameErrorAndDomain() {
+        let url = URL(fileURLWithPath: "/Users/ada/Documents/notes *draft*.md")
+        let markdown = QuickLookErrorPage.makeMarkdown(for: readError, fileURL: url)
+        XCTAssertTrue(markdown.contains("notes \\*draft\\*\\.md"))
+        XCTAssertTrue(markdown.contains(QuickLookErrorPage.escaped(readError.localizedDescription)))
+        XCTAssertTrue(markdown.contains("NSCocoaErrorDomain"))
+        XCTAssertTrue(markdown.contains("\(readError.errorCode)"))
+        XCTAssertTrue(markdown.contains(QuickLookErrorPage.escaped("/Users/ada/Documents")))
+    }
+
+    func testContainerPathGetsContainerHint() {
+        let url = URL(fileURLWithPath:
+            "/Users/ada/Library/Containers/com.tencent.xinWeChat/Data/Documents/files/report.md")
+        let markdown = QuickLookErrorPage.makeMarkdown(for: readError, fileURL: url)
+        XCTAssertTrue(markdown.contains("sandbox container"))
+    }
+
+    func testRegularPathGetsGenericHintOnly() {
+        let url = URL(fileURLWithPath: "/Users/ada/Documents/report.md")
+        let markdown = QuickLookErrorPage.makeMarkdown(for: readError, fileURL: url)
+        XCTAssertFalse(markdown.contains("sandbox container"))
+        XCTAssertTrue(markdown.contains("Double-click"))
+    }
+}


### PR DESCRIPTION
## Summary

When `String(contentsOf:)` fails in either Quick Look entry point (`PreviewViewController.preparePreviewOfFile` / `PreviewProvider.providePreview`), the extension used to `throw`, and the host showed a blank or generic pane with no explanation. It now renders an error page through the normal `MarkdownHTML` pipeline (same theme/color-scheme handling as regular previews) with:

- the file name,
- the underlying error (localized description, domain, code),
- the full path, and
- a location-aware hint:
  - files under `~/Library/Containers/<app>/…` (e.g. WeChat downloads) are told macOS keeps app-container files off-limits to Quick Look, and to open the file in Markdown Preview or copy it out first;
  - everything else gets a check-permissions hint (Finder ⌘I).

ASCII punctuation in interpolated details (file names, localized error strings, domains, paths) is encoded as numeric character references. Math preprocessing therefore leaves parentheses, brackets, backslashes, and dollar signs literal; CommonMark decodes the references as text without treating them as Markdown or raw HTML syntax. The copy button stays disabled on the error page (there is no Markdown source to copy).

## Scope note

This covers every host that actually runs the extension (app-embedded `QLPreviewPanel`s, `qlmanage`, the direct-hosting fallback). It deliberately cannot cover the pure-Finder case where the item lives in another app's container: macOS's own `QLPreviewGenerationExtension` host asserts before any third-party appex is launched there, so no extension code executes at all (see the README Troubleshooting section added in #380).

## Test plan

- [x] `swift test --package-path tests/swift-tests --filter QuickLookErrorPageTests` — 8 tests pass. The new regression test reproduced missing brackets and generated math nodes before the fix.
- [x] Runtime rendering through `MarkdownHTML.makeHTML` and `WKWebView`: DOM assertions verify exact file name, path, error description, and domain for parentheses, square brackets, explicit math delimiters, HTML/Markdown syntax, literal entity text, and Unicode. No unintended math, script, link, emphasis, or code elements appear in these fixtures.
- [x] `xcodebuild -project md-preview.xcodeproj -scheme md-preview -configuration Debug build CODE_SIGNING_ALLOWED=NO` — app and Quick Look extension build succeeds; signing settings unchanged.
- [ ] Finder/Quick Look host integration remains unverified. The WebKit runtime test verifies the generated error page, not macOS host activation or unreadable-file handling end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quick Look previews now display a helpful error page when Markdown files cannot be read, instead of appearing blank.
  * Copy is enabled only when preview content is available.
  * Error messages include relevant file details, technical error information, and recovery guidance tailored to the file location.

* **Tests**
  * Added coverage for error details, path-specific guidance, escaping, and safe formatting of displayed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=65837705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears functionally sound, but the repository’s required runtime verification of the actual Quick Look host flow and disabled Copy state remains outstanding before merge.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Runtime verification is missing** <a href="https://github.com/pluk-inc/markdown-preview/pull/383#discussion_r4056546183">▶</a>

<details open><summary>Summary</summary>

This PR replaces Quick Look read failures with a themed, actionable error page and keeps Copy disabled when no Markdown source is available.
- Adds location-aware guidance and safely renders file and error details as literal text.
- Handles failures in both Quick Look entry points.
- Adds unit and WebKit rendering coverage for escaping, displayed details, and guidance selection.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Quick Look requests file] --> B{UTF-8 read succeeds?}
  B -->|Yes| C[Render Markdown preview]
  B -->|No| D[Build escaped error Markdown]
  D --> E[Render through MarkdownHTML]
  E --> F[Display error page]
  F --> G[Keep Copy disabled]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["Keep Quick Look error details literal th..."](https://github.com/pluk-inc/markdown-preview/commit/18523e78c42e3dc691779fc5f3a4ecbe78728b06)</sub>

<!-- /greptile_comment -->