### PR TITLE
Fix bullet marker spacing

### DIFF
--- a/md-preview/Features/Editor/EditorViewController.swift
+++ b/md-preview/Features/Editor/EditorViewController.swift
@@ -694,7 +694,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             width: 2.1em;
             text-indent: 0;
             text-align: end;
-            padding-inline-end: 0.5em;
+            padding-inline-end: 0.75em;
             box-sizing: border-box;
             /* The glyph keeps its box for alignment but renders transparent;
                the ::after circle below matches the preview's painted bullet. */
@@ -704,9 +704,9 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
         .cm-md-bullet::after {
             content: "";
             position: absolute;
-            /* Match the preview's 0.5em gap between the circle and the
+            /* Match the preview's 0.75em gap between the circle and the
                item text. */
-            inset-inline-end: 0.5em;
+            inset-inline-end: 0.75em;
             top: 50%;
             transform: translateY(-50%);
             width: 0;
@@ -722,7 +722,7 @@ final class EditorViewController: NSViewController, WKNavigationDelegate {
             width: 2.1em;
             text-indent: 0;
             text-align: end;
-            padding-inline-end: 0.5em;
+            padding-inline-end: 0.75em;
             box-sizing: border-box;
             color: var(--secondary);
         }

--- a/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
+++ b/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
@@ -53,7 +53,7 @@ nonisolated extension MarkdownHTML {
         --hl-attribute: #815f03;
         --hl-url: #0e0eff;
         --mdp-list-indent: 2.1em;
-        --mdp-list-gap: 0.5em;
+        --mdp-list-gap: 0.75em;
     }
     :root[data-mdp-color-scheme="light"] {
         color-scheme: light;

--- a/samples/bullet-marker-spacing.md
+++ b/samples/bullet-marker-spacing.md
@@ -1,0 +1,28 @@
+# Bullet marker spacing
+
+Each marker should be round, vertically centered, and visibly separated from the first letter at every text size and with every document font.
+
+<details open>
+<summary><strong>Expanded details with a Markdown list</strong></summary>
+
+- [Every linked item needs a clear marker gap.](../README.md)
+- Run `inline code` after the marker without touching it.
+- One item wraps onto a second line so its continuation stays aligned with the first letter rather than the marker or the page edge. This sentence is deliberately long enough to wrap in a normal document window.
+- Never let an uppercase vertical stroke merge with the marker.
+- New files and proportional fonts should behave alike.
+- Tests: punctuation immediately after the first word should not matter.
+- Non-public methods provide a hyphenated first word.
+- Comments begin with a round letter.
+- Exact values include `--mdp-list-gap` and other code.
+
+</details>
+
+- Parent item
+  - Nested item beginning with a vertical stroke
+  - Another nested item that wraps onto a second line so nested continuation alignment is easy to inspect at a glance in the preview.
+
+1. Ordered markers remain right-aligned.
+2. Ordered list text keeps the same visual gap.
+
+- [ ] An unchecked task keeps its checkbox gap.
+- [x] A checked task keeps its checkbox gap.

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -517,7 +517,7 @@ final class MarkdownHTMLRenderTests: XCTestCase {
     @MainActor
     func testUnorderedListMarkersStayClearOfTextForEveryDocumentFont() async throws {
         let article = EscapingHTMLFormatter.format("""
-        <details open>
+        <details>
         <summary>Expanded details</summary>
 
         - [Every list marker needs visible clearance.](example.md)
@@ -540,6 +540,8 @@ final class MarkdownHTMLRenderTests: XCTestCase {
 
             let result = try await webView.evaluateJavaScript("""
             (() => {
+                const details = document.querySelector('details');
+                details.querySelector('summary').click();
                 const item = document.querySelector('ul > li');
                 const text = item.querySelector('a').firstChild;
                 const firstCharacter = document.createRange();
@@ -552,6 +554,7 @@ final class MarkdownHTMLRenderTests: XCTestCase {
                     + parseFloat(marker.borderLeftWidth) + parseFloat(marker.width)
                     + parseFloat(marker.borderRightWidth);
                 return {
+                    open: details.open,
                     fontSize: parseFloat(getComputedStyle(item).fontSize),
                     gap: textBox.left - markerRight,
                     left: marker.left,
@@ -562,6 +565,7 @@ final class MarkdownHTMLRenderTests: XCTestCase {
             })()
             """)
             let metrics = try XCTUnwrap(result as? [String: Any], font.rawValue)
+            XCTAssertEqual(metrics["open"] as? Bool, true, font.rawValue)
             let fontSize = try XCTUnwrap(metrics["fontSize"] as? Double, font.rawValue)
             let gap = try XCTUnwrap(metrics["gap"] as? Double, "\(font.rawValue): \(metrics)")
             XCTAssertGreaterThanOrEqual(

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -514,6 +514,64 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(metrics["h1"] as? Double), MarkdownHTML.bodyFontSize * 2, accuracy: 0.1)
     }
 
+    @MainActor
+    func testUnorderedListMarkersStayClearOfTextForEveryDocumentFont() async throws {
+        let article = EscapingHTMLFormatter.format("""
+        <details open>
+        <summary>Expanded details</summary>
+
+        - [Every list marker needs visible clearance.](example.md)
+
+        </details>
+        """)
+
+        for font in DocumentFontSetting.allCases {
+            let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 400))
+            webView.loadHTMLString("""
+            <!doctype html><meta charset="utf-8">
+            <style>\(MarkdownHTML.stylesheet)</style>
+            <style>:root { --mdp-doc-font: \(font.fontFamily); }</style>
+            <article class="markdown-body">\(article)</article>
+            """, baseURL: nil)
+            for _ in 0..<200 where webView.isLoading {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            XCTAssertFalse(webView.isLoading, font.rawValue)
+
+            let result = try await webView.evaluateJavaScript("""
+            (() => {
+                const item = document.querySelector('ul > li');
+                const text = item.querySelector('a').firstChild;
+                const firstCharacter = document.createRange();
+                firstCharacter.setStart(text, 0);
+                firstCharacter.setEnd(text, 1);
+                const itemBox = item.getBoundingClientRect();
+                const textBox = firstCharacter.getBoundingClientRect();
+                const marker = getComputedStyle(item, '::before');
+                const markerRight = itemBox.left + parseFloat(marker.left)
+                    + parseFloat(marker.borderLeftWidth) + parseFloat(marker.width)
+                    + parseFloat(marker.borderRightWidth);
+                return {
+                    fontSize: parseFloat(getComputedStyle(item).fontSize),
+                    gap: textBox.left - markerRight,
+                    left: marker.left,
+                    inlineStart: marker.insetInlineStart,
+                    width: marker.width,
+                    border: marker.borderLeftWidth
+                };
+            })()
+            """)
+            let metrics = try XCTUnwrap(result as? [String: Any], font.rawValue)
+            let fontSize = try XCTUnwrap(metrics["fontSize"] as? Double, font.rawValue)
+            let gap = try XCTUnwrap(metrics["gap"] as? Double, "\(font.rawValue): \(metrics)")
+            XCTAssertGreaterThanOrEqual(
+                gap,
+                fontSize * 0.75,
+                "\(font.rawValue): \(metrics)"
+            )
+        }
+    }
+
     func testCodeCopyButtonFallsBackToQuickLookPasteboardHandler() {
         // Quick Look has no `mdPreviewHost` bridge and its sandbox rejects
         // `navigator.clipboard`, so the copy button must reach the extension's


### PR DESCRIPTION
## What was fixed

Increased the space between unordered-list markers and text in both the preview and editor. This also fixes #385, including lists revealed after expanding `<details>` and all document fonts.

Before:
<img width="712" height="409" alt="image" src="https://github.com/user-attachments/assets/04f21d76-f650-4ef3-8c7a-9da855565b35" />

After:
<img width="639" height="433" alt="image" src="https://github.com/user-attachments/assets/5ad6bb78-05ee-4251-a4b0-f3568bb12cca" />