### PR TITLE
Keep a top-level inline element from spanning the column

### DIFF
--- a/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
+++ b/md-preview/Rendering/MarkdownHTML+Stylesheet.swift
@@ -215,6 +215,22 @@ nonisolated extension MarkdownHTML {
             flex-direction: column;
             align-items: stretch;
         }
+        /* Stretching suits block content, but an inline-level element sitting
+           at the top level gets stretched too, and a <button> drawn edge to
+           edge reads as a real control rather than the inert leftover it is:
+           DOMPurify removes a <form> and keeps its children, so a credential
+           prompt's button lands here. Media keeps its own width for the same
+           reason — a raw <img> should not be widened to the column. */
+        article.markdown-body > button,
+        article.markdown-body > input,
+        article.markdown-body > select,
+        article.markdown-body > textarea,
+        article.markdown-body > img,
+        article.markdown-body > svg,
+        article.markdown-body > video,
+        article.markdown-body > audio {
+            align-self: flex-start;
+        }
     }
     .md-inline-tab {
         white-space: pre;

--- a/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
+++ b/tests/swift-tests/Tests/MarkdownHelpersTests/MarkdownHTMLRenderTests.swift
@@ -1525,6 +1525,57 @@ final class MarkdownHTMLRenderTests: XCTestCase {
         XCTAssertEqual(restored.figureWidth, initial.figureWidth, accuracy: 1)
     }
 
+    /// The article is a flex column on screen, which stretches its children.
+    /// Block content should span the column; an inline-level element left at
+    /// the top level should not. A `<button>` whose `<form>` the sanitiser
+    /// removed lands there, and drawn edge to edge it reads as a working
+    /// control instead of the inert leftover it is.
+    @MainActor
+    func testTopLevelInlineElementsKeepTheirOwnWidth() async throws {
+        let rendered = MarkdownHTML.render(markdown: "Paragraph.\n", vendorLoading: .lazy)
+        let stylesheet = try XCTUnwrap(
+            rendered.html
+                .components(separatedBy: "<style>")
+                .dropFirst()
+                .first?
+                .components(separatedBy: "</style>")
+                .first
+        )
+        let html = """
+        <!DOCTYPE html>
+        <html><head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>\(stylesheet)</style>
+        </head><body><article class="markdown-body">
+        <p id="para">Paragraph.</p>
+        <button id="control">Sign in</button>
+        </article></body></html>
+        """
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 900, height: 600))
+        webView.loadHTMLString(html, baseURL: nil)
+        while webView.isLoading {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let result = try await webView.evaluateJavaScript("""
+        (() => {
+            const article = document.querySelector('.markdown-body');
+            return JSON.stringify({
+                articleWidth: article.clientWidth,
+                paragraphWidth: document.getElementById('para').getBoundingClientRect().width,
+                buttonWidth: document.getElementById('control').getBoundingClientRect().width,
+            });
+        })()
+        """)
+        let metrics = try JSONDecoder().decode(
+            TopLevelInlineMetrics.self,
+            from: Data(try XCTUnwrap(result as? String).utf8)
+        )
+
+        XCTAssertEqual(metrics.paragraphWidth, metrics.articleWidth, accuracy: 1)
+        XCTAssertLessThan(metrics.buttonWidth, metrics.articleWidth / 3)
+    }
+
     @MainActor
     func testMermaidHUDWrapsInsideNarrowDiagram() async throws {
         let rendered = MarkdownHTML.render(
@@ -2355,6 +2406,12 @@ private struct MermaidLayoutMetrics: Decodable {
     let svgWidth: CGFloat
     let expanded: Bool
     let buttonPressed: String
+}
+
+private struct TopLevelInlineMetrics: Decodable {
+    let articleWidth: CGFloat
+    let paragraphWidth: CGFloat
+    let buttonWidth: CGFloat
 }
 
 private struct MermaidHUDMetrics: Decodable {


### PR DESCRIPTION
Since #376 the article is a flex column on screen, which stretches its children. That suits block content, but an inline-level element left at the top level gets stretched too.

DOMPurify puts one there: forbidding `<form>` removes the element and keeps its children, so a credential prompt's `<button>` ends up a direct child of the article — drawn edge to edge, it reads as a working control rather than the inert leftover it is. A raw `<img>` is widened the same way.

Form controls and media now keep their own width with `align-self: flex-start`. Block content is untouched.

A WebKit test asserts a paragraph still spans the column while a top-level `<button>` does not; removing the rule fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
