### PR TITLE
Keep Mermaid figures from collapsing in the flex article

### DIFF
--- a/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
+++ b/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
@@ -495,12 +495,22 @@ nonisolated extension MarkdownHTML {
         border-radius: 15px;
         overflow: hidden;
         outline: none;
+        /* The stage is absolutely positioned, so the figure has no width of
+           its own. Left to its auto margins inside the article's flex column
+           it shrinks to 0 wide, and the aspect ratio then makes it 0 tall.
+           The max-width is the height cap carried through the aspect ratio,
+           which block layout derived by itself: a tall diagram narrows and
+           stays centred rather than filling the column with empty sides. */
+        --mm-max-height: min(70vh, 720px);
+        width: 100%;
+        max-width: calc(var(--mm-max-height) * (var(--mm-aspect, 4 / 3)));
         aspect-ratio: var(--mm-aspect, 4 / 3);
-        max-height: min(70vh, 720px);
+        max-height: var(--mm-max-height);
         contain: layout paint;
     }
     .mermaid-figure.mermaid-width-expanded {
         width: 100%;
+        max-width: none;
         max-height: none;
     }
     .mermaid-figure:focus-visible {

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -1478,6 +1478,7 @@ final class MarkdownHTMLRenderTests: XCTestCase {
                 articleWidth: article.clientWidth,
                 articleLeft: article.getBoundingClientRect().left,
                 figureWidth: figure.getBoundingClientRect().width,
+                figureHeight: figure.getBoundingClientRect().height,
                 figureLeft: figure.getBoundingClientRect().left,
                 availableWidth: host.clientWidth
                     - parseFloat(style.paddingLeft)
@@ -1494,6 +1495,11 @@ final class MarkdownHTMLRenderTests: XCTestCase {
 
         XCTAssertFalse(initial.expanded)
         XCTAssertEqual(initial.buttonPressed, "false")
+        // Pin the size, not just "narrower and centred": a figure collapsed to
+        // 0 x 0 satisfies both of those. The height cap is 70vh of the 600pt
+        // view, and the 1:4 aspect ratio carries it through to the width.
+        XCTAssertEqual(initial.figureHeight, 420, accuracy: 1)
+        XCTAssertEqual(initial.figureWidth, 105, accuracy: 1)
         XCTAssertLessThan(initial.figureWidth, initial.articleWidth)
         XCTAssertEqual(
             initial.figureLeft - initial.articleLeft,
@@ -1523,6 +1529,66 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertFalse(restored.expanded)
         XCTAssertEqual(restored.buttonPressed, "false")
         XCTAssertEqual(restored.figureWidth, initial.figureWidth, accuracy: 1)
+    }
+
+    @MainActor
+    func testWideMermaidDiagramFillsTheColumnInTheScreenLayout() async throws {
+        let rendered = MarkdownHTML.render(
+            markdown: """
+            ```mermaid
+            flowchart LR
+                A --> B
+            ```
+            """,
+            vendorLoading: .lazy
+        )
+        let stylesheet = try XCTUnwrap(
+            rendered.html
+                .components(separatedBy: "<style>")
+                .dropFirst()
+                .first?
+                .components(separatedBy: "</style>")
+                .first
+        )
+        // On screen the article is a flex column. The figure's contents are
+        // all absolutely positioned, so a figure sized by its content alone
+        // lays out at 0 x 0 and the diagram draws nowhere.
+        let html = """
+        <!DOCTYPE html>
+        <html><head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>\(stylesheet)</style>
+        </head><body><article class="markdown-body">\(rendered.articleHTML)</article>
+        <script>
+        document.querySelector('.mermaid-figure').style.setProperty('--mm-aspect', '2 / 1');
+        </script>
+        </body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let result = try await webView.evaluateJavaScript("""
+        (() => {
+            const article = document.querySelector('.markdown-body');
+            const figure = document.querySelector('.mermaid-figure').getBoundingClientRect();
+            return JSON.stringify({
+                display: getComputedStyle(article).display,
+                articleWidth: article.clientWidth,
+                figureWidth: figure.width,
+                figureHeight: figure.height,
+            });
+        })()
+        """)
+        let json = try XCTUnwrap(result as? String)
+        let metrics = try JSONDecoder().decode(WideMermaidMetrics.self, from: Data(json.utf8))
+
+        XCTAssertEqual(metrics.display, "flex")
+        XCTAssertGreaterThan(metrics.articleWidth, 0)
+        XCTAssertEqual(metrics.figureWidth, metrics.articleWidth, accuracy: 1)
+        XCTAssertEqual(metrics.figureHeight, metrics.articleWidth / 2, accuracy: 1)
     }
 
     @MainActor
@@ -2350,11 +2416,19 @@ private struct MermaidLayoutMetrics: Decodable {
     let articleWidth: CGFloat
     let articleLeft: CGFloat
     let figureWidth: CGFloat
+    let figureHeight: CGFloat
     let figureLeft: CGFloat
     let availableWidth: CGFloat
     let svgWidth: CGFloat
     let expanded: Bool
     let buttonPressed: String
+}
+
+private struct WideMermaidMetrics: Decodable {
+    let display: String
+    let articleWidth: CGFloat
+    let figureWidth: CGFloat
+    let figureHeight: CGFloat
 }
 
 private struct MermaidHUDMetrics: Decodable {


### PR DESCRIPTION
Closes #387

Since the article became a flex column (#376), `.mermaid-figure` — sized by auto margins and `aspect-ratio`, with only absolutely positioned children — shrinks to 0 × 0 in the preview.

- The figure now takes `width: 100%` with `max-width: calc(<height cap> × <aspect ratio>)`. That is the box block layout produced: a wide diagram fills the column; a tall one is capped at `min(70vh, 720px)` high and narrows, centred. Fill Width lifts the cap as before. The cap moves into `--mm-max-height` so both limits read one value.
- `testMermaidWidthToggleExpandsAndRestoresDiagram` now pins the figure's size; its existing checks (narrower than the article, centred) hold for a 0-wide figure. `testWideMermaidDiagramFillsTheColumnInTheScreenLayout` covers the wide case. Both fail without the stylesheet change.

Verified with `swift test`; in the app window with `samples/codeblocks.md` and `samples/mermaid-heavy.md`, which render again; and in Quick Look with `samples/codeblocks.md`, in a downstream build carrying this same commit. Not checked: print.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

