### PR TITLE
Support .mdx files

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -42,6 +42,7 @@
 				<string>doc.md-preview.mdwn</string>
 				<string>doc.md-preview.mdtxt</string>
 				<string>doc.md-preview.mdtext</string>
+				<string>doc.md-preview.mdx</string>
 			</array>
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).MarkdownDocument</string>
@@ -156,6 +157,23 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>mdtext</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document (mdx)</string>
+			<key>UTTypeIdentifier</key>
+			<string>doc.md-preview.mdx</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdx</string>
 				</array>
 			</dict>
 		</dict>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Or grab the latest signed and notarized DMG from the [Releases](https://github.c
 
 ## Supported file types
 
-`.md`, `.markdown`, `.mdown`, `.txt`
+`.md`, `.markdown`, `.mdown`, `.mdx`, `.txt`
 UTI: `net.daringfireball.markdown`
 
 ## Requirements

--- a/md-preview/App/MarkdownDocumentController.swift
+++ b/md-preview/App/MarkdownDocumentController.swift
@@ -7,7 +7,7 @@ import Cocoa
 import UniformTypeIdentifiers
 
 final class MarkdownDocumentController: NSDocumentController {
-    private static let markdownFileExtensions = ["md", "markdown", "mdown", "txt"]
+    private static let markdownFileExtensions = ["md", "markdown", "mdown", "mdx", "txt"]
 
     override func beginOpenPanel(
         _ openPanel: NSOpenPanel,

--- a/md-preview/Document/DocumentWindowController+OpenTargets.swift
+++ b/md-preview/Document/DocumentWindowController+OpenTargets.swift
@@ -472,7 +472,7 @@ extension DocumentWindowController {
 
     // MARK: - Open With
 
-    static let markdownFileExtensions = ["md", "markdown", "mdown", "txt"]
+    static let markdownFileExtensions = ["md", "markdown", "mdown", "mdx", "txt"]
 
     func makeOpenWithItem() -> NSToolbarItem {
         let item = NSMenuToolbarItem(itemIdentifier: .openWith)

--- a/md-preview/Features/OpenWith/OpenTargetCatalog.swift
+++ b/md-preview/Features/OpenWith/OpenTargetCatalog.swift
@@ -122,7 +122,7 @@ enum OpenTargetCatalog {
 
     // MARK: - Editors
 
-    private static let markdownDocTypeExtensions: Set<String> = ["md", "markdown", "mdown"]
+    private static let markdownDocTypeExtensions: Set<String> = ["md", "markdown", "mdown", "mdx"]
     private static let strongMarkdownUTIs: Set<String> = ["net.daringfireball.markdown"]
     private static let plainTextUTIs: Set<String> = [
         "public.plain-text", "public.text",

--- a/md-preview/Features/Sidebar/ProjectNavigatorView.swift
+++ b/md-preview/Features/Sidebar/ProjectNavigatorView.swift
@@ -6,7 +6,7 @@
 import Cocoa
 
 private final class FileNode {
-    static let markdownExtensions: Set<String> = ["md", "markdown", "mdown", "mkd", "mdwn"]
+    static let markdownExtensions: Set<String> = ["md", "markdown", "mdown", "mkd", "mdwn", "mdx"]
 
     let url: URL
     let isDirectory: Bool

--- a/md-preview/Rendering/MarkdownWebView.swift
+++ b/md-preview/Rendering/MarkdownWebView.swift
@@ -1582,7 +1582,7 @@ final class MarkdownWebView: NSView, WKNavigationDelegate {
     }
 
     private static func isMarkdownDocument(_ url: URL) -> Bool {
-        ["md", "markdown", "mdown", "mkdn", "mkd"].contains(url.pathExtension.lowercased())
+        ["md", "markdown", "mdown", "mkdn", "mkd", "mdx"].contains(url.pathExtension.lowercased())
     }
 
     private static func reattachingFragment(of source: URL, to target: URL) -> URL {

--- a/quick-look/Info.plist
+++ b/quick-look/Info.plist
@@ -20,6 +20,7 @@
 				<string>doc.md-preview.mdwn</string>
 				<string>doc.md-preview.mdtxt</string>
 				<string>doc.md-preview.mdtext</string>
+				<string>doc.md-preview.mdx</string>
 			</array>
 			<key>QLSupportsSearchableItems</key>
 			<false/>


### PR DESCRIPTION
Follows the long-tail extension pattern from #40. `.mdx` gets an exported app-private UTI (`doc.md-preview.mdx`) that conforms to `net.daringfireball.markdown`, and is claimed on the existing Markdown document type and in Quick Look.

The open panel, project navigator, in-document Markdown links, and Open With editor heuristic now treat `.mdx` the same way as the other Markdown extensions. README lists it under supported file types.

MDX is opened and rendered as Markdown. JSX is not compiled or executed.

Validation:
- Swift helper suites: 267 tests executed, one skipped, zero failures. Quick Look helpers: 33 tests, zero failures.
- Debug app and Quick Look extension build succeeded with `CODE_SIGNING_ALLOWED=NO`.
- Built app and Quick Look extension Info.plist both declare `doc.md-preview.mdx`.
- Debug build launched with a `.mdx` file.

## Test plan

- [ ] Double-click `foo.mdx` after a fresh install and confirm Markdown Preview opens it
- [ ] File > Open lists and opens `.mdx`
- [ ] Finder Quick Look (spacebar) renders a `.mdx` preview
- [ ] A folder that contains `.mdx` files shows them in the project navigator
- [ ] A Markdown link to a sibling `.mdx` file opens in the app


Made with [Cursor](https://cursor.com)